### PR TITLE
[Feature] [CUDA] Role-based automatic warp specialization

### DIFF
--- a/examples/aws/flash_attention.py
+++ b/examples/aws/flash_attention.py
@@ -130,9 +130,8 @@ def flash_attention(
                         )
 
                 # Affine first (packed f32x2 FMA), exp2 separately.
-                for i in T.Parallel(block_M):
-                    for j in T.vectorized(block_N):
-                        S_reg[i, j] = S_reg[i, j] * scale + (-scores_max[i] * scale)
+                for i, j in T.Parallel(block_M, block_N):
+                    S_reg[i, j] = S_reg[i, j] * scale + (-scores_max[i] * scale)
                 for i, j in T.Parallel(block_M, block_N):
                     S_reg[i, j] = T.exp2(S_reg[i, j])
 
@@ -523,9 +522,8 @@ def flash_attention_manual(
                             )
 
                     # Affine first (packed f32x2 FMA), exp2 separately.
-                    for i in T.Parallel(block_M, annotations={T.WSID: "exp_scale"}):
-                        for j in T.vectorized(block_N):
-                            S_reg[i, j] = S_reg[i, j] * scale + (-scores_max[i] * scale)
+                    for i, j in T.Parallel(block_M, block_N, annotations={T.WSID: "exp_scale"}):
+                        S_reg[i, j] = S_reg[i, j] * scale + (-scores_max[i] * scale)
                     for i, j in T.Parallel(block_M, block_N, annotations={T.WSID: "softmax_exp"}):
                         S_reg[i, j] = T.exp2(S_reg[i, j])
 
@@ -731,9 +729,8 @@ def flash_attention_ws(
                     T.mbarrier_arrive(scale_full[0])
 
                     # Affine first (packed f32x2 FMA), exp2 separately.
-                    for i in T.Parallel(block_M):
-                        for j in T.vectorized(block_N):
-                            S_reg[i, j] = S_reg[i, j] * scale + (-scores_max[i] * scale)
+                    for i, j in T.Parallel(block_M, block_N):
+                        S_reg[i, j] = S_reg[i, j] * scale + (-scores_max[i] * scale)
                     for i, j in T.Parallel(block_M, block_N):
                         S_reg[i, j] = T.exp2(S_reg[i, j])
 
@@ -800,9 +797,8 @@ def flash_attention_ws(
                     T.mbarrier_arrive(scale_full[1])
 
                     # Affine first (packed f32x2 FMA), exp2 separately.
-                    for i in T.Parallel(block_M):
-                        for j in T.vectorized(block_N):
-                            S_reg_1[i, j] = S_reg_1[i, j] * scale + (-scores_max_1[i] * scale)
+                    for i, j in T.Parallel(block_M, block_N):
+                        S_reg_1[i, j] = S_reg_1[i, j] * scale + (-scores_max_1[i] * scale)
                     for i, j in T.Parallel(block_M, block_N):
                         S_reg_1[i, j] = T.exp2(S_reg_1[i, j])
 

--- a/examples/aws/flash_attention.py
+++ b/examples/aws/flash_attention.py
@@ -13,8 +13,163 @@ PASS_CFG = {
 }
 
 
-@tilelang.jit(pass_configs=PASS_CFG)
+@tilelang.jit(
+    pass_configs={
+        **PASS_CFG,
+        tilelang.PassConfigKey.TL_ENABLE_AUTO_SCHEDULE: "role_based",
+    }
+)
 def flash_attention(
+    Q,
+    K,
+    V,
+    block_M,
+    block_N,
+    store_block_N,
+    dim,
+    dtype,
+    accum_dtype,
+    num_stages,
+    num_persistent_stages,
+):
+    batch, seq_len, heads = T.const("batch, seq_len, heads")
+
+    Q: T.Tensor((batch, seq_len, heads, dim), dtype)
+    K: T.Tensor((batch, seq_len, heads, dim), dtype)
+    V: T.Tensor((batch, seq_len, heads, dim), dtype)
+    Output = T.empty((batch, seq_len, heads, dim), dtype)
+
+    q_blocks = T.ceildiv(seq_len, block_M)
+    loop_range = T.ceildiv(seq_len, block_N)
+    sm_num = driver.get_num_sms()
+    scale = (1.0 / dim) ** 0.5 * 1.44269504
+    assert dim == 128
+    assert block_M == 128
+    assert block_N == 128
+    assert seq_len % block_M == 0
+    assert seq_len % block_N == 0
+    assert dim % store_block_N == 0
+
+    with T.Kernel(sm_num, threads=128) as block_id:
+        Q_shared = T.alloc_shared((block_M, dim), dtype)
+        K_shared = T.alloc_shared((block_N, dim), dtype)
+        V_shared = T.alloc_shared((block_N, dim), dtype)
+        O_shared = T.alloc_shared((block_M, dim), dtype)
+        scale_shared = T.alloc_shared((block_M,), accum_dtype)
+        logsum_shared = T.alloc_shared((block_M,), accum_dtype)
+
+        S_tmem = T.alloc_tmem((block_M, block_N), accum_dtype)
+        P_tmem = T.alloc_tmem((block_M, block_N), dtype)
+        O_tmem = T.alloc_tmem((block_M, dim), accum_dtype)
+
+        tid = T.get_thread_binding()
+
+        S_reg = T.alloc_fragment((block_M, block_N), accum_dtype)
+        P_cast = T.alloc_fragment((block_M, block_N), dtype)
+        scores_max = T.alloc_fragment((block_M,), accum_dtype)
+        scores_max_prev = T.alloc_fragment((block_M,), accum_dtype)
+        scores_rescale = T.alloc_fragment((block_M,), accum_dtype)
+        scores_sum = T.alloc_fragment((block_M,), accum_dtype)
+        logsum = T.alloc_fragment((block_M,), accum_dtype)
+        O_local = T.alloc_fragment((block_M, store_block_N), accum_dtype)
+        inv_sum = T.alloc_fragment((block_M,), accum_dtype)
+
+        sched = T.PersistentTileScheduler(q_blocks, heads * batch, name="sched")
+        sched.init(block_id)
+
+        while sched.valid():
+            T.annotate_ws_pipeline_depth({O_tmem: num_persistent_stages})
+
+            bx = sched.m_idx
+            hn = sched.n_idx
+            by = hn % heads
+            bz = hn // heads
+
+            T.copy(Q[bz, bx * block_M : (bx + 1) * block_M, by, :], Q_shared)
+            T.fill(scores_max, -T.infinity(accum_dtype))
+            T.fill(logsum, 0)
+
+            for k in T.Pipelined(loop_range, num_stages=1):
+                T.copy(K[bz, k * block_N : (k + 1) * block_N, by, :], K_shared)
+                T.copy(V[bz, k * block_N : (k + 1) * block_N, by, :], V_shared)
+
+                T.gemm(Q_shared, K_shared, S_tmem, transpose_B=True, clear_accum=True)
+
+                T.copy(S_tmem, S_reg)
+                T.copy(scores_max, scores_max_prev)
+                T.reduce_max(S_reg, scores_max, dim=1, clear=False)
+                for i in T.Parallel(block_M):
+                    # Stale-max fast path: a barely-moved max keeps a
+                    # rescale factor of exactly 1.
+                    scores_rescale[i] = T.if_then_else(
+                        (scores_max_prev[i] - scores_max[i]) * scale >= -8.0,
+                        1.0,
+                        T.exp2(scores_max_prev[i] * scale - scores_max[i] * scale),
+                    )
+                    scores_max[i] = T.if_then_else(
+                        (scores_max_prev[i] - scores_max[i]) * scale >= -8.0,
+                        scores_max_prev[i],
+                        scores_max[i],
+                    )
+
+                T.copy(scores_rescale, scale_shared)
+
+                # Skip the O read-modify-write when every factor is 1.
+                should_rescale = T.any_sync(scale_shared[tid % block_M] < 1.0)
+                if should_rescale != 0:
+                    for s in T.unroll(T.ceildiv(dim, store_block_N)):
+                        T.copy(
+                            O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
+                            O_local,
+                        )
+                        for i, j in T.Parallel(block_M, store_block_N):
+                            O_local[i, j] *= scale_shared[i]
+                        T.copy(
+                            O_local,
+                            O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
+                        )
+
+                # Affine first (packed f32x2 FMA), exp2 separately.
+                for i in T.Parallel(block_M):
+                    for j in T.vectorized(block_N):
+                        S_reg[i, j] = S_reg[i, j] * scale + (-scores_max[i] * scale)
+                for i, j in T.Parallel(block_M, block_N):
+                    S_reg[i, j] = T.exp2(S_reg[i, j])
+
+                T.copy(S_reg, P_cast)
+                T.copy(P_cast, P_tmem)
+
+                T.reduce_sum(S_reg, scores_sum, dim=1)
+                for i in T.Parallel(block_M):
+                    logsum[i] = logsum[i] * scores_rescale[i] + scores_sum[i]
+
+                T.gemm(P_tmem, V_shared, O_tmem, clear_accum=k == 0)
+
+            T.copy(logsum, logsum_shared)
+            T.copy(logsum_shared, inv_sum)
+            # One reciprocal per row, reused across all output slices.
+            for i in T.Parallel(block_M):
+                inv_sum[i] = 1.0 / inv_sum[i]
+            for s in T.unroll(T.ceildiv(dim, store_block_N)):
+                T.copy(
+                    O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
+                    O_local,
+                )
+                for i, j in T.Parallel(block_M, store_block_N):
+                    O_local[i, j] *= inv_sum[i]
+                T.copy(
+                    O_local,
+                    O_shared[:, s * store_block_N : (s + 1) * store_block_N],
+                )
+            T.copy(O_shared, Output[bz, bx * block_M : (bx + 1) * block_M, by, :])
+
+            sched.next_tile()
+
+    return Output
+
+
+@tilelang.jit(pass_configs=PASS_CFG)
+def flash_attention_manual(
     Q,
     K,
     V,
@@ -75,24 +230,32 @@ def flash_attention(
         # runs its own copy of the init / advance ops.
         sched = T.PersistentTileScheduler(q_blocks, heads * batch, name="sched")
 
-        # Four roles (an FA4-style split, minus 2-CTA):
+        # Five roles (an FA4-style split, minus 2-CTA):
         #  - Softmax owns the S -> P transform and the running
         #    statistics, handing the rescale factor to Correction right
         #    after row-max and publishing P before the row-sum.
         #  - Correction owns the O accumulator: the per-iteration rescale
-        #    (skipped on the stale-max fast path) and the final
-        #    normalize + store.
-        #  - TMA feeds Q/K/V; MMA issues both GEMMs.
+        #    (skipped on the stale-max fast path) and the final normalize,
+        #    staged into O_shared for the Epilogue.
+        #  - TMA feeds Q/K/V; MMA issues both GEMMs; Epilogue stores O.
         #
         # MMA's PV spans sit at stage 1, one iteration behind QK: the
         # tensor core computes S(i) while Softmax turns S(i-1) into
         # P(i-1).
         #
-        # The acc pipeline cycles loop_range + 1 times per wave on both
-        # sides (Correction's rescales + normalize vs MMA's PV consumes
-        # + one wave-level consume), keeping the parity aligned. Both
-        # roles touch acc at two loop depths, so their acc phases use
-        # runtime counters.
+        # O_tmem binds two nested pipelines: `acc` alternates Correction's
+        # rescale with MMA's PV inside loop_kv; `acc_wave` hands the finished
+        # accumulator to the normalize once per wave (MMA producer-brackets
+        # the whole kv loop). acc_wave's depth double-buffers O_tmem across
+        # waves, so wave n+1's QK/PV never stall behind normalize(n);
+        # Correction's rescale, holding only the inner span, derives the wave
+        # slot from its own acc_wave phase counter.
+        #
+        # Not reflected from flash_attention_ws (inexpressible here):
+        # q_stage=2 with PV-first interleave needs P overlaying S in TMEM;
+        # the merged S/P/O barrier has two signaling consumer roles; the
+        # commit-only barriers rely on in-order tcgen05 completion; split_P
+        # signals at sub-op granularity.
         T.annotate_ws_schedule(
             T.WSSchedule(
                 num_warps=12,
@@ -101,7 +264,11 @@ def flash_attention(
                     T.WSRole("Correction", warps_lo=4, warps_hi=8, max_nreg=80),
                     T.WSRole("TMA", warps_lo=8, warps_hi=9, max_nreg=40),
                     T.WSRole("MMA", warps_lo=9, warps_hi=10, max_nreg=40),
-                    # Warps 10-11 are unassigned register donors.
+                    # FA4-style dedicated store warp: Correction hands the
+                    # normalized O over in smem and moves on; the store's
+                    # drain never blocks the next tile's rescale work.
+                    T.WSRole("Epilogue", warps_lo=10, warps_hi=11, max_nreg=40),
+                    # Warp 11 is an unassigned register donor.
                 ],
                 pipelines=[
                     T.WSPipeline("q", [Q_shared], depth=num_persistent_stages),
@@ -109,13 +276,31 @@ def flash_attention(
                     T.WSPipeline("v", [V_shared], depth=num_stages),
                     T.WSPipeline("score", [S_tmem], depth=1),
                     T.WSPipeline("prob", [P_tmem], depth=1),
+                    # O_tmem's nested bindings; versions multiply, giving
+                    # num_persistent_stages accumulator slots.
                     T.WSPipeline("acc", [O_tmem], depth=1),
+                    T.WSPipeline("acc_wave", [O_tmem], depth=num_persistent_stages),
                     # Softmax -> Correction rescale handoff.
                     T.WSPipeline("scale", [scale_shared], depth=num_stages),
                     # Softmax -> Correction logsum handoff for the epilogue.
                     T.WSPipeline("stats", [logsum_shared], depth=1),
+                    # Correction -> Epilogue staged-O handoff. Correction's
+                    # generic O_shared writes are observed by the Epilogue's
+                    # TMA store, so the materializer emits the writer-side
+                    # proxy fence before the commit.
+                    T.WSPipeline("o_epi", [O_shared], depth=1),
                 ],
                 scopes=[
+                    # The unrolled O loops are scheduled scopes on
+                    # Correction; the acc brackets stay in the enclosing scopes.
+                    T.WSScope(
+                        "rescale_O",
+                        {"Correction": ["rescale_load", "rescale_mul", "rescale_store"]},
+                    ),
+                    T.WSScope(
+                        "normalize_O",
+                        {"Correction": ["normalize_load", "normalize_mul", "normalize_store"]},
+                    ),
                     T.WSScope(
                         "loop_kv",
                         {
@@ -196,12 +381,16 @@ def flash_attention(
                             ],
                             "MMA": [
                                 T.WSSync.consumer_wait("q"),
+                                # The producer bracket around the whole kv
+                                # loop: the commit (a tcgen05 watermark)
+                                # publishes the last PV; with the
+                                # depth-num_persistent_stages ring the
+                                # acquire pairs the normalize two waves
+                                # back, so the next wave never stalls.
+                                T.WSSync.producer_acquire("acc_wave"),
                                 "loop_kv",
+                                T.WSSync.producer_commit("acc_wave"),
                                 T.WSSync.consumer_release("q"),
-                                # Pairs the normalize commit, keeping
-                                # acc's per-wave cycle counts equal.
-                                T.WSSync.consumer_wait("acc"),
-                                T.WSSync.consumer_release("acc"),
                                 "sched_next",
                             ],
                             "Softmax": [
@@ -219,11 +408,19 @@ def flash_attention(
                                 T.WSSync.consumer_wait("stats"),
                                 "copy_inv_sum",
                                 "recip_sum",
-                                T.WSSync.producer_acquire("acc"),
+                                T.WSSync.consumer_wait("acc_wave"),
+                                T.WSSync.producer_acquire("o_epi"),
                                 "normalize_O",
-                                T.WSSync.producer_commit("acc"),
+                                T.WSSync.producer_commit("o_epi"),
+                                T.WSSync.consumer_release("acc_wave"),
                                 T.WSSync.consumer_release("stats"),
+                                "sched_next",
+                            ],
+                            "Epilogue": [
+                                "tile_idx",
+                                T.WSSync.consumer_wait("o_epi"),
                                 "copy_O_s2g",
+                                T.WSSync.consumer_release("o_epi"),
                                 "sched_next",
                             ],
                         },
@@ -235,6 +432,7 @@ def flash_attention(
                             "MMA": ["sched_init", "loop_wave"],
                             "Softmax": ["sched_init", "loop_wave"],
                             "Correction": ["sched_init", "loop_wave"],
+                            "Epilogue": ["sched_init", "loop_wave"],
                         },
                     ),
                 ],
@@ -305,7 +503,7 @@ def flash_attention(
                     # Warp-local vote: each warp owns 32 rows of O and
                     # skips its read-modify-write when all its rescale
                     # factors are 1 (at k == 0 PV clears the accumulator
-                    # anyway). The guard covers the op body alone; sync
+                    # anyway). The guard covers the scope body alone; sync
                     # entries stay unconditional.
                     with T.ws_op("rescale_vote"):
                         should_rescale = T.any_sync(scale_shared[tid % block_M] < 1.0)
@@ -314,12 +512,14 @@ def flash_attention(
                             T.copy(
                                 O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
                                 O_local,
+                                annotations={T.WSID: "rescale_load"},
                             )
-                            for i, j in T.Parallel(block_M, store_block_N):
+                            for i, j in T.Parallel(block_M, store_block_N, annotations={T.WSID: "rescale_mul"}):
                                 O_local[i, j] *= scale_shared[i]
                             T.copy(
                                 O_local,
                                 O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
+                                annotations={T.WSID: "rescale_store"},
                             )
 
                     # Affine first (packed f32x2 FMA), exp2 separately.
@@ -353,12 +553,14 @@ def flash_attention(
                     T.copy(
                         O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
                         O_local,
+                        annotations={T.WSID: "normalize_load"},
                     )
-                    for i, j in T.Parallel(block_M, store_block_N):
+                    for i, j in T.Parallel(block_M, store_block_N, annotations={T.WSID: "normalize_mul"}):
                         O_local[i, j] *= inv_sum[i]
                     T.copy(
                         O_local,
                         O_shared[:, s * store_block_N : (s + 1) * store_block_N],
+                        annotations={T.WSID: "normalize_store"},
                     )
                 T.copy(
                     O_shared,
@@ -393,45 +595,69 @@ def flash_attention_ws(
     V: T.Tensor((batch, seq_len, heads, dim), dtype)
     Output = T.empty((batch, seq_len, heads, dim), dtype)
 
-    q_blocks = T.ceildiv(seq_len, block_M)
+    # FA4 sm100 structure: each tile is 2*block_M query rows split into two
+    # q stages that share the K/V stream; the MMA warp interleaves the
+    # stages PV-first, so while one stage waits on its P the other's QK is
+    # already in flight. num_persistent_stages is the q-stage count.
+    assert num_persistent_stages == 2
+    q_blocks = T.ceildiv(seq_len, 2 * block_M)
     loop_range = T.ceildiv(seq_len, block_N)
     sm_num = driver.get_num_sms()
     scale = (1.0 / dim) ** 0.5 * 1.44269504
     assert dim == 128
     assert block_M == 128
     assert block_N == 128
-    assert seq_len % block_M == 0
+    assert seq_len % (2 * block_M) == 0
     assert seq_len % block_N == 0
     assert dim % store_block_N == 0
 
-    with T.Kernel(sm_num, threads=384) as block_id:
-        Q_shared = T.alloc_shared((num_persistent_stages, block_M, dim), dtype)
+    with T.Kernel(sm_num, threads=512) as block_id:
+        Q_shared = T.alloc_shared((2, block_M, dim), dtype)
         K_shared = T.alloc_shared((num_stages, block_N, dim), dtype)
         V_shared = T.alloc_shared((num_stages, block_N, dim), dtype)
         O_shared = T.alloc_shared((block_M, dim), dtype)
-        scale_shared = T.alloc_shared((num_stages, block_M), accum_dtype)
-        logsum_shared = T.alloc_shared((block_M,), accum_dtype)
+        # Single-slot per-stage handoffs (FA4's sScale): softmax and
+        # correction run in lockstep per iteration.
+        scale_shared = T.alloc_shared((2, block_M), accum_dtype)
+        logsum_shared = T.alloc_shared((2, block_M), accum_dtype)
 
-        S_tmem = T.alloc_tmem((block_M, block_N), accum_dtype)
-        P_tmem = T.alloc_tmem((block_M, block_N), dtype)
-        O_tmem = T.alloc_tmem((block_M, dim), accum_dtype)
+        # TMEM (512 cols): S0 S1 | O0 O1. P_s overlays the upper half of
+        # S_s as bf16 (FA4's tmem_s_to_p_offset): S is dead there once
+        # softmax read it, and PV(i) is issued before QK(i+1) overwrites S.
+        S_tmem = T.alloc_tmem((2, block_M, block_N), accum_dtype)
+        O_tmem = T.alloc_tmem((2, block_M, dim), accum_dtype)
+        P_tmem = T.view(S_tmem, shape=(2, block_M, 2 * block_N), dtype=dtype)
 
-        q_full = T.alloc_barrier([32] * num_persistent_stages)
-        q_empty = T.alloc_barrier([1] * num_persistent_stages)
+        q_full = T.alloc_barrier([32, 32])
+        q_empty = T.alloc_barrier([1, 1])
         k_full = T.alloc_barrier([32] * num_stages)
         k_empty = T.alloc_barrier([1] * num_stages)
         v_full = T.alloc_barrier([32] * num_stages)
         v_empty = T.alloc_barrier([1] * num_stages)
-        s_full = T.alloc_barrier([1])
-        s_empty = T.alloc_barrier([128])
-        prob_full = T.alloc_barrier([128])
-        prob_empty = T.alloc_barrier([1])
-        acc_full = T.alloc_barrier([128])
-        acc_empty = T.alloc_barrier([1])
-        scale_full = T.alloc_barrier([128] * num_stages)
-        scale_empty = T.alloc_barrier([128] * num_stages)
-        stats_full = T.alloc_barrier([128])
-        stats_empty = T.alloc_barrier([128])
+        # FA4's merged S/P/O pipeline, one per q stage. Full side: "S ready",
+        # one tcgen05 commit per QK. Empty side: "P written AND O rescaled",
+        # 128 softmax + 128 correction arrives; the MMA warp acquires it
+        # before each PV.
+        spo_full = T.alloc_barrier([1, 1])
+        spo_empty = T.alloc_barrier([256, 256])
+        # Commit-only, once per tile after the last PV; correction waits
+        # before the normalize read. The per-iteration O signal is elided:
+        # scale(g) published means QK(g) completed, and PV(g-1) was issued
+        # before QK(g), so it completed too.
+        o_full = T.alloc_barrier([1, 1])
+        # split_P: the spo arrive covers the first 3/4 of P; the last 1/4
+        # commits here and the MMA warp waits for it between the two PV
+        # halves (FA4's pipeline_p_lastsplit).
+        p_last = T.alloc_barrier([128, 128])
+        scale_full = T.alloc_barrier([128, 128])
+        scale_empty = T.alloc_barrier([128, 128])
+        stats_full = T.alloc_barrier([128, 128])
+        stats_empty = T.alloc_barrier([128, 128])
+        # Correction -> epilogue handoff (single O_shared slot): full =
+        # normalized O staged in smem; empty = the epilogue warp's gmem TMA
+        # store completed. Two handoffs per tile, completion #(wave*2 + s).
+        o_epi_full = T.alloc_barrier([128])
+        o_epi_empty = T.alloc_barrier([32])
 
         tid = T.get_thread_binding()
 
@@ -444,16 +670,24 @@ def flash_attention_ws(
         logsum = T.alloc_fragment((block_M,), accum_dtype)
         O_local = T.alloc_fragment((block_M, store_block_N), accum_dtype)
         inv_sum = T.alloc_fragment((block_M,), accum_dtype)
+        # Softmax stage 1 runs in a different warpgroup: fragment layouts
+        # bind to threads, so it needs its own register set.
+        S_reg_1 = T.alloc_fragment((block_M, block_N), accum_dtype)
+        P_cast_1 = T.alloc_fragment((block_M, block_N), dtype)
+        scores_max_1 = T.alloc_fragment((block_M,), accum_dtype)
+        scores_max_prev_1 = T.alloc_fragment((block_M,), accum_dtype)
+        scores_rescale_1 = T.alloc_fragment((block_M,), accum_dtype)
+        scores_sum_1 = T.alloc_fragment((block_M,), accum_dtype)
+        logsum_1 = T.alloc_fragment((block_M,), accum_dtype)
 
         # Scheduler state is per thread (FA4's static tile order: q block
         # minor, then head, then batch): init once, then every role runs
-        # its own `while sched.valid()` loop at its own pace, reading
-        # sched.current_iter as the wave clock.
+        # its own `while sched.valid()` loop at its own pace.
         sched = T.PersistentTileScheduler(q_blocks, heads * batch, name="sched")
         sched.init(block_id)
 
-        if tid < 128:  # warps 0-3: online softmax
-            T.set_max_nreg(224, 1)
+        if tid < 128:  # warps 0-3: softmax, q stage 0
+            T.set_max_nreg(200, 1)
             while sched.valid():
                 wave_id = sched.current_iter
                 T.fill(scores_max, -T.infinity(accum_dtype))
@@ -462,9 +696,16 @@ def flash_attention_ws(
                 for k in T.serial(loop_range):
                     g = wave_id * loop_range + k
 
-                    T.mbarrier_wait_parity(s_full[0], g & 1)
-                    T.copy(S_tmem, S_reg)
-                    T.mbarrier_arrive(s_empty[0])
+                    T.mbarrier_wait_parity(spo_full[0], g & 1)
+                    # Two x64 tmem loads: a single 32x32b.x128 load defines
+                    # 146 registers at once, above the 128-register entry
+                    # budget of a 512-thread kernel (region liveness may
+                    # exceed it, a single instruction's operands may not).
+                    for h in T.unroll(2):
+                        T.copy(
+                            S_tmem[0, :, h * (block_N // 2) : (h + 1) * (block_N // 2)],
+                            S_reg[:, h * (block_N // 2) : (h + 1) * (block_N // 2)],
+                        )
 
                     T.copy(scores_max, scores_max_prev)
                     T.reduce_max(S_reg, scores_max, dim=1, clear=False)
@@ -483,11 +724,11 @@ def flash_attention_ws(
                             scores_max[i],
                         )
 
-                    # Publish the rescale immediately after row-max so the
-                    # correction warps overlap with exp / P production.
-                    T.mbarrier_wait_parity(scale_empty[g % num_stages], ((g // num_stages) & 1) ^ 1)
-                    T.copy(scores_rescale, scale_shared[g % num_stages, :])
-                    T.mbarrier_arrive(scale_full[g % num_stages])
+                    # Publish the rescale right after row-max so correction
+                    # overlaps with exp / P production below.
+                    T.mbarrier_wait_parity(scale_empty[0], (g & 1) ^ 1)
+                    T.copy(scores_rescale, scale_shared[0, :])
+                    T.mbarrier_arrive(scale_full[0])
 
                     # Affine first (packed f32x2 FMA), exp2 separately.
                     for i in T.Parallel(block_M):
@@ -497,97 +738,178 @@ def flash_attention_ws(
                         S_reg[i, j] = T.exp2(S_reg[i, j])
 
                     # Publish P before row-sum: the reduction is not a PV
-                    # dependency.
-                    T.mbarrier_wait_parity(prob_empty[0], (g & 1) ^ 1)
+                    # dependency. This arrive also hands S back — P and S
+                    # share the tmem columns, so one signal covers both.
                     T.copy(S_reg, P_cast)
-                    T.copy(P_cast, P_tmem)
-                    T.mbarrier_arrive(prob_full[0])
+                    T.copy(P_cast[:, 0:96], P_tmem[0, :, block_N : block_N + 96])
+                    T.mbarrier_arrive(spo_empty[0])
+                    T.copy(P_cast[:, 96:128], P_tmem[0, :, block_N + 96 : 2 * block_N])
+                    T.mbarrier_arrive(p_last[0])
 
                     T.reduce_sum(S_reg, scores_sum, dim=1)
                     for i in T.Parallel(block_M):
                         logsum[i] = logsum[i] * scores_rescale[i] + scores_sum[i]
 
                 T.mbarrier_wait_parity(stats_empty[0], (wave_id & 1) ^ 1)
-                T.copy(logsum, logsum_shared)
+                T.copy(logsum, logsum_shared[0, :])
                 T.mbarrier_arrive(stats_full[0])
                 sched.next_tile()
 
-        elif tid < 256:  # warps 4-7: O correction + epilogue
-            T.set_max_nreg(80, 0)
+        elif tid < 256:  # warps 4-7: softmax, q stage 1
+            T.set_max_nreg(200, 1)
             while sched.valid():
                 wave_id = sched.current_iter
-                bx = sched.m_idx
-                by = sched.n_idx % heads
-                bz = sched.n_idx // heads
+                T.fill(scores_max_1, -T.infinity(accum_dtype))
+                T.fill(logsum_1, 0)
 
                 for k in T.serial(loop_range):
                     g = wave_id * loop_range + k
-                    # acc cycles loop_range + 1 times per wave (the final
-                    # normalize is one more producer cycle).
-                    c = wave_id * (loop_range + 1) + k
 
-                    T.mbarrier_wait_parity(scale_full[g % num_stages], (g // num_stages) & 1)
-                    T.mbarrier_wait_parity(acc_empty[0], (c & 1) ^ 1)
-                    # Common case: every rescale factor is exactly 1
-                    # (stale-max fast path), and each warp can skip the O
-                    # read-modify-write for its own rows. At k == 0 the
-                    # factor is 0 and O_tmem is garbage, but PV(0) clears
-                    # the accumulator anyway.
-                    should_rescale = T.any_sync(scale_shared[g % num_stages, tid % block_M] < 1.0)
-                    if should_rescale != 0:
-                        for s in T.unroll(T.ceildiv(dim, store_block_N)):
-                            T.copy(
-                                O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
-                                O_local,
-                            )
-                            for i, j in T.Parallel(block_M, store_block_N):
-                                O_local[i, j] *= scale_shared[g % num_stages, i]
-                            T.copy(
-                                O_local,
-                                O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
-                            )
-                    T.mbarrier_arrive(scale_empty[g % num_stages])
-                    T.mbarrier_arrive(acc_full[0])
+                    T.mbarrier_wait_parity(spo_full[1], g & 1)
+                    # Two x64 tmem loads: a single 32x32b.x128 load defines
+                    # 146 registers at once, above the 128-register entry
+                    # budget of a 512-thread kernel (region liveness may
+                    # exceed it, a single instruction's operands may not).
+                    for h in T.unroll(2):
+                        T.copy(
+                            S_tmem[1, :, h * (block_N // 2) : (h + 1) * (block_N // 2)],
+                            S_reg_1[:, h * (block_N // 2) : (h + 1) * (block_N // 2)],
+                        )
 
-                c_last = wave_id * (loop_range + 1) + loop_range
-                T.mbarrier_wait_parity(stats_full[0], wave_id & 1)
-                T.mbarrier_wait_parity(acc_empty[0], (c_last & 1) ^ 1)
-                T.copy(logsum_shared, inv_sum)
-                # One reciprocal per row, reused across all output slices.
-                for i in T.Parallel(block_M):
-                    inv_sum[i] = 1.0 / inv_sum[i]
-                for s in T.unroll(T.ceildiv(dim, store_block_N)):
-                    T.copy(
-                        O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
-                        O_local,
-                    )
-                    for i, j in T.Parallel(block_M, store_block_N):
-                        O_local[i, j] *= inv_sum[i]
-                    T.copy(
-                        O_local,
-                        O_shared[:, s * store_block_N : (s + 1) * store_block_N],
-                    )
-                T.mbarrier_arrive(stats_empty[0])
-                T.mbarrier_arrive(acc_full[0])
-                T.copy(O_shared, Output[bz, bx * block_M : (bx + 1) * block_M, by, :])
+                    T.copy(scores_max_1, scores_max_prev_1)
+                    T.reduce_max(S_reg_1, scores_max_1, dim=1, clear=False)
+                    for i in T.Parallel(block_M):
+                        # Stale-max fast path: keep the previous max when it
+                        # moves by less than 8 exponent steps, so the
+                        # rescale factor is exactly 1.
+                        scores_rescale_1[i] = T.if_then_else(
+                            (scores_max_prev_1[i] - scores_max_1[i]) * scale >= -8.0,
+                            1.0,
+                            T.exp2(scores_max_prev_1[i] * scale - scores_max_1[i] * scale),
+                        )
+                        scores_max_1[i] = T.if_then_else(
+                            (scores_max_prev_1[i] - scores_max_1[i]) * scale >= -8.0,
+                            scores_max_prev_1[i],
+                            scores_max_1[i],
+                        )
+
+                    # Publish the rescale right after row-max so correction
+                    # overlaps with exp / P production below.
+                    T.mbarrier_wait_parity(scale_empty[1], (g & 1) ^ 1)
+                    T.copy(scores_rescale_1, scale_shared[1, :])
+                    T.mbarrier_arrive(scale_full[1])
+
+                    # Affine first (packed f32x2 FMA), exp2 separately.
+                    for i in T.Parallel(block_M):
+                        for j in T.vectorized(block_N):
+                            S_reg_1[i, j] = S_reg_1[i, j] * scale + (-scores_max_1[i] * scale)
+                    for i, j in T.Parallel(block_M, block_N):
+                        S_reg_1[i, j] = T.exp2(S_reg_1[i, j])
+
+                    # Publish P before row-sum: the reduction is not a PV
+                    # dependency. This arrive also hands S back — P and S
+                    # share the tmem columns, so one signal covers both.
+                    T.copy(S_reg_1, P_cast_1)
+                    T.copy(P_cast_1[:, 0:96], P_tmem[1, :, block_N : block_N + 96])
+                    T.mbarrier_arrive(spo_empty[1])
+                    T.copy(P_cast_1[:, 96:128], P_tmem[1, :, block_N + 96 : 2 * block_N])
+                    T.mbarrier_arrive(p_last[1])
+
+                    T.reduce_sum(S_reg_1, scores_sum_1, dim=1)
+                    for i in T.Parallel(block_M):
+                        logsum_1[i] = logsum_1[i] * scores_rescale_1[i] + scores_sum_1[i]
+
+                T.mbarrier_wait_parity(stats_empty[1], (wave_id & 1) ^ 1)
+                T.copy(logsum_1, logsum_shared[1, :])
+                T.mbarrier_arrive(stats_full[1])
                 sched.next_tile()
 
-        elif tid < 288:  # warp 8: TMA
-            T.set_max_nreg(40, 0)
+        elif tid < 384:  # warps 8-11: O correction, both stages
+            T.set_max_nreg(64, 0)
+            # One-time priming: the first PV of each stage's first tile
+            # needs no correction, so pre-supply this side's arrive.
+            T.mbarrier_arrive(spo_empty[0])
+            T.mbarrier_arrive(spo_empty[1])
+            while sched.valid():
+                wave_id = sched.current_iter
+                g0 = wave_id * loop_range
+
+                # Each stage's first rescale factor covers an O that PV(0)
+                # clears anyway: consume and discard it.
+                for s in T.serial(2):
+                    T.mbarrier_wait_parity(scale_full[s], g0 & 1)
+                    T.mbarrier_arrive(scale_empty[s])
+
+                for k in T.serial(loop_range - 1):
+                    g = g0 + k + 1
+                    for s in T.serial(2):
+                        T.mbarrier_wait_parity(scale_full[s], g & 1)
+                        # No O wait: scale(g) published means QK(s, g)
+                        # completed, so PV(s, g-1) — issued before it — has
+                        # completed as well. Common case: every rescale
+                        # factor is exactly 1 (stale-max fast path), and
+                        # each warp skips the O read-modify-write.
+                        should_rescale = T.any_sync(scale_shared[s, tid % block_M] < 1.0)
+                        if should_rescale != 0:
+                            for t in T.unroll(T.ceildiv(dim, store_block_N)):
+                                T.copy(
+                                    O_tmem[s, :, t * store_block_N : (t + 1) * store_block_N],
+                                    O_local,
+                                )
+                                for i, j in T.Parallel(block_M, store_block_N):
+                                    O_local[i, j] *= scale_shared[s, i]
+                                T.copy(
+                                    O_local,
+                                    O_tmem[s, :, t * store_block_N : (t + 1) * store_block_N],
+                                )
+                        T.mbarrier_arrive(spo_empty[s])
+                        T.mbarrier_arrive(scale_empty[s])
+
+                for s in T.serial(2):
+                    T.mbarrier_wait_parity(stats_full[s], wave_id & 1)
+                    T.mbarrier_wait_parity(o_full[s], wave_id & 1)
+                    T.copy(logsum_shared[s, :], inv_sum)
+                    # One reciprocal per row, reused across all output slices.
+                    for i in T.Parallel(block_M):
+                        inv_sum[i] = 1.0 / inv_sum[i]
+                    # O_shared free once the epilogue's previous store is done.
+                    T.mbarrier_wait_parity(o_epi_empty[0], ((wave_id * 2 + s) & 1) ^ 1)
+                    for t in T.unroll(T.ceildiv(dim, store_block_N)):
+                        T.copy(
+                            O_tmem[s, :, t * store_block_N : (t + 1) * store_block_N],
+                            O_local,
+                        )
+                        for i, j in T.Parallel(block_M, store_block_N):
+                            O_local[i, j] *= inv_sum[i]
+                        T.copy(
+                            O_local,
+                            O_shared[:, t * store_block_N : (t + 1) * store_block_N],
+                        )
+                    # O[s] read: the next tile's clearing PV may overwrite.
+                    T.mbarrier_arrive(spo_empty[s])
+                    T.mbarrier_arrive(stats_empty[s])
+                    # Generic O_shared writes are observed by the epilogue's
+                    # TMA store (async proxy): writer-side fence, then arrive.
+                    T.fence_proxy_async()
+                    T.mbarrier_arrive(o_epi_full[0])
+                sched.next_tile()
+
+        elif tid < 416:  # warp 12: TMA
+            T.set_max_nreg(48, 0)
             while sched.valid():
                 wave_id = sched.current_iter
                 bx = sched.m_idx
                 by = sched.n_idx % heads
                 bz = sched.n_idx // heads
 
-                q_stage = wave_id % num_persistent_stages
-                T.mbarrier_wait_parity(q_empty[q_stage], ((wave_id // num_persistent_stages) & 1) ^ 1)
-                T.tma_copy(
-                    Q[bz, bx * block_M : (bx + 1) * block_M, by, :],
-                    Q_shared[q_stage, :, :],
-                    barrier=q_full[q_stage],
-                )
-                T.mbarrier_arrive(q_full[q_stage])
+                for s in T.serial(2):
+                    T.mbarrier_wait_parity(q_empty[s], (wave_id & 1) ^ 1)
+                    T.tma_copy(
+                        Q[bz, (bx * 2 + s) * block_M : (bx * 2 + s + 1) * block_M, by, :],
+                        Q_shared[s, :, :],
+                        barrier=q_full[s],
+                    )
+                    T.mbarrier_arrive(q_full[s])
 
                 for k in T.serial(loop_range):
                     g = wave_id * loop_range + k
@@ -609,62 +931,149 @@ def flash_attention_ws(
                     T.mbarrier_arrive(v_full[stage])
                 sched.next_tile()
 
-        elif tid < 320:  # warp 9: tensor-core issue
-            T.set_max_nreg(40, 0)
+        elif tid < 448:  # warp 13: tensor-core issue
+            T.set_max_nreg(48, 0)
             while sched.valid():
                 wave_id = sched.current_iter
-                q_stage = wave_id % num_persistent_stages
-                T.mbarrier_wait_parity(q_full[q_stage], (wave_id // num_persistent_stages) & 1)
-                # PV runs one software-pipeline stage behind QK: QK(i) is
-                # issued before PV(i-1), so the tensor core computes S(i)
-                # while softmax is still turning S(i-1) into P(i-1).
-                for i in T.serial(loop_range + 1):
-                    if i < loop_range:
-                        g = wave_id * loop_range + i
-                        T.mbarrier_wait_parity(k_full[g % num_stages], (g // num_stages) & 1)
-                        T.mbarrier_wait_parity(s_empty[0], (g & 1) ^ 1)
+                g0 = wave_id * loop_range
+
+                # Prologue QKs need no S acquire: the previous tile's tail
+                # PV acquired spo, so S was read (and reused as P) by then.
+                T.mbarrier_wait_parity(q_full[0], wave_id & 1)
+                T.mbarrier_wait_parity(k_full[g0 % num_stages], (g0 // num_stages) & 1)
+                T.tcgen05_gemm(
+                    Q_shared[0, :, :],
+                    K_shared[g0 % num_stages, :, :],
+                    S_tmem[0, :, :],
+                    transpose_B=True,
+                    mbar=None,
+                    clear_accum=True,
+                )
+                T.tcgen05_mma_arrive(spo_full[0])
+                T.mbarrier_wait_parity(q_full[1], wave_id & 1)
+                T.tcgen05_gemm(
+                    Q_shared[1, :, :],
+                    K_shared[g0 % num_stages, :, :],
+                    S_tmem[1, :, :],
+                    transpose_B=True,
+                    mbar=None,
+                    clear_accum=True,
+                )
+                T.tcgen05_mma_arrive(spo_full[1])
+                T.tcgen05_mma_arrive(k_empty[g0 % num_stages])
+
+                # PV-first, stages interleaved: while a stage waits on its
+                # P, the other stage's QK is already executing. PV(s, i)
+                # before QK(s, i+1) is also what makes the P-in-S overlay
+                # and correction's elided O wait sound.
+                for i in T.serial(loop_range - 1):
+                    gv = g0 + i
+                    gk = gv + 1
+                    T.mbarrier_wait_parity(v_full[gv % num_stages], (gv // num_stages) & 1)
+                    T.mbarrier_wait_parity(spo_empty[0], gv & 1)
+                    # split_P: the last K chunk waits for its p_last commit.
+                    for h in T.unroll(4):
+                        if h == 3:
+                            T.mbarrier_wait_parity(p_last[0], gv & 1)
                         T.tcgen05_gemm(
-                            Q_shared[q_stage, :, :],
-                            K_shared[g % num_stages, :, :],
-                            S_tmem,
-                            transpose_B=True,
+                            P_tmem[0, :, block_N + 32 * h : block_N + 32 * (h + 1)],
+                            V_shared[gv % num_stages, 32 * h : 32 * (h + 1), :],
+                            O_tmem[0, :, :],
                             mbar=None,
-                            clear_accum=True,
+                            clear_accum=(i == 0) & (h == 0),
                         )
-                        T.tcgen05_mma_arrive(s_full[0])
-                        T.tcgen05_mma_arrive(k_empty[g % num_stages])
-                    if i >= 1:
-                        gp = wave_id * loop_range + i - 1
-                        cp = wave_id * (loop_range + 1) + i - 1
-                        T.mbarrier_wait_parity(prob_full[0], gp & 1)
-                        T.mbarrier_wait_parity(v_full[gp % num_stages], (gp // num_stages) & 1)
-                        T.mbarrier_wait_parity(acc_full[0], cp & 1)
+                    T.mbarrier_wait_parity(k_full[gk % num_stages], (gk // num_stages) & 1)
+                    T.tcgen05_gemm(
+                        Q_shared[0, :, :],
+                        K_shared[gk % num_stages, :, :],
+                        S_tmem[0, :, :],
+                        transpose_B=True,
+                        mbar=None,
+                        clear_accum=True,
+                    )
+                    T.tcgen05_mma_arrive(spo_full[0])
+                    T.mbarrier_wait_parity(spo_empty[1], gv & 1)
+                    for h in T.unroll(4):
+                        if h == 3:
+                            T.mbarrier_wait_parity(p_last[1], gv & 1)
                         T.tcgen05_gemm(
-                            P_tmem,
-                            V_shared[gp % num_stages, :, :],
-                            O_tmem,
+                            P_tmem[1, :, block_N + 32 * h : block_N + 32 * (h + 1)],
+                            V_shared[gv % num_stages, 32 * h : 32 * (h + 1), :],
+                            O_tmem[1, :, :],
                             mbar=None,
-                            clear_accum=(i - 1) == 0,
+                            clear_accum=(i == 0) & (h == 0),
                         )
-                        T.tcgen05_mma_arrive(prob_empty[0])
-                        T.tcgen05_mma_arrive(v_empty[gp % num_stages])
-                        T.tcgen05_mma_arrive(acc_empty[0])
-                T.tcgen05_mma_arrive(q_empty[q_stage])
-                # Consume the version produced by the normalize commit,
-                # keeping acc's per-wave cycle counts equal on both sides.
-                c_last = wave_id * (loop_range + 1) + loop_range
-                T.mbarrier_wait_parity(acc_full[0], c_last & 1)
-                T.tcgen05_mma_arrive(acc_empty[0])
+                    T.tcgen05_mma_arrive(v_empty[gv % num_stages])
+                    T.tcgen05_gemm(
+                        Q_shared[1, :, :],
+                        K_shared[gk % num_stages, :, :],
+                        S_tmem[1, :, :],
+                        transpose_B=True,
+                        mbar=None,
+                        clear_accum=True,
+                    )
+                    T.tcgen05_mma_arrive(spo_full[1])
+                    T.tcgen05_mma_arrive(k_empty[gk % num_stages])
+
+                T.tcgen05_mma_arrive(q_empty[0])
+                T.tcgen05_mma_arrive(q_empty[1])
+
+                gl = g0 + loop_range - 1
+                T.mbarrier_wait_parity(v_full[gl % num_stages], (gl // num_stages) & 1)
+                T.mbarrier_wait_parity(spo_empty[0], gl & 1)
+                for h in T.unroll(4):
+                    if h == 3:
+                        T.mbarrier_wait_parity(p_last[0], gl & 1)
+                    T.tcgen05_gemm(
+                        P_tmem[0, :, block_N + 32 * h : block_N + 32 * (h + 1)],
+                        V_shared[gl % num_stages, 32 * h : 32 * (h + 1), :],
+                        O_tmem[0, :, :],
+                        mbar=None,
+                        clear_accum=(loop_range == 1) & (h == 0),
+                    )
+                # The only O signal of the tile: softmax's last signal does
+                # not imply the tail PV finished, so correction must wait.
+                T.tcgen05_mma_arrive(o_full[0])
+                T.mbarrier_wait_parity(spo_empty[1], gl & 1)
+                for h in T.unroll(4):
+                    if h == 3:
+                        T.mbarrier_wait_parity(p_last[1], gl & 1)
+                    T.tcgen05_gemm(
+                        P_tmem[1, :, block_N + 32 * h : block_N + 32 * (h + 1)],
+                        V_shared[gl % num_stages, 32 * h : 32 * (h + 1), :],
+                        O_tmem[1, :, :],
+                        mbar=None,
+                        clear_accum=(loop_range == 1) & (h == 0),
+                    )
+                T.tcgen05_mma_arrive(o_full[1])
+                T.tcgen05_mma_arrive(v_empty[gl % num_stages])
                 sched.next_tile()
 
-        else:  # warps 10-11: idle register donors
-            T.set_max_nreg(40, 0)
+        elif tid < 480:  # warp 14: epilogue, O store to gmem
+            T.set_max_nreg(48, 0)
+            while sched.valid():
+                wave_id = sched.current_iter
+                bx = sched.m_idx
+                by = sched.n_idx % heads
+                bz = sched.n_idx // heads
+                for s in T.serial(2):
+                    T.mbarrier_wait_parity(o_epi_full[0], (wave_id * 2 + s) & 1)
+                    T.copy(
+                        O_shared,
+                        Output[bz, (bx * 2 + s) * block_M : (bx * 2 + s + 1) * block_M, by, :],
+                    )
+                    T.mbarrier_arrive(o_epi_empty[0])
+                sched.next_tile()
+
+        else:  # warp 15: idle register donor
+            T.set_max_nreg(48, 0)
 
     return Output
 
 
 KERNELS = {
     "flash_attention": flash_attention,
+    "flash_attention_manual": flash_attention_manual,
     "flash_attention_ws": flash_attention_ws,
 }
 

--- a/examples/aws/gemm.py
+++ b/examples/aws/gemm.py
@@ -7,8 +7,67 @@ from tilelang.carver.arch import driver
 from tilelang.profiler import do_bench
 
 
-@tilelang.jit
+@tilelang.jit(pass_configs={tilelang.PassConfigKey.TL_ENABLE_AUTO_SCHEDULE: "role_based"})
 def gemm(
+    A,
+    B,
+    block_M,
+    block_N,
+    store_block_N,
+    block_K,
+    dtype,
+    accum_dtype,
+    num_stages,
+    num_persistent_stages,
+):
+    M, N, K = T.const("M, N, K")
+
+    A: T.Tensor((M, K), dtype)
+    B: T.Tensor((N, K), dtype)
+    C = T.empty((M, N), dtype)
+
+    m_blocks = T.ceildiv(M, block_M)
+    n_blocks = T.ceildiv(N, block_N)
+    k_blocks = T.ceildiv(K, block_K)
+    sm_num = driver.get_num_sms()
+    group_size = 8
+    assert n_blocks % (2 * group_size) == 0
+    assert K % (2 * block_K) == 0
+    assert block_N % store_block_N == 0
+
+    with T.Kernel(sm_num, threads=128) as block_id:
+        A_shared = T.alloc_shared((block_M, block_K), dtype)
+        B_shared = T.alloc_shared((block_N, block_K), dtype)
+        C_tmem = T.alloc_tmem([block_M, block_N], accum_dtype)
+        C_local = T.alloc_fragment((block_M, store_block_N), accum_dtype)
+        C_shared = T.alloc_shared((block_M, store_block_N), dtype)
+
+        sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, name="sched")
+        sched.init(block_id)
+
+        while sched.valid():
+            T.annotate_ws_pipeline_depth({C_tmem: num_persistent_stages})
+
+            bx = sched.m_idx
+            by = sched.n_idx
+
+            for k in T.Pipelined(k_blocks, num_stages=num_stages):
+                T.copy(A[bx * block_M, k * block_K], A_shared)
+                T.copy(B[by * block_N, k * block_K], B_shared)
+                T.gemm(A_shared, B_shared, C_tmem, transpose_B=True, clear_accum=k == 0)
+
+            for i in T.unroll(T.ceildiv(block_N, store_block_N)):
+                T.copy(C_tmem[:, i * store_block_N : (i + 1) * store_block_N], C_local)
+                T.copy(C_local, C_shared)
+                T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
+
+            sched.next_tile()
+
+    return C
+
+
+@tilelang.jit
+def gemm_manual(
     A,
     B,
     block_M,
@@ -45,7 +104,7 @@ def gemm(
 
         sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, name="sched")
 
-        # The complete, unambiguous schedule to transform `gemm` to `gemm_ws`.
+        # The complete, unambiguous schedule to transform `gemm_manual` to `gemm_ws`.
         #
         # Ops and loops carry stable ids (a T.WSID entry in their
         # annotations); the schedule refers to those ids. Data
@@ -128,6 +187,19 @@ def gemm(
                             "Epilogue": [],
                         },
                     ),
+                    # The epilogue loop.
+                    T.WSScope(
+                        "loop_i",
+                        {
+                            "TMA": [],
+                            "MMA": [],
+                            "Epilogue": [
+                                "copy_O_t2r",
+                                "copy_O_r2s",
+                                "copy_O_s2g",
+                            ],
+                        },
+                    ),
                     # This is the persistent loop.
                     T.WSScope(
                         "loop_wave",
@@ -146,8 +218,8 @@ def gemm(
                             "Epilogue": [
                                 "tile_idx",
                                 T.WSSync.consumer_wait("tmem", stage=0),
-                                # The unrolled loop is one op; it reads the
-                                # acquired version of C_tmem.
+                                # The epilogue scope reads the acquired
+                                # version of C_tmem.
                                 "loop_i",
                                 T.WSSync.consumer_release("tmem", stage=0),
                                 "sched_next",
@@ -207,9 +279,17 @@ def gemm(
                     T.ceildiv(block_N, store_block_N),
                     annotations={T.WSID: "loop_i"},
                 ):
-                    T.copy(C_tmem[:, i * store_block_N : (i + 1) * store_block_N], C_local)
-                    T.copy(C_local, C_shared)
-                    T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
+                    T.copy(
+                        C_tmem[:, i * store_block_N : (i + 1) * store_block_N],
+                        C_local,
+                        annotations={T.WSID: "copy_O_t2r"},
+                    )
+                    T.copy(C_local, C_shared, annotations={T.WSID: "copy_O_r2s"})
+                    T.copy(
+                        C_shared,
+                        C[bx * block_M, by * block_N + i * store_block_N],
+                        annotations={T.WSID: "copy_O_s2g"},
+                    )
 
                 with T.ws_op("sched_next"):
                     sched.next_tile()
@@ -350,7 +430,7 @@ def gemm_ws(
     return C
 
 
-KERNELS = {"gemm": gemm, "gemm_ws": gemm_ws}
+KERNELS = {"gemm": gemm, "gemm_manual": gemm_manual, "gemm_ws": gemm_ws}
 
 
 def main(

--- a/examples/aws/test_example_aws.py
+++ b/examples/aws/test_example_aws.py
@@ -8,8 +8,14 @@ import gemm
 @tilelang.testing.requires_cuda_compute_version(10)
 @tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_example_gemm():
-    # N must be a multiple of 2 * group_size * block_N, K of 2 * block_K.
     gemm.main(kernel="gemm", M=512, N=4096, K=512)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_example_gemm_manual():
+    gemm.main(kernel="gemm_manual", M=512, N=4096, K=512)
 
 
 @tilelang.testing.requires_cuda
@@ -24,6 +30,13 @@ def test_example_gemm_ws():
 @tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_example_flash_attention():
     flash_attention.main(kernel="flash_attention", batch=1, heads=4, seq_len=1024)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_example_flash_attention_manual():
+    flash_attention.main(kernel="flash_attention_manual", batch=1, heads=4, seq_len=1024)
 
 
 @tilelang.testing.requires_cuda

--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -163,6 +163,7 @@ file(GLOB TILE_LANG_CUDA_ACTIVE_SRCS
   src/cuda/codegen/rt_mod_cutedsl.cc
   src/cuda/op/*.cc
   src/cuda/transform/*.cc
+  src/cuda/transform/auto_schedule/*.cc
 )
 list(REMOVE_ITEM TILE_LANG_CUDA_ACTIVE_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/src/cuda/op/builtin.cc"

--- a/src/cuda/op/builtin.cc
+++ b/src/cuda/op/builtin.cc
@@ -15,6 +15,7 @@ namespace tl {
 using namespace tirx;
 
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableWarpSpecialized, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kEnableAutoSchedule, ffi::String);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableTMALower, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kPtxasRegisterUsageLevel, Integer);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableVectorize256, Bool);

--- a/src/cuda/op/builtin.h
+++ b/src/cuda/op/builtin.h
@@ -35,6 +35,7 @@ static constexpr const char *kHasTMA = "tl.has_tma";
 // because they are part of the Python PassContext interface.
 static constexpr const char *kDisableWarpSpecialized =
     "tl.disable_warp_specialized";
+static constexpr const char *kEnableAutoSchedule = "tl.enable_auto_schedule";
 static constexpr const char *kDisableTMALower = "tl.disable_tma_lower";
 static constexpr const char *kPtxasRegisterUsageLevel =
     "tl.ptxas_register_usage_level";

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -917,8 +917,8 @@ Stmt Copy::LowerCluster(const CopyNode &op, const LowerArgs &lower_args,
   const Array<Range> &src_range = op.src_range;
   const Array<Range> &dst_range = op.dst_range;
   ICHECK(op.dst_block.defined());
-  ICHECK(src.scope() == "shared" || src.scope() == "shared.dyn");
-  ICHECK(dst.scope() == "shared" || dst.scope() == "shared.dyn");
+  ICHECK(IsSharedBuffer(src));
+  ICHECK(IsSharedBuffer(dst));
 
   if (auto barrier_opt = GetBarrier(op)) {
     bool src_contiguous = IsContiguousRegion(src, src_range, analyzer);
@@ -1357,7 +1357,7 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
     is_ld = true;
   } else if (IsFragmentBuffer(src) && IsTmemBuffer(dst)) {
     is_st = true;
-  } else if (src.scope() == "shared.dyn" && IsTmemBuffer(dst)) {
+  } else if (IsSharedBuffer(src) && IsTmemBuffer(dst)) {
     is_cp = true;
   } else {
     LOG(FATAL) << "Unsupported tensor memory copy: " << "src scope = "

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -1340,7 +1340,7 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
   const Buffer &src = op.src;
   const Buffer &dst = op.dst;
 
-  if (src.scope() != "shared.tmem" && dst.scope() != "shared.tmem") {
+  if (!IsTmemBuffer(src) && !IsTmemBuffer(dst)) {
     return Stmt();
   }
   ICHECK(TargetHasTmem(lower_args.target))
@@ -1353,11 +1353,11 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
   bool src_needs_pack = 16 == src->dtype.bits();
   bool dst_needs_unpack = 16 == dst->dtype.bits();
 
-  if (src.scope() == "shared.tmem" && IsFragmentBuffer(dst)) {
+  if (IsTmemBuffer(src) && IsFragmentBuffer(dst)) {
     is_ld = true;
-  } else if (IsFragmentBuffer(src) && dst.scope() == "shared.tmem") {
+  } else if (IsFragmentBuffer(src) && IsTmemBuffer(dst)) {
     is_st = true;
-  } else if (src.scope() == "shared.dyn" && dst.scope() == "shared.tmem") {
+  } else if (src.scope() == "shared.dyn" && IsTmemBuffer(dst)) {
     is_cp = true;
   } else {
     LOG(FATAL) << "Unsupported tensor memory copy: " << "src scope = "

--- a/src/cuda/op/copy.h
+++ b/src/cuda/op/copy.h
@@ -37,7 +37,8 @@ enum class CopyInst : uint8_t {
 };
 
 const char *CopyInstToString(CopyInst inst);
-bool CopyInstIsTMA(CopyInst inst);
+bool CopyInstIsTMALoad(CopyInst inst);
+bool CopyInstIsTMAStore(CopyInst inst);
 bool CopyInstIsCPAsync(CopyInst inst);
 
 struct TMADesc {
@@ -95,9 +96,9 @@ struct CopyInstSelection {
 CopyInstSelection SelectCopyInstForLowering(const CopyNode &op,
                                             const CopyAnalysisContext &ctx);
 
-// Pre-layout producer classification used by warp-specialized scheduling.
-CopyInstSelection ClassifyWarpSpecializedProducerCopy(const CopyNode &op,
-                                                      Target target);
+// Pre-layout classification used by warp-specialized scheduling.
+CopyInstSelection ClassifyWarpSpecializedCopy(const CopyNode &op,
+                                              Target target);
 
 // Semantic queries used by transform passes that need copy shape/capability
 // information without knowing the CUDA lowering policy knobs.

--- a/src/cuda/op/copy_analysis.cc
+++ b/src/cuda/op/copy_analysis.cc
@@ -415,13 +415,13 @@ bool CheckSTSMCopy(const CopyNode &op, Target target) {
 }
 
 bool CheckTMemLoad(const CopyNode &op, Target target) {
-  return TargetHasTmem(target) && op.src.scope() == "shared.tmem" &&
+  return TargetHasTmem(target) && IsTmemBuffer(op.src) &&
          IsFragmentBuffer(op.dst);
 }
 
 bool CheckTMemStore(const CopyNode &op, Target target) {
   return TargetHasTmem(target) && IsFragmentBuffer(op.src) &&
-         op.dst.scope() == "shared.tmem";
+         IsTmemBuffer(op.dst);
 }
 
 bool CheckCPAsyncCopyPreconditions(const CopyNode &op) {
@@ -477,9 +477,12 @@ const char *CopyInstToString(CopyInst inst) {
   }
 }
 
-bool CopyInstIsTMA(CopyInst inst) {
-  return inst == CopyInst::kBulkLoad || inst == CopyInst::kBulkStore ||
-         inst == CopyInst::kBulkLoad1D || inst == CopyInst::kBulkStore1D;
+bool CopyInstIsTMALoad(CopyInst inst) {
+  return inst == CopyInst::kBulkLoad || inst == CopyInst::kBulkLoad1D;
+}
+
+bool CopyInstIsTMAStore(CopyInst inst) {
+  return inst == CopyInst::kBulkStore || inst == CopyInst::kBulkStore1D;
 }
 
 bool CopyInstIsCPAsync(CopyInst inst) { return inst == CopyInst::kCPAsync; }
@@ -804,10 +807,15 @@ CopyInstSelection SelectCopyInstForLowering(const CopyNode &op,
   return Supported(SelectSyncLikeInst(facts));
 }
 
-CopyInstSelection ClassifyWarpSpecializedProducerCopy(const CopyNode &op,
-                                                      Target target) {
+CopyInstSelection ClassifyWarpSpecializedCopy(const CopyNode &op,
+                                              Target target) {
   CopyAnalysisContext ctx;
   ctx.target = target;
+
+  if (IsSharedBuffer(op.src) && IsGlobalBuffer(op.dst)) {
+    return SelectCopyInstForLowering(op, ctx);
+  }
+
   CopyFacts facts = AnalyzeCopyFacts(op, ctx);
   if (!facts.cuda_like_target) {
     return Supported(CopyInst::kNormal);

--- a/src/cuda/op/gemm.cc
+++ b/src/cuda/op/gemm.cc
@@ -78,12 +78,11 @@ bool CheckWgmma(const GemmNode &op) {
 }
 
 bool AllowTcgen5Mma(const GemmNode &op, Target target) {
-  bool scope_ok = (IsSharedBuffer(op.a_) || op.a_.scope() == "shared.tmem") &&
-                  IsSharedBuffer(op.b_) && op.c_.scope() == "shared.tmem";
+  bool scope_ok = (IsSharedBuffer(op.a_) || IsTmemBuffer(op.a_)) &&
+                  IsSharedBuffer(op.b_) && IsTmemBuffer(op.c_);
   if (!TargetIsSm100(target) || !scope_ok)
     return false;
-  DataType ab_dtype =
-      (op.a_.scope() == "shared.tmem") ? op.b_->dtype : op.a_->dtype;
+  DataType ab_dtype = IsTmemBuffer(op.a_) ? op.b_->dtype : op.a_->dtype;
   return GetTCGEN5MMAMeta(op.m_, op.n_, op.k_, ab_dtype, op.c_->dtype).first;
 }
 

--- a/src/cuda/op/gemm_sp.cc
+++ b/src/cuda/op/gemm_sp.cc
@@ -69,12 +69,11 @@ bool CheckWGMMA(const GemmSPNode &op) {
 
 // TODO @botbw: support tcgen5mma.sp for sparse inputs when it's available
 bool AllowTcgen5Mma(const GemmSPNode &op, Target target) {
-  bool scope_ok = (IsSharedBuffer(op.A) || op.A.scope() == "shared.tmem") &&
-                  IsSharedBuffer(op.B) && op.C.scope() == "shared.tmem";
+  bool scope_ok = (IsSharedBuffer(op.A) || IsTmemBuffer(op.A)) &&
+                  IsSharedBuffer(op.B) && IsTmemBuffer(op.C);
   if (!TargetIsSm100(target) || !scope_ok)
     return false;
-  DataType ab_dtype =
-      (op.A.scope() == "shared.tmem") ? op.B->dtype : op.A->dtype;
+  DataType ab_dtype = IsTmemBuffer(op.A) ? op.B->dtype : op.A->dtype;
   return GetTCGEN5MMAMeta(op.M, op.N, op.K, ab_dtype, op.C->dtype).first;
 }
 

--- a/src/cuda/transform/auto_schedule.cc
+++ b/src/cuda/transform/auto_schedule.cc
@@ -1,0 +1,156 @@
+/*!
+ * \file auto_schedule.cc
+ * \brief Generic entrypoint for automatic warp-specialization schedulers.
+ *
+ * The pass config "tl.enable_auto_schedule" names the scheduler to run
+ * (see SchedulerRegistry; currently "role_based"); when unset the pass
+ * is a no-op. For each eligible kernel — a tilelang_root block with a
+ * known threadIdx.x extent, no existing schedule, and no manual warp
+ * specialization — the entrypoint
+ * gives every schedulable statement a stable "tl.ws_op_id" marker and
+ * checks the schedulability contract (preprocess_ir), then asks the
+ * scheduler for a typed WSSchedule, which MaterializeWSSchedule then
+ * lowers. The kernel body itself only gains the id markers; any kernel
+ * preprocessing or the scheduler declines is left byte-for-byte
+ * unchanged, with the reason emitted as an on-site warning (auto
+ * scheduling is opt-in, so the user expects it to fire).
+ *
+ * TODO: verify dependence coverage of USER-PROVIDED schedules with a real
+ * dependence analysis (synthesized schedules cover exactly the cross-role
+ * accesses they create; MaterializeWSSchedule does not verify dependence
+ * coverage).
+ */
+
+#include <tvm/ffi/reflection/registry.h>
+#include <tvm/runtime/logging.h>
+#include <tvm/target/target.h>
+#include <tvm/tirx/stmt.h>
+#include <tvm/tirx/stmt_functor.h>
+#include <tvm/tirx/transform.h>
+
+#include <map>
+#include <string>
+#include <utility>
+
+#include "./auto_schedule/preprocess_ir.h"
+#include "./auto_schedule/role_based_scheduler.h"
+#include "./ws_analysis.h"
+#include "cuda/op/builtin.h"
+#include "transform/common/warp_specialize.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+using namespace tirx::transform;
+
+namespace {
+
+// Available schedulers, by the name passed in tl.enable_auto_schedule.
+const std::map<std::string, SchedulerFn> &SchedulerRegistry() {
+  static const std::map<std::string, SchedulerFn> registry = {
+      {"role_based", RoleBasedSchedule},
+  };
+  return registry;
+}
+
+SchedulerFn FindScheduler(const ffi::String &name) {
+  const auto &registry = SchedulerRegistry();
+  auto it = registry.find(std::string(name));
+  if (it == registry.end()) {
+    std::string known;
+    for (const auto &[known_name, fn] : registry)
+      known += (known.empty() ? "" : ", ") + known_name;
+    LOG(FATAL) << "unknown auto-schedule scheduler '" << name
+               << "'; available: " << known;
+  }
+  return it->second;
+}
+
+class AutoScheduleRewriter : public StmtMutator {
+public:
+  AutoScheduleRewriter(SchedulerFn scheduler, Target target)
+      : scheduler_(scheduler), target_(std::move(target)) {}
+
+private:
+  Stmt VisitStmt_(const AttrStmtNode *op) final {
+    // Role ranges are expressed relative to the kernel's original worker
+    // count, so carry the enclosing thread extent while visiting its root.
+    if (op->attr_key == tirx::attr::thread_extent) {
+      const auto *iv = op->node.as<IterVarNode>();
+      if (iv && iv->thread_tag == "threadIdx.x") {
+        int old_threads = original_threads_;
+        original_threads_ = 0;
+        if (const auto *value = op->value.as<IntImmNode>())
+          original_threads_ = static_cast<int>(value->value);
+        Stmt result = StmtMutator::VisitStmt_(op);
+        original_threads_ = old_threads;
+        return result;
+      }
+    }
+    return StmtMutator::VisitStmt_(op);
+  }
+
+  Stmt VisitStmt_(const SBlockNode *op) final {
+    // Existing schedules and manually specialized scopes are explicit
+    // user decisions and take precedence over automatic planning.
+    if (op->name_hint != "tilelang_root" || original_threads_ == 0 ||
+        op->annotations.count(kWSScheduleKey) ||
+        HasManualWarpSpecialization(op->body)) {
+      return StmtMutator::VisitStmt_(op);
+    }
+
+    ffi::Optional<Stmt> body = PreprocessIR(op->body, target_);
+    if (!body.defined())
+      return GetRef<Stmt>(op);
+    ffi::Optional<WSSchedule> schedule = scheduler_(
+        GetRef<SBlock>(op), body.value(), original_threads_, target_);
+    if (!schedule.defined())
+      return GetRef<Stmt>(op);
+
+    auto annotations = op->annotations;
+    annotations.Set(kWSScheduleKey, schedule.value());
+    return SBlock(op->iter_vars, op->reads, op->writes, op->name_hint,
+                  std::move(body).value(), op->init, op->alloc_buffers,
+                  op->match_buffers, annotations, op->span);
+  }
+
+  SchedulerFn scheduler_;
+  Target target_;
+  int original_threads_{0};
+};
+
+PrimFunc AutoScheduleImpl(PrimFunc func, SchedulerFn scheduler) {
+  auto target = func->GetAttr<Target>(tvm::attr::kTarget);
+  ICHECK(target.defined()) << "AutoSchedule: PrimFunc has no bound target "
+                              "(BindTarget must run before AutoSchedule)";
+
+  AutoScheduleRewriter rewriter(scheduler, target.value());
+  Stmt body = rewriter(func->body);
+  if (body.same_as(func->body))
+    return func;
+  func.CopyOnWrite()->body = std::move(body);
+  return func;
+}
+
+} // namespace
+
+tvm::transform::Pass AutoSchedule() {
+  auto pass_func = [](PrimFunc func, const IRModule &, const PassContext &ctx) {
+    auto scheduler_name =
+        ctx->GetConfig(kEnableAutoSchedule, ffi::Optional<ffi::String>());
+    if (!scheduler_name.has_value())
+      return func;
+    return AutoScheduleImpl(std::move(func),
+                            FindScheduler(scheduler_name.value()));
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.AutoSchedule", {});
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef().def("tl.cuda.transform.AutoSchedule", AutoSchedule);
+}
+
+} // namespace tl
+} // namespace tvm

--- a/src/cuda/transform/auto_schedule/common.h
+++ b/src/cuda/transform/auto_schedule/common.h
@@ -1,0 +1,40 @@
+/*!
+ * \file common.h
+ * \brief Shared declarations of the AutoSchedule entrypoint and schedulers.
+ *
+ * A scheduler receives one eligible kernel — the root block and its body
+ * normalized so every schedulable statement carries a "tl.ws_op_id" marker —
+ * and returns a typed WSSchedule for MaterializeWSSchedule to lower, or
+ * nothing, logging the reason on-site (visible with TVM_LOG_DEBUG=1). It
+ * must not rewrite the kernel body.
+ */
+#pragma once
+
+#include <tvm/ffi/optional.h>
+#include <tvm/target/target.h>
+#include <tvm/tirx/stmt.h>
+
+#include "support/check.h"
+#include "transform/common/warp_specialize.h"
+
+namespace tvm {
+namespace tl {
+
+using SchedulerFn = ffi::Optional<WSSchedule> (*)(const tirx::SBlock &block,
+                                                  const tirx::Stmt &body,
+                                                  int worker_threads,
+                                                  const Target &target);
+
+// An id value arrives as an ffi String (loop annotations) or as a
+// StringImm (call annotations, whose values must be objects).
+inline ffi::String ExtractOpId(const ffi::Any &value) {
+  if (auto string = value.try_cast<ffi::String>())
+    return string.value();
+  if (const auto *imm = value.as<tirx::StringImmNode>())
+    return imm->value;
+  TVM_FFI_THROW(ValueError) << "AutoSchedule op id must be a string";
+  return "";
+}
+
+} // namespace tl
+} // namespace tvm

--- a/src/cuda/transform/auto_schedule/memory_detector.h
+++ b/src/cuda/transform/auto_schedule/memory_detector.h
@@ -1,0 +1,463 @@
+#pragma once
+#include <tvm/arith/analyzer.h>
+#include <tvm/runtime/logging.h>
+#include <tvm/tirx/buffer.h>
+#include <tvm/tirx/builtin.h>
+#include <tvm/tirx/expr.h>
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt.h>
+#include <tvm/tirx/stmt_functor.h>
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <set>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "op/builtin.h"
+#include "op/operator.h"
+#include "op/utils.h"
+#include "support/check.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+using ffi::Array;
+using ffi::GetRef;
+
+// Collect direct buffer regions and scalar-variable accesses from a statement.
+// Buffer indices are relaxed over surrounding loop domains, and repeated
+// accesses to the same logical buffer are unioned dimension by dimension.
+// Adapted from BlockReadWriteDetector in TVM.
+class MemoryAccessDetector : public StmtExprVisitor {
+public:
+  MemoryAccessDetector() = default;
+
+  // Analyze a statement and collect read/write regions
+  void Analyze(const Stmt &stmt) {
+    read_buffers_.clear();
+    write_buffers_.clear();
+    read_regions_.clear();
+    write_regions_.clear();
+    dom_map_.clear();
+    hint_map_.clear();
+    pending_conditions_.clear();
+    let_bindings_.clear();
+    read_vars_.clear();
+    write_vars_.clear();
+    operator()(stmt);
+  }
+
+  void Analyze(const PrimExpr &expr) {
+    read_buffers_.clear();
+    write_buffers_.clear();
+    read_regions_.clear();
+    write_regions_.clear();
+    dom_map_.clear();
+    hint_map_.clear();
+    pending_conditions_.clear();
+    let_bindings_.clear();
+    read_vars_.clear();
+    write_vars_.clear();
+    operator()(expr);
+  }
+
+  // Return collected read regions
+  std::vector<BufferRegion> GetReadRegions() const {
+    return CollectRegions(read_buffers_, read_regions_);
+  }
+
+  // Return collected write regions
+  std::vector<BufferRegion> GetWriteRegions() const {
+    return CollectRegions(write_buffers_, write_regions_);
+  }
+
+  // Return all variables that are read from
+  std::vector<Var> GetReadVars() const { return read_vars_; }
+  // Return all variables that are written to
+  std::vector<Var> GetWriteVars() const { return write_vars_; }
+
+private:
+  /*! \brief Iteration range for loop_vars */
+  std::unordered_map<const VarNode *, arith::IntSet> dom_map_;
+  /*! \brief Extra iteration range hint for free vars */
+  std::unordered_map<const VarNode *, arith::IntSet> hint_map_;
+  /*! \brief Unresolved conditions within current scope. */
+  std::vector<PrimExpr> pending_conditions_;
+  /*! \brief The buffers that the current block reads */
+  std::vector<Buffer> read_buffers_;
+  /*! \brief The buffers that the current block writes */
+  std::vector<Buffer> write_buffers_;
+  /*! \brief The read regions of the current block */
+  std::vector<std::vector<tvm::arith::IntSet>> read_regions_;
+  /*! \brief The write regions of the current block */
+  std::vector<std::vector<tvm::arith::IntSet>> write_regions_;
+  /*!\ brief Internal analyzer. */
+  arith::Analyzer ana_;
+  /*! \brief let bindings inside the block */
+  std::unordered_map<const VarNode *, PrimExpr> let_bindings_;
+
+  /*! \brief The set of variables that are read in the current block.  */
+  std::vector<Var> read_vars_;
+  /*! \brief The set of variables that are written in the current block.  */
+  std::vector<Var> write_vars_;
+
+  /*!
+   * \brief Update read/write buffers and regions with provided buffer and
+   * region
+   */
+  void Update(std::vector<Buffer> *buffers,
+              std::vector<std::vector<arith::IntSet>> *regions, Buffer buffer,
+              std::vector<arith::IntSet> region) {
+    UpdateReadVar(buffer->data);
+    // Check if buffer already exists
+    for (size_t i = 0; i < buffers->size(); ++i) {
+      if ((*buffers)[i].same_as(buffer)) {
+        // Merge regions
+        ICHECK_EQ((*regions)[i].size(), region.size());
+        for (size_t j = 0; j < region.size(); ++j) {
+          (*regions)[i][j] = arith::Union({(*regions)[i][j], region[j]});
+        }
+        return;
+      }
+    }
+    // New buffer
+    buffers->push_back(buffer);
+    regions->push_back(region);
+  }
+
+  /*!
+   * \brief Update the set of read variables with the given variable
+   * \param var The variable to add to the set of read variables
+   */
+  void UpdateReadVar(const Var &var) {
+    for (const auto &v : read_vars_) {
+      if (v.same_as(var))
+        return;
+    }
+    read_vars_.push_back(var);
+  }
+
+  /*!
+   * \brief Update the set of write variables with the given variable
+   * \param var The variable to add to the set of write variables
+   */
+  void UpdateWriteVar(const Var &var) {
+    for (const auto &v : write_vars_) {
+      if (v.same_as(var))
+        return;
+    }
+    write_vars_.push_back(var);
+  }
+
+  /*!
+   * \brief Record one normalized access region: relax every range over the
+   * loop domain, charge the index computations' variable reads, and file
+   * the region under the mask's sides.
+   */
+  void ProcessAccessRegion(const AccessRegion &access) {
+    const Buffer &buffer = access.region->buffer;
+    std::vector<arith::IntSet> int_sets;
+    int_sets.reserve(access.region->region.size());
+    for (const auto &range : access.region->region) {
+      int_sets.push_back(RelaxAccessIndex(range->min, range->extent));
+      VisitExpr(range->min);
+      VisitExpr(range->extent);
+    }
+    if (access.access_mask & kAccessRead)
+      Update(&read_buffers_, &read_regions_, buffer, int_sets);
+    if (access.access_mask & kAccessWrite)
+      Update(&write_buffers_, &write_regions_, buffer, int_sets);
+  }
+
+  /*!
+   * \brief Process a buffer-like argument (BufferRegion, BufferLoad, or
+   * tl.region bridge) of a tile op.
+   * \param is_read The access side when the argument carries no mask itself
+   */
+  void ProcessBufferRegion(const PrimExpr &arg, bool is_read) {
+    ProcessAccessRegion(
+        NormalizeToAccessRegion(arg, is_read ? kAccessRead : kAccessWrite));
+  }
+
+  /*! \brief Helper function to collect access regions. */
+  std::vector<BufferRegion> CollectRegions(
+      const std::vector<Buffer> &buffers,
+      const std::vector<std::vector<tvm::arith::IntSet>> &regions) const {
+    std::vector<BufferRegion> result;
+    result.reserve(buffers.size());
+    for (size_t i = 0; i < buffers.size(); ++i) {
+      const Buffer &buffer = buffers[i];
+      const std::vector<arith::IntSet> &int_sets = regions[i];
+      Region region;
+      size_t ndim = buffer->shape.size();
+      size_t region_ndim = int_sets.size();
+
+      // Assert that region dimension equals buffer dimension
+      ICHECK_EQ(region_ndim, ndim) << "Region dimension " << region_ndim
+                                   << " must equal buffer dimension " << ndim;
+
+      region.reserve(ndim);
+      for (size_t j = 0; j < ndim; ++j) {
+        const tvm::arith::IntSet &int_set = int_sets[j];
+        region.push_back(
+            int_set.CoverRange(Range::FromMinExtent(0, buffer->shape[j])));
+      }
+
+      result.push_back(BufferRegion(buffer, region));
+    }
+    return result;
+  }
+
+  /*! \brief Resolve Let bindings in an expression to a fixpoint. */
+  PrimExpr ResolveLets(const PrimExpr &e) {
+    PrimExpr current = e;
+    PrimExpr remapped = Substitute(current, let_bindings_);
+    while (!remapped.same_as(current)) {
+      current = remapped;
+      remapped = Substitute(current, let_bindings_);
+    }
+    return current;
+  }
+
+  /*! \brief Relax the half-open range [base, base + extent) over the loop
+   * domain, resolving Let bindings first. The default extent of 1 gives the
+   * single-point relaxation of one index. */
+  arith::IntSet RelaxAccessIndex(const PrimExpr &index,
+                                 PrimExpr extent = IntImm(DataType::Int(32),
+                                                          1)) {
+    PrimExpr base = ResolveLets(index);
+    arith::IntSet lo_set =
+        arith::EvalSet(arith::IntSet::Vector(base), dom_map_);
+    const auto *ext_imm = extent.as<IntImmNode>();
+    if (ext_imm && ext_imm->value <= 1) {
+      return lo_set;
+    }
+    PrimExpr hi = base + ResolveLets(extent) - make_const(base.dtype(), 1);
+    arith::IntSet hi_set = arith::EvalSet(arith::IntSet::Vector(hi), dom_map_);
+    return arith::IntSet::Interval(lo_set.min(), hi_set.max());
+  }
+
+  void VisitStmt_(const ForNode *op) override {
+    Range range = Range::FromMinExtent(op->min, op->extent);
+    dom_map_[op->loop_var.get()] = arith::IntSet::FromRange(range);
+    StmtExprVisitor::VisitStmt_(op);
+    dom_map_.erase(op->loop_var.get());
+  }
+
+  void VisitStmt_(const IfThenElseNode *op) override {
+    VisitExpr(op->condition);
+    {
+      // Visit then branch
+      // Simplified: we don't handle conditional bounds for now
+      StmtExprVisitor::VisitStmt(op->then_case);
+    }
+    if (op->else_case) {
+      // Visit else branch
+      StmtExprVisitor::VisitStmt(op->else_case.value());
+    }
+  }
+
+  void VisitStmt_(const BindNode *op) override {
+    // The value contributes this task's direct reads; the bound variable is a
+    // scalar write. The scheduler follows these direct def-use links on demand
+    // when it computes the transitive Let dependency closure.
+    VisitExpr(op->value);
+    let_bindings_[op->var.get()] = op->value;
+    UpdateWriteVar(op->var);
+  }
+
+  void VisitExpr_(const VarNode *op) override {
+    UpdateReadVar(tvm::ffi::GetRef<Var>(op));
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  void VisitExpr_(const BufferLoadNode *op) override {
+    std::vector<arith::IntSet> relaxed_region;
+    size_t num_indices = op->indices.size();
+    size_t buffer_ndim = op->buffer->shape.size();
+
+    // Assert that indices count equals buffer dimension
+    ICHECK_EQ(num_indices, buffer_ndim)
+        << "BufferLoad indices count " << num_indices
+        << " must equal buffer dimension " << buffer_ndim;
+
+    for (PrimExpr index : op->indices) {
+      relaxed_region.push_back(RelaxAccessIndex(index));
+    }
+    Update(&read_buffers_, &read_regions_, op->buffer, relaxed_region);
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  void VisitStmt_(const BufferStoreNode *op) override {
+    std::vector<arith::IntSet> relaxed_region;
+    size_t num_indices = op->indices.size();
+    size_t buffer_ndim = op->buffer->shape.size();
+
+    // Assert that indices count equals buffer dimension
+    ICHECK_EQ(num_indices, buffer_ndim)
+        << "BufferStore indices count " << num_indices
+        << " must equal buffer dimension " << buffer_ndim;
+
+    for (PrimExpr index : op->indices) {
+      relaxed_region.push_back(RelaxAccessIndex(index));
+    }
+    Update(&write_buffers_, &write_regions_, op->buffer, relaxed_region);
+    StmtExprVisitor::VisitStmt_(op);
+  }
+
+  void VisitExpr_(const CallNode *op) override {
+    static const auto reduce_op = Op::Get("tl.tileop.reduce");
+    static const auto tl_access_ptr_op = Op::Get("tl.access_ptr");
+
+    // A tl.region(...) bridge: decode through the shared normalizer.
+    if (op->op.same_as(tl::region())) {
+      ProcessAccessRegion(NormalizeToAccessRegion(GetRef<PrimExpr>(op)));
+      return;
+    }
+
+    // Check for tl.tileop.reduce call
+    if (op->op.same_as(reduce_op)) {
+      // Handle tl.tileop.reduce call for memory access analysis
+      // args[0] = input buffer region (read)
+      // args[1] = output buffer region (write)
+      // args[2] = reduce_type (string)
+      // args[3] = dim (int)
+      // args[4] = clear (bool)
+      if (op->args.size() >= 2) {
+        // Process first argument as read region
+        ProcessBufferRegion(op->args[0], true); // is_read = true
+        // Process second argument as write region
+        ProcessBufferRegion(op->args[1], false); // is_read = false
+      }
+      return;
+    }
+
+    // Handle other calls (e.g., builtin::tvm_access_ptr)
+    if (op->op.same_as(builtin::tvm_access_ptr())) {
+      // Simplified: skip for now
+      StmtExprVisitor::VisitExpr_(op);
+      return;
+    }
+
+    // Handle TileLang `tl.access_ptr(BufferLoad(buf, mins), extent, rw_mask)`.
+    // The access is a contiguous run of `extent` elements in row-major layout
+    // starting at the base index `mins`. Reconstruct the per-dimension region
+    // by distributing the flat extent across dimensions from innermost outward,
+    // rather than conservatively taking the whole buffer for every dimension.
+    if (op->op.same_as(tl_access_ptr_op)) {
+      if (op->args.size() >= 3) {
+        const auto *buffer_load = op->args[0].as<BufferLoadNode>();
+        const auto *mask_int = op->args[2].as<IntImmNode>();
+        if (buffer_load && mask_int) {
+          Buffer buffer = buffer_load->buffer;
+          int rw_mask = mask_int->value;
+          size_t ndim = buffer->shape.size();
+          std::vector<arith::IntSet> region(ndim);
+
+          const auto *ext_imm = op->args[1].as<IntImmNode>();
+          if (ext_imm && buffer_load->indices.size() == ndim) {
+            // Distribute a known flat extent (in elements) across dims,
+            // innermost-first. `rem` is the number of elements still to be
+            // covered at the current dimension; each dim consumes as many of
+            // its `shape[i]` indices as the run spans, carrying the rounded-up
+            // remainder to the next (outer) dim.
+            int64_t rem = ext_imm->value;
+            for (size_t k = ndim; k-- > 0;) {
+              PrimExpr base = buffer_load->indices[k];
+              const auto *dim_imm = buffer->shape[k].as<IntImmNode>();
+              if (rem <= 1) {
+                region[k] = RelaxAccessIndex(base);
+              } else if (dim_imm) {
+                int64_t d = dim_imm->value;
+                if (rem >= d) {
+                  // Run spills past this dim: cover it whole and carry up.
+                  region[k] = arith::IntSet::FromRange(
+                      Range::FromMinExtent(0, buffer->shape[k]));
+                  rem = (rem + d - 1) / d;
+                } else {
+                  region[k] = RelaxAccessIndex(base, IntImm(base.dtype(), rem));
+                  rem = 1;
+                }
+              } else {
+                // Non-constant dim size: be conservative for this and any
+                // remaining outer dims.
+                region[k] = arith::IntSet::FromRange(
+                    Range::FromMinExtent(0, buffer->shape[k]));
+                rem = 1;
+              }
+            }
+          } else {
+            // Non-constant extent or arity mismatch: fall back to whole buffer.
+            for (size_t k = 0; k < ndim; ++k) {
+              region[k] = arith::IntSet::FromRange(
+                  Range::FromMinExtent(0, buffer->shape[k]));
+            }
+          }
+
+          if (rw_mask & 1) {
+            Update(&read_buffers_, &read_regions_, buffer, region);
+          }
+          if (rw_mask & 2) {
+            Update(&write_buffers_, &write_regions_, buffer, region);
+          }
+          for (const PrimExpr &index : buffer_load->indices) {
+            VisitExpr(index);
+          }
+          VisitExpr(op->args[1]);
+          return;
+        }
+      }
+      StmtExprVisitor::VisitExpr_(op);
+      return;
+    }
+
+    // Query each TileLang operator's exact access regions so GEMM, copy, fill,
+    // scan, atomic and future tile ops retain region sensitivity without one
+    // special case per operation.
+    if (TileOperator tile_op = ParseOperator(GetRef<Call>(op));
+        tile_op.defined()) {
+      AccessRegions accesses = tile_op->GetAccessRegions();
+      auto add_regions = [&](const Array<BufferRegion> &regions, bool is_read) {
+        for (const BufferRegion &buffer_region : regions) {
+          std::vector<arith::IntSet> int_sets;
+          int_sets.reserve(buffer_region->region.size());
+          for (const Range &range : buffer_region->region) {
+            int_sets.push_back(RelaxAccessIndex(range->min, range->extent));
+            VisitExpr(range->min);
+            VisitExpr(range->extent);
+          }
+          if (is_read) {
+            Update(&read_buffers_, &read_regions_, buffer_region->buffer,
+                   int_sets);
+          } else {
+            Update(&write_buffers_, &write_regions_, buffer_region->buffer,
+                   int_sets);
+          }
+        }
+      };
+      add_regions(accesses.reads, true);
+      add_regions(accesses.writes, false);
+      return;
+    }
+
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  void VisitStmt_(const SBlockNode *op) override {
+    // TIRX represents many TileLang regions as direct SBlock nodes.  Match the
+    // old TIR behavior for BlockNode by visiting the body so task-level buffer
+    // dependencies are preserved.
+    StmtExprVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const SBlockRealizeNode *op) override {
+    // Don't visit child blocks recursively
+  }
+};
+
+} // namespace tl
+} // namespace tvm

--- a/src/cuda/transform/auto_schedule/preprocess_ir.cc
+++ b/src/cuda/transform/auto_schedule/preprocess_ir.cc
@@ -135,11 +135,10 @@ public:
 private:
   explicit OpIdNormalizer(Target target) : target_(std::move(target)) {}
 
-  // A simple wrapper around one call is a direct op (ClassifyStmt sees
-  // through it); only genuinely compound statements are opaque.
+  // The scheduler and the materializer treat only a bare Evaluate as a
+  // directly scheduled call, so a wrapped asynchronous op must decline.
   void CheckOpaqueOp(const Stmt &stmt) {
-    if (!GetEvaluateCallInSimpleWrapper(stmt).defined())
-      ok_ = ok_ && CheckHostsNoAsync(stmt, target_);
+    ok_ = ok_ && CheckHostsNoAsync(stmt, target_);
   }
 
   void CollectIds(const Stmt &stmt) {

--- a/src/cuda/transform/auto_schedule/preprocess_ir.cc
+++ b/src/cuda/transform/auto_schedule/preprocess_ir.cc
@@ -1,0 +1,263 @@
+/*!
+ * \file preprocess_ir.cc
+ * \brief Give every schedulable statement a stable "tl.ws_op_id" marker.
+ *
+ * The markers use the same surface forms a hand-written schedule uses:
+ * call annotations on tile ops, loop annotations on For loops (sequential
+ * kinds — serial, unrolled — are scopes; parallel and vectorized loops are
+ * single opaque ops), and a `T.ws_op` AttrStmt wrapper on everything else
+ * (Binds, stores, nested blocks, while-loop scopes).
+ * Generated ids carry a name hint — the callee's op name, the bound var,
+ * the stored buffer — so schedules and diagnostics stay readable.
+ * Existing ids are reused, so normalization is idempotent.
+ *
+ * Normalization also checks the schedulability contract, declining the
+ * kernel (warning + nullopt): no loop_break, no atomics, no hand-written
+ * synchronization, and no asynchronous tile op nested inside an opaque
+ * op.
+ */
+
+#include "./preprocess_ir.h"
+
+#include <tvm/ir/op.h>
+#include <tvm/runtime/logging.h>
+#include <tvm/tirx/stmt_functor.h>
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <string>
+
+#include "cuda/transform/ws_analysis.h"
+#include "op/builtin.h"
+#include "op/copy.h"
+#include "op/operator.h"
+#include "op/utils.h"
+#include "transform/common/warp_specialize.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+using namespace ffi;
+
+namespace {
+
+// The callee's op name with "." replaced by "_".
+std::string CallKind(const CallNode *call) {
+  if (const auto *op = call->op.as<OpNode>()) {
+    std::string name = op->name;
+    std::replace(name.begin(), name.end(), '.', '_');
+    return name;
+  }
+  return "op";
+}
+
+// Constructs the materializer cannot schedule at all; warns and returns
+// false on the first violation.
+bool CheckCalls(const Stmt &body) {
+  bool ok = true;
+  PostOrderVisit(body, [&ok](const ObjectRef &node) {
+    const auto *call = node.as<CallNode>();
+    if (call == nullptr || !ok)
+      return;
+    if (call->op.same_as(tl::loop_break())) {
+      LOG(WARNING) << "AutoSchedule skipped: cannot schedule loop_break";
+      ok = false;
+      return;
+    }
+    if (IsBarrierOrTmaControlCall(call)) {
+      LOG(WARNING) << "AutoSchedule skipped: cannot schedule hand-written "
+                      "synchronization or TMA control ('"
+                   << call->op << "'): block-wide syncs cannot be duplicated "
+                   << "into roles, and hand-managed barrier protocols are "
+                   << "invisible to the schedule";
+      ok = false;
+      return;
+    }
+    if (const auto *op = call->op.as<OpNode>()) {
+      if (std::string(op->name).find("atomic") != std::string::npos) {
+        LOG(WARNING) << "AutoSchedule skipped: cannot schedule atomic op '"
+                     << op->name << "'";
+        ok = false;
+      }
+    }
+  });
+  return ok;
+}
+
+// A tile op whose completion the schedule must track (g2s async
+// producer, tmem or wg_wait gemm) cannot nest inside an opaque op. TMA
+// stores are fine: they complete through the copy lowering's own
+// commit-group machinery.
+bool CheckHostsNoAsync(const Stmt &stmt, const Target &target) {
+  bool ok = true;
+  PostOrderVisit(stmt, [&](const ObjectRef &node) {
+    const auto *call = node.as<CallNode>();
+    if (call == nullptr || !ok)
+      return;
+    TileOperator tile_op = ParseOperator(GetRef<Call>(call));
+    if (!tile_op.defined())
+      return;
+    if (const auto *copy = tile_op.as<CopyNode>()) {
+      if (ClassifyCopy(copy, target) == TileStmtKind::kTmaProducer) {
+        LOG(WARNING) << "AutoSchedule skipped: an asynchronous "
+                        "global->shared copy is nested inside a compound "
+                        "statement; write it as its own statement so its "
+                        "completion barrier can be wired";
+        ok = false;
+      }
+      return;
+    }
+    if (auto gemm = GetGemmInfo(tile_op)) {
+      if (IsTmemBuffer(gemm->accumulator) || gemm->wg_wait != 0) {
+        LOG(WARNING) << "AutoSchedule skipped: an asynchronous gemm is "
+                        "nested inside a compound statement; write it as "
+                        "its own statement";
+        ok = false;
+      }
+    }
+  });
+  return ok;
+}
+
+class OpIdNormalizer : public StmtMutator {
+public:
+  static Optional<Stmt> Rewrite(Stmt body, const Target &target) {
+    OpIdNormalizer normalizer(target);
+    normalizer.CollectIds(body);
+    Stmt result = normalizer(std::move(body));
+    if (!normalizer.ok_)
+      return std::nullopt;
+    return result;
+  }
+
+private:
+  explicit OpIdNormalizer(Target target) : target_(std::move(target)) {}
+
+  // A simple wrapper around one call is a direct op (ClassifyStmt sees
+  // through it); only genuinely compound statements are opaque.
+  void CheckOpaqueOp(const Stmt &stmt) {
+    if (!GetEvaluateCallInSimpleWrapper(stmt).defined())
+      ok_ = ok_ && CheckHostsNoAsync(stmt, target_);
+  }
+
+  void CollectIds(const Stmt &stmt) {
+    PostOrderVisit(stmt, [&](const ObjectRef &node) {
+      if (const auto *attr = node.as<AttrStmtNode>()) {
+        if (attr->attr_key == kWSOpIdKey)
+          used_ids_.insert(ExtractOpId(Any(attr->value)));
+      } else if (const auto *loop = node.as<ForNode>()) {
+        if (auto value = loop->annotations.Get(kWSOpIdKey))
+          used_ids_.insert(ExtractOpId(value.value()));
+      } else if (const auto *call = node.as<CallNode>()) {
+        if (auto value = call->annotations.Get(kWSOpIdKey))
+          used_ids_.insert(ExtractOpId(Any(value.value())));
+      }
+    });
+  }
+
+  String FreshId(const std::string &kind) {
+    while (true) {
+      String id(kind + "_" + std::to_string(next_id_[kind]++));
+      if (used_ids_.insert(id).second)
+        return id;
+    }
+  }
+
+  Stmt WrapWithId(const Stmt &stmt, const std::string &kind) {
+    return AttrStmt(Integer(0), kWSOpIdKey, StringImm(FreshId(kind)), stmt,
+                    stmt->span);
+  }
+
+  Stmt VisitStmt_(const AttrStmtNode *op) final {
+    // Other wrappers (assumptions, kernel metadata,
+    // T.annotate_ws_pipeline_depth) are transparent.
+    if (op->attr_key != kWSOpIdKey)
+      return StmtMutator::VisitStmt_(op);
+    // A while loop under an existing wrapper is a scope: keep the wrapper,
+    // keep the loop, and normalize only the loop body (re-dispatching the
+    // while would wrap it a second time and turn the scope into an op).
+    // Anything else is one indivisible op.
+    if (const auto *wl = op->body.as<WhileNode>()) {
+      While loop = GetRef<While>(wl);
+      loop.CopyOnWrite()->body = VisitStmt(wl->body);
+      return AttrStmt(op->node, op->attr_key, op->value, std::move(loop),
+                      op->span);
+    }
+    Stmt stmt = GetRef<Stmt>(op);
+    CheckOpaqueOp(stmt);
+    return stmt;
+  }
+
+  Stmt VisitStmt_(const EvaluateNode *op) final {
+    const auto *call = op->value.as<CallNode>();
+    if (call == nullptr)
+      return WrapWithId(GetRef<Stmt>(op), "op");
+    if (call->annotations.count(kWSOpIdKey))
+      return GetRef<Stmt>(op);
+    auto annotations = call->annotations;
+    annotations.Set(kWSOpIdKey, StringImm(FreshId(CallKind(call))));
+    return Evaluate(Call(call->dtype, call->op, call->args,
+                         std::move(annotations), call->span));
+  }
+
+  Stmt VisitStmt_(const WhileNode *op) final {
+    While loop = GetRef<While>(op);
+    loop.CopyOnWrite()->body = VisitStmt(op->body);
+    return WrapWithId(loop, "while");
+  }
+
+  Stmt VisitStmt_(const BufferStoreNode *op) final {
+    return WrapWithId(GetRef<Stmt>(op), std::string(op->buffer->name));
+  }
+
+  Stmt VisitStmt_(const BindNode *op) final {
+    return WrapWithId(GetRef<Stmt>(op), std::string(op->var->name_hint));
+  }
+
+  Stmt VisitStmt_(const SBlockNode *op) final {
+    Stmt stmt = GetRef<Stmt>(op);
+    CheckOpaqueOp(stmt);
+    return WrapWithId(stmt, "block");
+  }
+
+  Stmt VisitStmt_(const ForNode *op) final {
+    // Sequential loops (serial, unrolled) are scopes; parallel and
+    // vectorized loops are single opaque ops. Both carry the id in the
+    // loop annotations, so recurse only into scope bodies.
+    if (op->kind != ForKind::kSerial && op->kind != ForKind::kUnrolled) {
+      CheckOpaqueOp(GetRef<For>(op));
+      if (op->annotations.count(kWSOpIdKey))
+        return GetRef<For>(op);
+      const char *kind = op->kind == ForKind::kParallel     ? "parallel"
+                         : op->kind == ForKind::kVectorized ? "vectorize"
+                                                            : "loop";
+      For loop = GetRef<For>(op);
+      loop.CopyOnWrite()->annotations.Set(kWSOpIdKey, FreshId(kind));
+      return loop;
+    }
+    For loop = Downcast<For>(StmtMutator::VisitStmt_(op));
+    if (!loop->annotations.count(kWSOpIdKey))
+      loop.CopyOnWrite()->annotations.Set(
+          kWSOpIdKey,
+          FreshId(op->kind == ForKind::kUnrolled ? "unroll" : "loop"));
+    return loop;
+  }
+
+  Target target_;
+  bool ok_ = true;
+  std::set<String> used_ids_;
+  std::map<std::string, int> next_id_;
+};
+
+} // namespace
+
+ffi::Optional<Stmt> PreprocessIR(Stmt body, const Target &target) {
+  if (!CheckCalls(body))
+    return std::nullopt;
+  return OpIdNormalizer::Rewrite(std::move(body), target);
+}
+
+} // namespace tl
+} // namespace tvm

--- a/src/cuda/transform/auto_schedule/preprocess_ir.h
+++ b/src/cuda/transform/auto_schedule/preprocess_ir.h
@@ -1,0 +1,18 @@
+/*!
+ * \file preprocess_ir.h
+ * \brief Give every schedulable statement a stable "tl.ws_op_id" marker.
+ */
+#pragma once
+
+#include "./common.h"
+
+namespace tvm {
+namespace tl {
+
+// Give every schedulable statement a stable "tl.ws_op_id" marker in the
+// forms MaterializeWSSchedule consumes; idempotent. Unschedulable
+// constructs decline the kernel (warning + nullopt).
+ffi::Optional<tirx::Stmt> PreprocessIR(tirx::Stmt body, const Target &target);
+
+} // namespace tl
+} // namespace tvm

--- a/src/cuda/transform/auto_schedule/role_based_scheduler.cc
+++ b/src/cuda/transform/auto_schedule/role_based_scheduler.cc
@@ -31,8 +31,8 @@
  * cycle (producer_consumer_ws's positional criterion; merging is then
  * free by construction). Software-pipeline stage offsets (every sync is
  * stage 0); if-else branches; sibling-pipeline chaining; multi-consumer
- * fan-out; a multi-warp copy role; delayed wgmma waits (wg_wait != 0
- * declines).
+ * fan-out; a multi-warp role for register-staged SIMT copies; delayed
+ * wgmma waits (wg_wait != 0 declines).
  */
 
 #include "./role_based_scheduler.h"
@@ -52,6 +52,7 @@
 #include <vector>
 
 #include "./memory_detector.h"
+#include "cuda/op/builtin.h"
 #include "cuda/target_utils.h"
 #include "cuda/transform/ws_analysis.h"
 #include "op/copy.h"
@@ -73,6 +74,37 @@ enum class Role : uint8_t { kWorker = 0, kLoad = 1, kMma = 2, kStore = 3 };
 constexpr int kNumRoles = 4;
 constexpr std::array<Role, kNumRoles> kAllRoles = {Role::kWorker, Role::kLoad,
                                                    Role::kMma, Role::kStore};
+
+constexpr int kAuxiliaryRoleNumRegisters = 24;
+
+// Registers for a widened cp.async Load warpgroup's addressing work.
+constexpr int kCpAsyncLoadNumRegisters = 48;
+
+// Occupancy estimate cap, and the per-SM capacities bounding it.
+constexpr int kHeuristicBlocksPerSM = 4;
+constexpr int kMaxThreadsPerSM = 2048;
+constexpr int kSmemBytesPerSM = 228 * 1024; // sm90 / sm100
+constexpr int kTmemBytesPerSM = 256 * 1024; // 512 b32 columns of 128 rows
+
+// The occupancy annotation from the T.annotate_min_blocks_per_sm
+// wrapper, 0 when absent.
+int AnnotatedMinBlocksPerSM(const Stmt &body) {
+  int min_blocks = 0;
+  PostOrderVisit(body, [&](const ObjectRef &node) {
+    if (const auto *attr = node.as<AttrStmtNode>()) {
+      if (attr->attr_key == attr::kMinBlocksPerSM) {
+        if (const auto *imm = attr->value.as<IntImmNode>()) {
+          if (imm->value <= 0) {
+            LOG(FATAL) << "min_blocks_per_sm must be positive, got: "
+                       << imm->value;
+          }
+          min_blocks = static_cast<int>(imm->value);
+        }
+      }
+    }
+  });
+  return min_blocks;
+}
 
 // A SET of roles: an op is replicated into several roles when roleless,
 // and a scope's participants span its ops' roles. Single-role facts use
@@ -426,6 +458,8 @@ public:
       return std::nullopt;
     }
     CollectAnnotatedLayouts(block, layout_map_);
+    annotated_min_blocks_ = AnnotatedMinBlocksPerSM(body);
+    alloc_buffers_ = block->alloc_buffers;
     if (!BuildStructure(body) || !ClassifyOps())
       return std::nullopt;
     IndexBufferUses();
@@ -1006,25 +1040,124 @@ private:
 
   // ---- emission -------------------------------------------------------------
 
+  struct RolePlan {
+    Role role;
+    int warp_lo;
+    int warp_hi;
+    int nreg;
+  };
+
+  // Use more threads if async producer is cp.async.
+  bool HasCpAsyncLoad() const {
+    for (const auto &op : ops_)
+      if (op->kind == TileStmtKind::kCpAsyncProducer &&
+          op->PlacedIn(Role::kLoad))
+        return true;
+    return false;
+  }
+
+  // The occupancy-target average minus the auxiliary requests, split
+  // over the worker warpgroups. 0 = emit no setmaxnreg anywhere: the
+  // split fell below the average or outside setmaxnreg's [24, 256].
+  int WorkerNreg(const std::vector<RolePlan> &plans, int num_warps,
+                 int avg) const {
+    int worker_warps = worker_threads_ / 32;
+    if (worker_warps % 4 != 0 || num_warps == worker_warps)
+      return 0;
+    int budget = num_warps / 4 * avg;
+    for (int wg = worker_warps / 4; wg < num_warps / 4; ++wg) {
+      int nreg = kAuxiliaryRoleNumRegisters; // idle warps donate too
+      for (const RolePlan &p : plans)
+        if (p.role != Role::kWorker && p.warp_lo < (wg + 1) * 4 &&
+            wg * 4 < p.warp_hi)
+          nreg = std::max(nreg, p.nreg);
+      budget -= nreg;
+    }
+    int nreg = budget / (worker_warps / 4) / 8 * 8;
+    if (nreg < std::max(avg, 24) || nreg > 256)
+      return 0;
+    return nreg;
+  }
+
+  // Occupancy estimate from the scheduled resource usage: shared and
+  // tensor memory.
+  int EstimateBlocksPerSM(int num_threads) const {
+    if (annotated_min_blocks_ > 0)
+      return annotated_min_blocks_;
+    int64_t smem_bytes = 0;
+    int64_t tmem_bytes = 0;
+    for (const Buffer &buf : alloc_buffers_) {
+      if (!IsPipelineBuffer(buf))
+        continue;
+      int64_t bytes = (buf->dtype.bits() * buf->dtype.lanes() + 7) / 8;
+      for (const PrimExpr &extent : buf->shape) {
+        const auto *imm = extent.as<IntImmNode>();
+        if (imm == nullptr)
+          return 1;
+        bytes *= imm->value;
+      }
+      int64_t versions = 1;
+      for (const Pipeline &pipeline : pipelines_)
+        if (pipeline.allocation.same_as(buf))
+          versions = std::max<int64_t>(versions, pipeline.depth);
+      if (IsSharedBuffer(buf))
+        smem_bytes += bytes * versions;
+      else
+        tmem_bytes += bytes * versions;
+    }
+    int64_t blocks = std::min<int64_t>(kHeuristicBlocksPerSM,
+                                       kMaxThreadsPerSM / num_threads);
+    if (smem_bytes > 0)
+      blocks = std::min<int64_t>(blocks, kSmemBytesPerSM / smem_bytes);
+    if (tmem_bytes > 0)
+      blocks = std::min<int64_t>(blocks, kTmemBytesPerSM / tmem_bytes);
+    return std::max<int64_t>(1, blocks);
+  }
+
+  // Plan the active roles in warp order: worker low, one warp per
+  // auxiliary role, a cp.async Load widened to a full warpgroup.
+  std::vector<RolePlan> PlanRoles(RoleMask active) const {
+    int worker_warps = worker_threads_ / 32;
+    std::vector<RolePlan> plans;
+    int cursor = active.Contains(Role::kWorker) ? worker_warps : 0;
+    for (Role role : kAllRoles) {
+      if (!active.Contains(role))
+        continue;
+      if (role == Role::kWorker) {
+        plans.push_back({role, 0, worker_warps, 0});
+        continue;
+      }
+      bool wide = role == Role::kLoad && HasCpAsyncLoad();
+      plans.push_back(
+          {role, cursor, cursor + (wide ? 4 : 1),
+           wide ? kCpAsyncLoadNumRegisters : kAuxiliaryRoleNumRegisters});
+      cursor = plans.back().warp_hi;
+    }
+    int num_warps = (cursor + 3) / 4 * 4;
+    // Registers per thread at the occupancy target.
+    int num_threads = num_warps * 32;
+    int avg = 65536 / (EstimateBlocksPerSM(num_threads) * num_threads) / 8 * 8;
+    int worker_nreg = 0;
+    for (RolePlan &p : plans)
+      if (p.role == Role::kWorker)
+        p.nreg = worker_nreg = WorkerNreg(plans, num_warps, avg);
+    // Donations pay off only when the worker receives.
+    if (worker_nreg == 0)
+      for (RolePlan &p : plans)
+        p.nreg = 0;
+    return plans;
+  }
+
   Optional<WSSchedule> Emit() const {
     RoleMask active;
     for (const auto &op : ops_)
       active.Add(op->roles);
 
-    Array<WSRole> roles;
-    int worker_warps = worker_threads_ / 32;
-    int cursor = 0;
-    if (active.Contains(Role::kWorker)) {
-      roles.push_back(WSRole(RoleName(Role::kWorker), 0, worker_warps, 0));
-      cursor = worker_warps;
-    }
-    for (Role role : {Role::kLoad, Role::kMma, Role::kStore}) {
-      if (active.Contains(role)) {
-        roles.push_back(WSRole(RoleName(role), cursor, cursor + 1, 32));
-        ++cursor;
-      }
-    }
-    int num_warps = (cursor + 3) / 4 * 4;
+    std::vector<RolePlan> plans = PlanRoles(active);
+    int num_warps = 0;
+    for (const RolePlan &p : plans)
+      num_warps = std::max(num_warps, p.warp_hi);
+    num_warps = (num_warps + 3) / 4 * 4;
     int max_threads = static_cast<int>(
         target_->GetAttr<Integer>("max_num_threads").value_or(1024)->value);
     if (num_warps * 32 > max_threads) {
@@ -1033,6 +1166,10 @@ private:
                    << "-thread block limit";
       return std::nullopt;
     }
+
+    Array<WSRole> roles;
+    for (const RolePlan &p : plans)
+      roles.push_back(WSRole(RoleName(p.role), p.warp_lo, p.warp_hi, p.nreg));
 
     Array<WSPipeline> ws_pipelines;
     for (const Pipeline &pipeline : pipelines_) {
@@ -1100,6 +1237,8 @@ private:
 
   Target target_;
   int worker_threads_;
+  int annotated_min_blocks_ = 0;
+  Array<Buffer> alloc_buffers_;
   BufferLayoutMap layout_map_;
   std::vector<std::unique_ptr<SchedOp>> ops_;
   std::vector<std::unique_ptr<SchedScope>> scopes_; // [0] is the root

--- a/src/cuda/transform/auto_schedule/role_based_scheduler.cc
+++ b/src/cuda/transform/auto_schedule/role_based_scheduler.cc
@@ -461,14 +461,15 @@ private:
 
   // ---- classification -------------------------------------------------------
 
-  // A TMA-classified copy is a Load only when its destination's annotated
-  // layout (if any) is TMA-expressible; otherwise lowering falls back to
-  // a normal copy.
-  bool TmaDstLayoutCompatible(const SchedOp &op) const {
+  // A TMA-classified copy joins its one-warp role only when its shared
+  // side's annotated layout (if any) is TMA-expressible; otherwise
+  // lowering falls back to a normal copy, which one warp would serialize.
+  bool TmaSharedLayoutCompatible(const SchedOp &op, bool store) const {
     const auto *copy = op.tile_op.as<CopyNode>();
     if (copy == nullptr)
       return true; // Im2Col carries no annotated shared layout
-    auto it = layout_map_.find(copy->dst->data);
+    const Buffer &shared = store ? copy->src : copy->dst;
+    auto it = layout_map_.find(shared->data);
     if (it == layout_map_.end())
       return true;
     const auto &[buffer, layout] = it->second;
@@ -480,8 +481,22 @@ private:
       SchedOp &op = *op_ptr;
       switch (op.kind) {
       case TileStmtKind::kTmaProducer:
-        op.roles = RoleMask::Of(TmaDstLayoutCompatible(op) ? Role::kLoad
-                                                           : Role::kWorker);
+        // TODO: support warp specialization for cluster kernels — the
+        // materialized barriers are CTA-local, so cluster-wide multicast
+        // backpressure cannot be expressed yet.
+        if (const auto *copy = op.tile_op.as<CopyNode>()) {
+          if (auto mask = copy->annotations.Get("cluster_mask")) {
+            if (const auto *imm = mask.value().as<IntImmNode>();
+                imm == nullptr || imm->value != 0) {
+              LOG(WARNING) << "AutoSchedule skipped: op '" << op.id
+                           << "' is a cluster multicast copy";
+              return false;
+            }
+          }
+        }
+        op.roles = RoleMask::Of(TmaSharedLayoutCompatible(op, /*store=*/false)
+                                    ? Role::kLoad
+                                    : Role::kWorker);
         continue;
       case TileStmtKind::kCpAsyncProducer:
         // The pipeline commit arrives through a deferred
@@ -500,7 +515,9 @@ private:
         op.roles = RoleMask::Of(Role::kWorker);
         continue;
       case TileStmtKind::kTmaStore:
-        op.roles = RoleMask::Of(Role::kStore);
+        op.roles = RoleMask::Of(TmaSharedLayoutCompatible(op, /*store=*/true)
+                                    ? Role::kStore
+                                    : Role::kWorker);
         continue;
       case TileStmtKind::kTcgen05Mma:
         op.roles = RoleMask::Of(Role::kMma);

--- a/src/cuda/transform/auto_schedule/role_based_scheduler.cc
+++ b/src/cuda/transform/auto_schedule/role_based_scheduler.cc
@@ -1,0 +1,1105 @@
+/*!
+ * \file role_based_scheduler.cc
+ * \brief The "role_based" automatic warp-specialization scheduler.
+ *
+ * Four steps:
+ *  1. Classify: each op gets a fixed role from its lowering eligibility
+ *     (ws_analysis.h) — Load (TMA / cp.async global->shared copy), MMA
+ *     (tcgen05 GEMM), Store (shared->global TMA copy), Worker (the
+ *     rest). Ops touching only warp-private state start roleless.
+ *  2. Place: a role's body is the backward slice of its fixed ops — the
+ *     defs of every scalar and private-buffer read, plus the bounds and
+ *     guards of every entered scope. Slices may overlap (the
+ *     materializer SSA-freshens shared private chains per role); a slice
+ *     reaching an op fixed to another role declines. Roleless ops in no
+ *     slice run in every active role.
+ *  3. Pipelines: synchronization is ownership movement. Each touch owns
+ *     a storage from an initial to a final role. Bottom-up, a scope
+ *     hosts a pipeline iff consecutive touches mismatch (fin != next
+ *     init, wrapping to the first touch); an unbroken chain passes
+ *     upward as one opaque touch. Program order names the producer (the
+ *     first in-body transfer is its handoff), transfers alternate
+ *     handoff/recycle, and the wrap recycle — consumer release at the
+ *     end of the body, producer acquire at its start — rides the
+ *     barrier's cyclic phases. Nested bindings multiply a storage's
+ *     versions; bindings below the outermost stay single-buffered.
+ *  4. Emit the typed WSSchedule; versioning, barriers, and arrive
+ *     counts are MaterializeWSSchedule's job.
+ *
+ * TODO: pipeline merging — one barrier pair for pipelines of one scope
+ * whose consumer-side brackets coincide, producer sides unioned per
+ * cycle (producer_consumer_ws's positional criterion; merging is then
+ * free by construction). Software-pipeline stage offsets (every sync is
+ * stage 0); if-else branches; sibling-pipeline chaining; multi-consumer
+ * fan-out; a multi-warp copy role; delayed wgmma waits (wg_wait != 0
+ * declines).
+ */
+
+#include "./role_based_scheduler.h"
+
+#include <tvm/runtime/logging.h>
+#include <tvm/tirx/stmt_functor.h>
+
+#include <algorithm>
+#include <array>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "./memory_detector.h"
+#include "cuda/target_utils.h"
+#include "cuda/transform/ws_analysis.h"
+#include "op/copy.h"
+#include "op/operator.h"
+#include "op/utils.h"
+#include "transform/common/constr_visitor.h"
+#include "transform/common/warp_specialize.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+using namespace ffi;
+
+namespace {
+
+// Fixed heuristic roles, in warp order.
+enum class Role : uint8_t { kWorker = 0, kLoad = 1, kMma = 2, kStore = 3 };
+constexpr int kNumRoles = 4;
+constexpr std::array<Role, kNumRoles> kAllRoles = {Role::kWorker, Role::kLoad,
+                                                   Role::kMma, Role::kStore};
+
+// A SET of roles: an op is replicated into several roles when roleless,
+// and a scope's participants span its ops' roles. Single-role facts use
+// `Role` directly.
+struct RoleMask {
+  uint8_t bits{0};
+
+  static constexpr RoleMask Of(Role role) {
+    return {static_cast<uint8_t>(1u << static_cast<unsigned>(role))};
+  }
+  bool Empty() const { return bits == 0; }
+  int Count() const { return __builtin_popcount(bits); }
+  bool Contains(Role role) const { return bits & Of(role).bits; }
+  bool ContainsAll(RoleMask other) const { return !(other.bits & ~bits); }
+  void Add(Role role) { bits |= Of(role).bits; }
+  void Add(RoleMask other) { bits |= other.bits; }
+  // The single role of a one-role set.
+  Role TheRole() const {
+    ICHECK_EQ(Count(), 1);
+    return static_cast<Role>(__builtin_ctz(bits));
+  }
+  bool operator==(const RoleMask &other) const { return bits == other.bits; }
+};
+
+const char *RoleName(Role role) {
+  switch (role) {
+  case Role::kWorker:
+    return "Worker";
+  case Role::kLoad:
+    return "Load";
+  case Role::kMma:
+    return "MMA";
+  case Role::kStore:
+    return "Store";
+  }
+  LOG(FATAL) << "invalid role";
+  return "";
+}
+
+// Warp-private storage: values there cannot be handed between roles.
+bool IsPrivateBuffer(const Buffer &buffer) {
+  return IsLocalBuffer(buffer, true) || IsFragmentBuffer(buffer);
+}
+
+// Storage that may carry a cross-role handoff through a pipeline.
+bool IsPipelineBuffer(const Buffer &buffer) {
+  return IsSharedBuffer(buffer) || IsTmemBuffer(buffer);
+}
+
+// The pipeline depth a scope contributes: its loop's num_stages, else 1.
+int ScopeStages(const For &loop) {
+  if (!loop.defined())
+    return 1;
+  if (auto value = loop->annotations.Get("num_stages")) {
+    if (auto integer = value.value().try_cast<Integer>())
+      return std::max<int64_t>(1, integer.value()->value);
+    if (const auto *imm = value.value().as<IntImmNode>())
+      return std::max<int64_t>(1, imm->value);
+  }
+  return 1;
+}
+
+struct SchedScope;
+
+// The roles owning a storage when an entry begins and when it ends: a
+// leaf owns in its role throughout; a hosting scope receives as its
+// producer and surrenders as its consumer.
+struct Ownership {
+  Role initial;
+  Role final;
+};
+
+// One schedulable statement, reduced to the facts scheduling needs (the
+// statement stays in the kernel body, addressed by id). A scope IS an
+// op: one opaque entry at its parent's level, `roles` = participants,
+// `reads` = bound/guard reads.
+struct SchedOp {
+  String id;
+  TileStmtKind kind{TileStmtKind::kConsumer};
+  TileOperator tile_op;        // parsed once for a direct tile-op call
+  SchedScope *parent{nullptr}; // scope whose entries reference this
+  bool is_bind{false};  // scalar Bind: duplicable even when it reads globals
+  bool guarded{false};  // under an if: a skipped write carries state
+  bool roleless{false}; // touches only warp-private state
+  RoleMask roles;       // a fixed single role, or the grown set when roleless
+  std::vector<Buffer> reads, writes;      // buffer accesses, guards included
+  std::vector<Var> read_vars, write_vars; // scalar uses / Bind defs
+  // Ownership per resolved storage (nullopt = untouched): leaves seeded
+  // by BuildPipelines, scopes written by ResolveOwnership.
+  std::vector<std::optional<Ownership>> ownership;
+
+  virtual ~SchedOp() = default;
+  virtual SchedScope *AsScope() { return nullptr; }
+  const SchedScope *AsScope() const {
+    return const_cast<SchedOp *>(this)->AsScope();
+  }
+  bool PlacedIn(Role role) const { return roles.Contains(role); }
+};
+
+// The single placing role of an op touching shared storage.
+Role RoleOf(const SchedOp &op) { return op.roles.TheRole(); }
+
+struct SchedScope : SchedOp {
+  For loop;         // a sequential-loop (serial / unrolled) scope
+  While while_loop; // a T.ws_op-wrapped while scope; both undefined = root
+  std::vector<SchedOp *> entries; // ops and child scopes, in source order
+  // T.annotate_ws_pipeline_depth in this scope's body: buffer var -> depth.
+  std::unordered_map<Var, int64_t, ObjectPtrHash, ObjectPtrEqual>
+      pipeline_depth;
+
+  SchedScope *AsScope() override { return this; }
+
+  bool IsRoot() const { return parent == nullptr; }
+
+  // Whether this scope is `ancestor` or nested somewhere below it.
+  bool IsNestedIn(const SchedScope *ancestor) const {
+    for (const SchedScope *s = this; s != nullptr; s = s->parent)
+      if (s == ancestor)
+        return true;
+    return false;
+  }
+};
+
+std::string ScopeName(const SchedScope *scope) {
+  return scope->IsRoot() ? "root" : std::string(scope->id);
+}
+
+struct Pipeline {
+  String name;
+  Buffer allocation;
+  int depth{1};
+  Role producer{Role::kWorker};
+  Role consumer{Role::kWorker};
+  // The single scope hosting this pipeline's brackets, keyed by entry
+  // boundary (boundary b sits just before entry b). At a boundary,
+  // closes emit before opens, in push order.
+  const SchedScope *scope{nullptr};
+  std::map<int, std::vector<WSSyncKind>> closes, opens;
+};
+
+// Append the detector's results for `stmt` to the given vectors.
+void CollectAccess(const Stmt &stmt, std::vector<Buffer> *reads,
+                   std::vector<Buffer> *writes, std::vector<Var> *read_vars,
+                   std::vector<Var> *write_vars) {
+  MemoryAccessDetector detector;
+  detector.Analyze(stmt);
+  for (const BufferRegion &region : detector.GetReadRegions())
+    reads->push_back(region->buffer);
+  if (writes) {
+    for (const BufferRegion &region : detector.GetWriteRegions())
+      writes->push_back(region->buffer);
+  }
+  for (const Var &var : detector.GetReadVars())
+    read_vars->push_back(var);
+  if (write_vars) {
+    for (const Var &var : detector.GetWriteVars())
+      write_vars->push_back(var);
+  }
+}
+
+// Builds the op/scope structure from the normalized body. ConstrVisitor
+// maintains the lexical constraint stack, so an op's guards are the
+// conditions on the stack where it appears. Ops are leaves: recorded,
+// not recursed into.
+class StructureBuilder : public ConstrVisitor {
+public:
+  explicit StructureBuilder(Target target) : target_(std::move(target)) {}
+
+  std::vector<std::unique_ptr<SchedOp>> ops;
+  std::vector<std::unique_ptr<SchedScope>> scopes; // [0] is the root
+
+  bool Build(const Stmt &body) {
+    auto root = std::make_unique<SchedScope>();
+    root->id = kWSRootScopeId;
+    scope_stack_.push_back(root.get());
+    scopes.push_back(std::move(root));
+    VisitStmt(body);
+    return ok_;
+  }
+
+private:
+  // Conditions evaluated on every control path to the current statement;
+  // assumes are facts, not evaluated code.
+  void ChargeConditions(std::vector<Buffer> *reads,
+                        std::vector<Var> *read_vars) {
+    for (const Constr &constr : constr_stack_) {
+      if (constr.kind == Constr::kConstr && !constr.is_assume)
+        CollectAccess(Evaluate(constr.value), reads, nullptr, read_vars,
+                      nullptr);
+    }
+  }
+
+  void MakeOp(const String &id, const Stmt &stmt) {
+    ICHECK(op_ids_.insert(id).second)
+        << "two statements carry ws op id '" << id << "'";
+    auto op = std::make_unique<SchedOp>();
+    op->id = id;
+    op->parent = scope_stack_.back();
+    op->is_bind = stmt.as<BindNode>() != nullptr;
+    op->guarded = if_depth_ > 0;
+    if (const auto *eval = stmt.as<EvaluateNode>()) {
+      if (const auto *call = eval->value.as<CallNode>())
+        op->tile_op = ParseOperator(GetRef<Call>(call));
+    }
+    op->kind = ClassifyStmt(stmt, target_);
+    CollectAccess(stmt, &op->reads, &op->writes, &op->read_vars,
+                  &op->write_vars);
+    ChargeConditions(&op->reads, &op->read_vars);
+    scope_stack_.back()->entries.push_back(op.get());
+    ops.push_back(std::move(op));
+  }
+
+  SchedScope *OpenScope(const String &id) {
+    auto scope = std::make_unique<SchedScope>();
+    SchedScope *child = scope.get();
+    child->id = id;
+    child->parent = scope_stack_.back();
+    scope_stack_.back()->entries.push_back(child);
+    scopes.push_back(std::move(scope));
+    scope_stack_.push_back(child);
+    return child;
+  }
+
+  void VisitStmt_(const IfThenElseNode *op) final {
+    if (!ok_)
+      return;
+    if (op->else_case.defined()) {
+      LOG(WARNING)
+          << "AutoSchedule skipped: if-else branches are not supported";
+      ok_ = false;
+      return;
+    }
+    ++if_depth_;
+    ConstrVisitor::VisitStmt_(op); // guards the branch with its condition
+    --if_depth_;
+  }
+
+  void VisitStmt_(const ForNode *op) final {
+    if (!ok_)
+      return;
+    auto id = op->annotations.Get(kWSOpIdKey);
+    ICHECK(id.has_value()) << "AutoSchedule normalized loop is missing "
+                           << kWSOpIdKey;
+    // Sequential loops are scopes; parallel / vectorized loops are one op.
+    if (op->kind != ForKind::kSerial && op->kind != ForKind::kUnrolled) {
+      MakeOp(ExtractOpId(id.value()), GetRef<For>(op));
+      return;
+    }
+    SchedScope *child = OpenScope(ExtractOpId(id.value()));
+    child->loop = GetRef<For>(op);
+    CollectAccess(Evaluate(op->min), &child->reads, nullptr, &child->read_vars,
+                  nullptr);
+    CollectAccess(Evaluate(op->extent), &child->reads, nullptr,
+                  &child->read_vars, nullptr);
+    if (op->step.defined())
+      CollectAccess(Evaluate(op->step.value()), &child->reads, nullptr,
+                    &child->read_vars, nullptr);
+    ChargeConditions(&child->reads, &child->read_vars);
+    ConstrVisitor::VisitStmt_(op); // guards the body with the loop range
+    scope_stack_.pop_back();
+  }
+
+  void VisitStmt_(const AttrStmtNode *op) final {
+    if (!ok_)
+      return;
+    if (op->attr_key == kWSOpIdKey) {
+      // A wrapped while loop is a scope; any other wrapped statement is
+      // one opaque op.
+      if (const auto *wl = op->body.as<WhileNode>()) {
+        SchedScope *child = OpenScope(ExtractOpId(Any(op->value)));
+        child->while_loop = GetRef<While>(wl);
+        CollectAccess(Evaluate(wl->condition), &child->reads, nullptr,
+                      &child->read_vars, nullptr);
+        ChargeConditions(&child->reads, &child->read_vars);
+        ConstrVisitor::VisitStmt_(wl); // guards the body with the condition
+        scope_stack_.pop_back();
+        return;
+      }
+      MakeOp(ExtractOpId(Any(op->value)), op->body);
+      return;
+    }
+    if (op->attr_key == kWSPipelineDepthKey) {
+      auto gmap = op->node.as<Map<ObjectRef, ObjectRef>>();
+      ICHECK(gmap.has_value())
+          << "T.annotate_ws_pipeline_depth must carry a map";
+      for (const auto &[key, val] : gmap.value()) {
+        auto var = key.as<Var>();
+        const auto *depth = val.as<IntImmNode>();
+        ICHECK(var && depth && depth->value >= 1)
+            << "T.annotate_ws_pipeline_depth entries must map a buffer to a "
+               "positive depth";
+        scope_stack_.back()->pipeline_depth[var.value()] = depth->value;
+      }
+    }
+    // Assumptions enter the constraint stack; other wrappers (kernel
+    // metadata) are transparent.
+    ConstrVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const EvaluateNode *op) final {
+    if (!ok_)
+      return;
+    if (const auto *call = op->value.as<CallNode>()) {
+      if (auto id = call->annotations.Get(kWSOpIdKey)) {
+        MakeOp(ExtractOpId(Any(id.value())), GetRef<Stmt>(op));
+        return;
+      }
+    }
+    LOG(FATAL) << "AutoSchedule: Evaluate carries no ws op id";
+  }
+
+  // The normalizer wraps these statement forms with an id; reaching one
+  // bare is its bug.
+  void VisitStmt_(const BufferStoreNode *op) final {
+    LOG(FATAL) << "AutoSchedule: BufferStore carries no ws op id";
+  }
+  void VisitStmt_(const BindNode *op) final {
+    LOG(FATAL) << "AutoSchedule: Bind carries no ws op id";
+  }
+  void VisitStmt_(const WhileNode *op) final {
+    LOG(FATAL) << "AutoSchedule: while loop carries no ws op id";
+  }
+  void VisitStmt_(const SBlockNode *op) final {
+    LOG(FATAL) << "AutoSchedule: block carries no ws op id";
+  }
+
+  Target target_;
+  bool ok_ = true;   // cleared when the kernel shape is unsupported
+  int if_depth_ = 0; // enclosing IfThenElse frames
+  std::vector<SchedScope *> scope_stack_;
+  std::set<String> op_ids_;
+};
+
+// Plans the schedule for one normalized kernel body. Every unsupported
+// shape declines with a warning: auto scheduling is opt-in, so the user
+// expects it to fire.
+class RoleBasedScheduler {
+public:
+  RoleBasedScheduler(Target target, int worker_threads)
+      : target_(std::move(target)), worker_threads_(worker_threads) {}
+
+  Optional<WSSchedule> Run(const SBlock &block, const Stmt &body) {
+    if (!TargetHasBulkCopy(target_)) {
+      LOG(WARNING) << "AutoSchedule skipped: target has no bulk-copy (TMA) "
+                      "support";
+      return std::nullopt;
+    }
+    if (worker_threads_ % 128 != 0) {
+      LOG(WARNING) << "AutoSchedule skipped: worker threads must be a multiple "
+                      "of 128 so issuer warps start a fresh warpgroup";
+      return std::nullopt;
+    }
+    CollectAnnotatedLayouts(block, layout_map_);
+    if (!BuildStructure(body) || !ClassifyOps())
+      return std::nullopt;
+    IndexBufferUses();
+    if (!PlaceSlices())
+      return std::nullopt;
+    // A scope's roles are its participants.
+    for (const auto &op : ops_) {
+      for (SchedScope *s = op->parent; s != nullptr; s = s->parent)
+        s->roles.Add(op->roles);
+    }
+    if (!BuildPipelines(block))
+      return std::nullopt;
+    if (pipelines_.empty()) {
+      LOG(WARNING) << "AutoSchedule skipped: no cross-role on-chip handoff to "
+                      "pipeline";
+      return std::nullopt;
+    }
+    return Emit();
+  }
+
+private:
+  // ---- structure ------------------------------------------------------------
+
+  bool BuildStructure(const Stmt &body) {
+    StructureBuilder builder(target_);
+    if (!builder.Build(body))
+      return false;
+    ops_ = std::move(builder.ops);
+    scopes_ = std::move(builder.scopes);
+    root_ = scopes_.front().get();
+    return true;
+  }
+
+  // ---- classification -------------------------------------------------------
+
+  // A TMA-classified copy is a Load only when its destination's annotated
+  // layout (if any) is TMA-expressible; otherwise lowering falls back to
+  // a normal copy.
+  bool TmaDstLayoutCompatible(const SchedOp &op) const {
+    const auto *copy = op.tile_op.as<CopyNode>();
+    if (copy == nullptr)
+      return true; // Im2Col carries no annotated shared layout
+    auto it = layout_map_.find(copy->dst->data);
+    if (it == layout_map_.end())
+      return true;
+    const auto &[buffer, layout] = it->second;
+    return layout.defined() && IsTmaCompatibleLayout(layout, buffer);
+  }
+
+  bool ClassifyOps() {
+    for (const auto &op_ptr : ops_) {
+      SchedOp &op = *op_ptr;
+      switch (op.kind) {
+      case TileStmtKind::kTmaProducer:
+        op.roles = RoleMask::Of(TmaDstLayoutCompatible(op) ? Role::kLoad
+                                                           : Role::kWorker);
+        continue;
+      case TileStmtKind::kCpAsyncProducer:
+        // The pipeline commit arrives through a deferred
+        // cp.async.mbarrier.arrive.
+        op.roles = RoleMask::Of(Role::kLoad);
+        continue;
+      case TileStmtKind::kCpAsyncRaw:
+        // Raw cp.async carries its own thread-local completion protocol.
+        LOG(WARNING) << "AutoSchedule skipped: op '" << op.id
+                     << "': raw cp.async statements carry their own "
+                        "thread-local completion protocol";
+        return false;
+      case TileStmtKind::kSimtProducer:
+        // Register-staged and blocking; a one-warp Load role would
+        // serialize it. TODO: multi-warp copy role.
+        op.roles = RoleMask::Of(Role::kWorker);
+        continue;
+      case TileStmtKind::kTmaStore:
+        op.roles = RoleMask::Of(Role::kStore);
+        continue;
+      case TileStmtKind::kTcgen05Mma:
+        op.roles = RoleMask::Of(Role::kMma);
+        continue;
+      case TileStmtKind::kConsumer:
+        break;
+      }
+
+      if (op.tile_op.defined()) {
+        // wg_wait != 0 returns with MMAs still reading the operands; a
+        // release right after the gemm would race with them.
+        if (auto gemm = GetGemmInfo(op.tile_op)) {
+          if (gemm->wg_wait != 0) {
+            LOG(WARNING) << "AutoSchedule skipped: op '" << op.id
+                         << "': gemm with wg_wait != 0 completes "
+                            "asynchronously; delayed wgmma waits are not "
+                            "supported yet";
+            return false;
+          }
+        }
+        op.roles =
+            RoleMask::Of(Role::kWorker); // any other tile op is SIMT work
+        continue;
+      }
+
+      // Compound or plain statement op (PreprocessIR enforced no hosted
+      // asynchronous tile op).
+      bool private_writes = true;
+      for (const Buffer &buffer : op.writes)
+        private_writes = private_writes && IsPrivateBuffer(buffer);
+      bool duplicable_reads = true;
+      for (const Buffer &buffer : op.reads) {
+        duplicable_reads =
+            duplicable_reads &&
+            (IsPrivateBuffer(buffer) || (op.is_bind && IsGlobalBuffer(buffer)));
+      }
+      if (private_writes && duplicable_reads)
+        op.roleless = true; // placed by demand propagation
+      else
+        op.roles = RoleMask::Of(Role::kWorker);
+    }
+    return true;
+  }
+
+  // ---- role placement: backward slices --------------------------------------
+
+  // A role's body is the backward slice of its fixed ops: the reaching
+  // definition of each scalar read, every writer of each private-buffer
+  // read, and — once a slice enters a scope — the reads of that scope's
+  // bounds and guards.
+  bool PlaceSlices() {
+    std::unordered_map<Var, SchedOp *, ObjectPtrHash, ObjectPtrEqual> bind_def;
+    for (const auto &op : ops_) {
+      for (const Var &var : op->write_vars)
+        bind_def.emplace(var, op.get());
+    }
+
+    auto slice = [&](Role role, const std::vector<SchedOp *> &seeds) {
+      std::vector<SchedOp *> queue;
+      for (SchedOp *op : seeds) {
+        op->roles.Add(role);
+        queue.push_back(op);
+      }
+      auto enqueue = [&](SchedOp *def, const String &user) {
+        if (def->roles.Contains(role))
+          return true;
+        if (!def->roleless) {
+          LOG(WARNING) << "AutoSchedule skipped: '" << user << "' needs op '"
+                       << def->id << "' in role " << RoleName(role)
+                       << ", but that op is fixed to role "
+                       << RoleName(RoleOf(*def));
+          return false;
+        }
+        def->roles.Add(role);
+        queue.push_back(def);
+        return true;
+      };
+      auto enqueue_reads = [&](const std::vector<Buffer> &reads,
+                               const std::vector<Var> &read_vars,
+                               const SchedOp *self, const String &user) {
+        for (const Var &var : read_vars) {
+          auto it = bind_def.find(var);
+          if (it != bind_def.end() && it->second != self &&
+              !enqueue(it->second, user))
+            return false;
+        }
+        for (const Buffer &buffer : reads) {
+          if (!IsPrivateBuffer(buffer))
+            continue;
+          auto it = buffer_uses_.find(buffer->data);
+          if (it == buffer_uses_.end())
+            continue;
+          for (SchedOp *writer : it->second.writers) {
+            if (writer != self && !enqueue(writer, user))
+              return false;
+          }
+        }
+        return true;
+      };
+      std::unordered_set<const SchedScope *> entered;
+      while (!queue.empty()) {
+        SchedOp *op = queue.back();
+        queue.pop_back();
+        // An entered scope implies every ancestor is entered; the root
+        // has no bounds to charge.
+        for (SchedScope *s = op->parent; s != nullptr && !entered.count(s);
+             s = s->parent) {
+          entered.insert(s);
+          if (!enqueue_reads(s->reads, s->read_vars, /*self=*/nullptr, s->id))
+            return false;
+        }
+        if (!enqueue_reads(op->reads, op->read_vars, op, op->id))
+          return false;
+      }
+      return true;
+    };
+
+    for (Role role : kAllRoles) {
+      std::vector<SchedOp *> seeds;
+      for (const auto &op : ops_) {
+        if (!op->roleless && op->roles == RoleMask::Of(role))
+          seeds.push_back(op.get());
+      }
+      if (!seeds.empty() && !slice(role, seeds))
+        return false;
+    }
+
+    // Private state in no slice runs in every active role.
+    RoleMask active;
+    for (const auto &op : ops_)
+      active.Add(op->roles);
+    if (active.Empty()) {
+      LOG(WARNING) << "AutoSchedule skipped: kernel has no schedulable work";
+      return false;
+    }
+    std::vector<SchedOp *> leftovers;
+    for (const auto &op : ops_) {
+      if (op->roles.Empty())
+        leftovers.push_back(op.get());
+    }
+    for (Role role : kAllRoles) {
+      if (leftovers.empty())
+        break;
+      if (active.Contains(role) && !slice(role, leftovers))
+        return false;
+    }
+    return true;
+  }
+
+  // ---- def-use index --------------------------------------------------------
+
+  // Program-ordered users of one buffer, indexed once; later phases query
+  // these lists instead of re-scanning the IR.
+  struct BufferUses {
+    std::vector<SchedOp *> touches; // readers and writers, program order
+    std::vector<SchedOp *> writers;
+    std::vector<SchedOp *> readers;
+  };
+
+  void IndexBufferUses() {
+    auto touch = [&](const Buffer &buffer, SchedOp *op) -> BufferUses & {
+      BufferUses &uses = buffer_uses_[buffer->data];
+      if (uses.touches.empty() || uses.touches.back() != op)
+        uses.touches.push_back(op);
+      return uses;
+    };
+    for (const auto &op : ops_) {
+      for (const Buffer &buffer : op->reads)
+        touch(buffer, op.get()).readers.push_back(op.get());
+      for (const Buffer &buffer : op->writes)
+        touch(buffer, op.get()).writers.push_back(op.get());
+    }
+  }
+
+  // ---- pipelines ------------------------------------------------------------
+
+  // Resolves one storage into pipelines, collected innermost first.
+  struct StorageResolution {
+    Buffer allocation;
+    std::vector<Pipeline> pipelines;
+    bool failed{false};
+  };
+
+  // Synchronization is ownership movement: a transfer is needed exactly
+  // where one touch's final owner differs from the next touch's initial
+  // owner, cyclically (wrap included). A scope with transfers hosts a
+  // pipeline; an unbroken chain passes upward as one opaque touch.
+  void ResolveOwnership(std::vector<StorageResolution> *resolutions,
+                        SchedScope &scope) const {
+    for (SchedOp *entry : scope.entries)
+      if (SchedScope *child = entry->AsScope())
+        ResolveOwnership(resolutions, *child);
+
+    for (size_t k = 0; k < resolutions->size(); ++k) {
+      StorageResolution &resolution = (*resolutions)[k];
+      if (resolution.failed)
+        continue;
+      // Positions of the entries touching this storage.
+      std::vector<int> pos;
+      for (int e = 0; e < static_cast<int>(scope.entries.size()); ++e)
+        if (scope.entries[e]->ownership[k].has_value())
+          pos.push_back(e);
+      if (pos.empty())
+        continue;
+      auto own = [&](int e) -> const Ownership & {
+        return *scope.entries[e]->ownership[k];
+      };
+      Ownership level{own(pos.front()).initial, own(pos.back()).final};
+      // A lone touch covers even the wraparound with its own handshake.
+      if (pos.size() == 1) {
+        scope.ownership[k] = level;
+        continue;
+      }
+      // A loop runs back-to-back: before the first touch the storage is
+      // owned by whoever ends the iteration, and it returns there after
+      // the last. Host iff ownership must move between consecutive
+      // touches, the wraparound included; an unbroken chain passes
+      // upward as one opaque touch.
+      size_t m = pos.size();
+      bool moves = false;
+      for (size_t i = 0; i < m; ++i)
+        moves = moves || own(pos[i]).final != own(pos[(i + 1) % m]).initial;
+      if (!moves) {
+        scope.ownership[k] = level;
+        continue;
+      }
+
+      // Production precedes consumption (the pattern of every schedule
+      // in examples/aws): the first ownership movement between touches
+      // is the producer's handoff. A body whose only movement is the
+      // wraparound recycles — whoever takes the storage back produces.
+      Role producer, consumer;
+      {
+        size_t i = 1;
+        while (i < m && own(pos[i - 1]).final == own(pos[i]).initial)
+          ++i;
+        producer = i < m ? own(pos[i - 1]).final : own(pos.front()).initial;
+        consumer = i < m ? own(pos[i]).initial : own(pos.back()).final;
+      }
+      bool two_roles = true;
+      for (size_t i = 0; i < m; ++i) {
+        for (Role role : {own(pos[i]).initial, own(pos[i]).final})
+          two_roles = two_roles && (role == producer || role == consumer);
+      }
+      if (!two_roles) {
+        LOG(WARNING) << "AutoSchedule skipped: storage '"
+                     << resolution.allocation->name
+                     << "' is handed between more than two roles in scope '"
+                     << scope.id << "'";
+        resolution.failed = true;
+        continue;
+      }
+
+      Pipeline pipeline;
+      pipeline.allocation = resolution.allocation;
+      pipeline.scope = &scope;
+      pipeline.producer = producer;
+      pipeline.consumer = consumer;
+      // The wraparound transfer returns the storage to the producer. Its
+      // two halves are unconditional: the producer acquires at the first
+      // touch and the consumer releases after the last (parity-only when
+      // ownership does not move at the boundary — barrier elision TODO).
+      pipeline.opens[pos[0]].push_back(WSSyncKind::ProducerAcquire());
+
+      // Walk the touches with the owed transfer direction. A transfer
+      // between touches alternates the producer's handoff (commit/wait)
+      // with the recycle (release/acquire); a touch that surrenders
+      // ownership to the consumer internally completes an owed handoff —
+      // the producer commits right after it and the consumer waits at
+      // its next touch, or drains with a bare wait;release at the end.
+      bool ok = true;
+      bool handoff = true; // the producer's handoff is owed first
+      const char *reason = nullptr;
+      for (size_t i = 0; ok && i < m; ++i) {
+        const Ownership &o = own(pos[i]);
+        if (i > 0 && own(pos[i - 1]).final != o.initial) {
+          Role giver = handoff ? producer : consumer;
+          // A recycle mid-body must come from the consumer's own touch:
+          // an empty consumer span is only the end-of-body drain.
+          if (own(pos[i - 1]).final != giver ||
+              (!handoff && own(pos[i - 1]).initial != consumer)) {
+            reason = "ownership transfers do not alternate between one "
+                     "producer and one consumer";
+            ok = false;
+            break;
+          }
+          pipeline.closes[pos[i - 1] + 1].push_back(
+              handoff ? WSSyncKind::ProducerCommit()
+                      : WSSyncKind::ConsumerRelease());
+          pipeline.opens[pos[i]].push_back(handoff
+                                               ? WSSyncKind::ConsumerWait()
+                                               : WSSyncKind::ProducerAcquire());
+          handoff = !handoff;
+        }
+        if (o.initial == o.final) {
+          if (o.initial == consumer && handoff) {
+            reason = "the consumer touches the storage before the "
+                     "producer's handoff";
+            ok = false;
+          }
+          continue;
+        }
+        // A touch moving ownership is bracketed by the producer; inside
+        // the consumer's span it would leave its producer-side interior
+        // unheld.
+        if (!handoff) {
+          reason = "ownership moves inside the consumer's span";
+          ok = false;
+          break;
+        }
+        if (o.final == consumer) {
+          pipeline.closes[pos[i] + 1].push_back(WSSyncKind::ProducerCommit());
+          if (i + 1 < m)
+            pipeline.opens[pos[i + 1]].push_back(WSSyncKind::ConsumerWait());
+          else
+            pipeline.closes[pos[m - 1] + 1].push_back(
+                WSSyncKind::ConsumerWait());
+          handoff = false;
+        }
+      }
+      if (ok && handoff) {
+        // A trailing producer run would need its span to cross the
+        // wraparound (software-pipeline stages, unsupported).
+        reason = "the body ends in the producer's span";
+        ok = false;
+      }
+      if (!ok) {
+        LOG(WARNING) << "AutoSchedule skipped: storage '"
+                     << resolution.allocation->name << "' in scope '"
+                     << scope.id << "': " << reason;
+        resolution.failed = true;
+        continue;
+      }
+      pipeline.closes[pos[m - 1] + 1].push_back(WSSyncKind::ConsumerRelease());
+
+      scope.ownership[k] = level;
+      resolution.pipelines.push_back(std::move(pipeline));
+    }
+  }
+
+  // Depth of one binding. Multi-versioning is sound only when the
+  // storage carries no LOOP-CARRIED DEPENDENCY across the scope's
+  // iterations — each cycle must fully redefine the value. Conservative
+  // approximation: the consumer writing or the producer reading inside
+  // the scope may carry the previous cycle's value (TODO: a dependence
+  // analyzer, e.g. proving a clear_accum resets the recurrence; today
+  // T.annotate_ws_pipeline_depth asserts it). Accesses from OUTSIDE the
+  // scope do not pin: the materializer resolves them to the adjacent
+  // version (reads the last-completed, writes the next-produced).
+  bool FinalizePipeline(Pipeline *pipeline,
+                        const SchedScope *inner_scope) const {
+    bool loop_carried = false;
+    bool guarded_writer = false;
+    std::optional<int64_t> annotated;
+    if (auto vit =
+            pipeline->scope->pipeline_depth.find(pipeline->allocation->data);
+        vit != pipeline->scope->pipeline_depth.end())
+      annotated = vit->second;
+    const BufferUses &uses = buffer_uses_.at(pipeline->allocation->data);
+    for (const SchedOp *op : uses.writers) {
+      if (!op->parent->IsNestedIn(pipeline->scope)) {
+        // A skipped outside write would leave the adjacent slot stale.
+        guarded_writer = guarded_writer || op->guarded;
+        continue;
+      }
+      loop_carried = loop_carried || RoleOf(*op) == pipeline->consumer;
+      // A write inside a deeper binding's scope cycles that binding's
+      // slot; skipping it cannot skew this ring's versions.
+      if (!(inner_scope && op->parent->IsNestedIn(inner_scope)))
+        guarded_writer = guarded_writer || op->guarded;
+    }
+    for (const SchedOp *op : uses.readers) {
+      if (op->parent->IsNestedIn(pipeline->scope))
+        loop_carried = loop_carried || RoleOf(*op) == pipeline->producer;
+    }
+    if (annotated)
+      pipeline->depth = static_cast<int>(*annotated);
+    else if (!loop_carried)
+      pipeline->depth = ScopeStages(pipeline->scope->loop);
+    // Under versioning, a guard-skipped write would expose the slot from
+    // `depth` iterations ago instead of the previous value.
+    if (guarded_writer && pipeline->depth > 1) {
+      LOG(WARNING) << "AutoSchedule skipped: storage '" << pipeline->name
+                   << "' is written under a guard and would be "
+                   << pipeline->depth
+                   << "-way versioned; a skipped write would expose a "
+                      "stale version instead of the previous value";
+      return false;
+    }
+    return true;
+  }
+
+  // Name, nesting, and depth for one storage's pipelines (innermost
+  // first), then hand them to pipelines_.
+  bool FinalizeResolution(StorageResolution *resolution) {
+    // Sibling bindings of one storage (barrier chaining, a TODO) are the
+    // materializer's strictly-nested mandate to reject.
+    for (size_t i = 0; i < resolution->pipelines.size(); ++i) {
+      Pipeline &pipeline = resolution->pipelines[i];
+      // The innermost pipeline keeps the storage name; enclosing ones
+      // carry their scope's id.
+      std::string storage(resolution->allocation->name);
+      pipeline.name =
+          i == 0 ? storage : storage + "_" + ScopeName(pipeline.scope);
+      const SchedScope *inner_scope =
+          i == 0 ? nullptr : resolution->pipelines[i - 1].scope;
+      if (!FinalizePipeline(&pipeline, inner_scope))
+        return false;
+      pipelines_.push_back(std::move(pipeline));
+    }
+    return true;
+  }
+
+  bool BuildPipelines(const SBlock &block) {
+    // A global buffer written by one role must not be touched by another;
+    // globals have no cross-role synchronization mechanism.
+    for (const auto &writer : ops_) {
+      for (const Buffer &buffer : writer->writes) {
+        if (!IsGlobalBuffer(buffer))
+          continue;
+        RoleMask others;
+        for (const SchedOp *op : buffer_uses_[buffer->data].touches)
+          others.Add(op->roles);
+        if (!writer->roles.ContainsAll(others)) {
+          LOG(WARNING) << "AutoSchedule skipped: global buffer '"
+                       << buffer->name << "' is written by op '" << writer->id
+                       << "' and touched by another role";
+          return false;
+        }
+      }
+    }
+
+    std::vector<StorageResolution> resolutions;
+    for (const Buffer &allocation : block->alloc_buffers) {
+      if (!IsPipelineBuffer(allocation))
+        continue;
+      auto it = buffer_uses_.find(allocation->data);
+      if (it == buffer_uses_.end() || it->second.writers.empty())
+        continue; // never written by a scheduled op
+      RoleMask roles;
+      for (const SchedOp *op : it->second.touches) {
+        ICHECK_EQ(op->roles.Count(), 1)
+            << "op '" << op->id << "' touches shared storage '"
+            << allocation->name << "' but is placed by several roles";
+        roles.Add(op->roles);
+      }
+      if (roles.Count() < 2)
+        continue; // role-private storage needs no pipeline
+      StorageResolution resolution;
+      resolution.allocation = allocation;
+      resolutions.push_back(std::move(resolution));
+    }
+    if (resolutions.empty())
+      return true; // Run declines when nothing needs a pipeline
+
+    for (const auto &op : ops_)
+      op->ownership.assign(resolutions.size(), std::nullopt);
+    for (const auto &scope : scopes_)
+      scope->ownership.assign(resolutions.size(), std::nullopt);
+    for (size_t k = 0; k < resolutions.size(); ++k) {
+      const Buffer &allocation = resolutions[k].allocation;
+      for (SchedOp *op : buffer_uses_.at(allocation->data).touches) {
+        Role role = RoleOf(*op);
+        op->ownership[k] = Ownership{role, role};
+      }
+    }
+    ResolveOwnership(&resolutions, *root_);
+    for (StorageResolution &resolution : resolutions) {
+      if (resolution.failed)
+        return false;
+      // Two-role ownership must alternate at some scope, or the walk
+      // fails the resolution.
+      ICHECK(!resolution.pipelines.empty());
+      if (!FinalizeResolution(&resolution))
+        return false;
+    }
+    // Nested bindings' derived names may collide with real buffer names.
+    std::set<std::string> names;
+    for (Pipeline &pipeline : pipelines_) {
+      std::string base = pipeline.name;
+      for (int i = 2; !names.insert(pipeline.name).second; ++i)
+        pipeline.name = base + "_" + std::to_string(i);
+    }
+    return true;
+  }
+
+  // ---- emission -------------------------------------------------------------
+
+  Optional<WSSchedule> Emit() const {
+    RoleMask active;
+    for (const auto &op : ops_)
+      active.Add(op->roles);
+
+    Array<WSRole> roles;
+    int worker_warps = worker_threads_ / 32;
+    int cursor = 0;
+    if (active.Contains(Role::kWorker)) {
+      roles.push_back(WSRole(RoleName(Role::kWorker), 0, worker_warps, 0));
+      cursor = worker_warps;
+    }
+    for (Role role : {Role::kLoad, Role::kMma, Role::kStore}) {
+      if (active.Contains(role)) {
+        roles.push_back(WSRole(RoleName(role), cursor, cursor + 1, 32));
+        ++cursor;
+      }
+    }
+    int num_warps = (cursor + 3) / 4 * 4;
+    int max_threads = static_cast<int>(
+        target_->GetAttr<Integer>("max_num_threads").value_or(1024)->value);
+    if (num_warps * 32 > max_threads) {
+      LOG(WARNING) << "AutoSchedule skipped: " << num_warps
+                   << " warps exceed the target's " << max_threads
+                   << "-thread block limit";
+      return std::nullopt;
+    }
+
+    Array<WSPipeline> ws_pipelines;
+    for (const Pipeline &pipeline : pipelines_) {
+      ws_pipelines.push_back(WSPipeline(
+          pipeline.name, Array<Buffer>{pipeline.allocation}, pipeline.depth));
+    }
+
+    // Scopes, innermost first, root last.
+    Array<WSScope> scopes;
+    for (auto it = scopes_.rbegin(); it != scopes_.rend(); ++it)
+      scopes.push_back(EmitScope(**it, active));
+
+    return WSSchedule(num_warps, roles, ws_pipelines, scopes);
+  }
+
+  // A bracket belongs to the producer or the consumer by its kind.
+  static Role SyncRole(const Pipeline &pipeline, const WSSyncKind &kind) {
+    return kind.IsProducerAcquire() || kind.IsProducerCommit()
+               ? pipeline.producer
+               : pipeline.consumer;
+  }
+
+  WSScope EmitScope(const SchedScope &scope, RoleMask active) const {
+    int num_entries = static_cast<int>(scope.entries.size());
+    Map<String, Array<WSInstr>> bodies;
+    for (Role role : kAllRoles) {
+      if (!active.Contains(role))
+        continue;
+      std::vector<char> mine(num_entries, 0);
+      int count = 0;
+      for (int e = 0; e < num_entries; ++e) {
+        mine[e] = scope.entries[e]->PlacedIn(role);
+        count += mine[e];
+      }
+      if (count == 0)
+        continue;
+
+      // At every boundary: this role's closes, then its opens, then the
+      // entry itself when it is ours.
+      Array<WSInstr> body;
+      auto append = [&](int boundary, bool close) {
+        for (const Pipeline &pipeline : pipelines_) {
+          if (pipeline.scope != &scope)
+            continue;
+          const auto &at = close ? pipeline.closes : pipeline.opens;
+          auto it = at.find(boundary);
+          if (it == at.end())
+            continue;
+          for (const WSSyncKind &kind : it->second) {
+            if (SyncRole(pipeline, kind) == role)
+              body.push_back(WSSync(kind, pipeline.name, /*stage=*/0));
+          }
+        }
+      };
+      for (int b = 0; b <= num_entries; ++b) {
+        append(b, /*close=*/true);
+        append(b, /*close=*/false);
+        if (b < num_entries && mine[b])
+          body.push_back(WSOpRef(scope.entries[b]->id));
+      }
+      bodies.Set(RoleName(role), body);
+    }
+    return WSScope(scope.id, bodies);
+  }
+
+  Target target_;
+  int worker_threads_;
+  BufferLayoutMap layout_map_;
+  std::vector<std::unique_ptr<SchedOp>> ops_;
+  std::vector<std::unique_ptr<SchedScope>> scopes_; // [0] is the root
+  SchedScope *root_ = nullptr;
+  std::unordered_map<Var, BufferUses, ObjectPtrHash, ObjectPtrEqual>
+      buffer_uses_;
+  std::vector<Pipeline> pipelines_;
+};
+
+} // namespace
+
+ffi::Optional<WSSchedule> RoleBasedSchedule(const SBlock &block,
+                                            const Stmt &body,
+                                            int worker_threads,
+                                            const Target &target) {
+  return RoleBasedScheduler(target, worker_threads).Run(block, body);
+}
+
+} // namespace tl
+} // namespace tvm

--- a/src/cuda/transform/auto_schedule/role_based_scheduler.h
+++ b/src/cuda/transform/auto_schedule/role_based_scheduler.h
@@ -1,0 +1,22 @@
+/*!
+ * \file role_based_scheduler.h
+ * \brief The "role_based" automatic warp-specialization scheduler.
+ */
+#pragma once
+
+#include "./common.h"
+
+namespace tvm {
+namespace tl {
+
+// Fixed-role heuristic: classify ops by lowering eligibility (Load / MMA /
+// Store / Worker), pull warp-private def-use chains into their consumers'
+// roles, and pipeline every shared / tensor-memory storage handed across
+// roles. See role_based_scheduler.cc for the full model.
+ffi::Optional<WSSchedule> RoleBasedSchedule(const tirx::SBlock &block,
+                                            const tirx::Stmt &body,
+                                            int worker_threads,
+                                            const Target &target);
+
+} // namespace tl
+} // namespace tvm

--- a/src/cuda/transform/lower_shared_tmem.cc
+++ b/src/cuda/transform/lower_shared_tmem.cc
@@ -9,6 +9,7 @@
  */
 #include "cuda/op/builtin.h"
 #include "cuda/target_utils.h"
+#include "op/utils.h"
 #include "support/check.h"
 #include "tvm/ir/type.h"
 #include <algorithm>
@@ -619,7 +620,7 @@ private:
   Stmt VisitStmt_(const BufferStoreNode *op) final {
     auto store = Downcast<BufferStore>(StmtExprMutator::VisitStmt_(op));
     auto buffer = store->buffer;
-    ICHECK(buffer.scope() != "shared.tmem")
+    ICHECK(!IsTmemBuffer(buffer))
         << "We should never directly store data into tmem!";
     return store;
   }

--- a/src/cuda/transform/materialize_ws_schedule.cc
+++ b/src/cuda/transform/materialize_ws_schedule.cc
@@ -103,10 +103,6 @@ using namespace ffi;
 
 namespace {
 
-// Below this register budget a role donates registers (setmaxnreg.dec);
-// at or above it the role receives (setmaxnreg.inc).
-constexpr int kNregIncThreshold = 128;
-
 // ---------------------------------------------------------------------------
 // Small helpers
 // ---------------------------------------------------------------------------
@@ -167,7 +163,7 @@ struct RoleSpec {
   int nreg = 0;                 // 0 = absent
   int index = -1;               // position in the sorted role list
   int NumThreads() const { return (warp_hi - warp_lo) * 32; }
-  int NregAction() const { return nreg >= kNregIncThreshold ? 1 : 0; }
+  int NregAction(int avg_nreg) const { return nreg >= avg_nreg ? 1 : 0; }
 };
 
 // Identity-keyed maps on Buffer handles. Iteration order is hash order
@@ -512,7 +508,7 @@ public:
     BuildUseChains();
     PlanArriveCounts();
     VerifySchedule();
-    return RebuildBlock(EmitRoleBranches());
+    return RebuildBlock(MarkCustomWS(EmitRoleBranches()));
   }
 
 private:
@@ -605,13 +601,18 @@ private:
     }
     int donor = 0;
     for (const auto &r : roles_) {
-      if (r->nreg > 0 && r->NregAction() == 0)
+      if (r->nreg > 0)
         donor = donor == 0 ? r->nreg : std::min(donor, r->nreg);
     }
     for (int &v : warpgroup_nreg_) {
       if (v == -1)
         v = donor;
     }
+    // setmaxnreg keeps the block's register total constant
+    avg_nreg_ = 0;
+    for (int v : warpgroup_nreg_)
+      avg_nreg_ += v;
+    avg_nreg_ /= static_cast<int>(warpgroup_nreg_.size());
 
     // Pipelines.
     for (const WSPipeline &p : sched->pipelines) {
@@ -2602,10 +2603,10 @@ private:
 
     Array<Stmt> stmts;
     if (role.nreg > 0) {
-      stmts.push_back(
-          Evaluate(Call(DataType::Handle(), set_max_nreg(),
-                        {IntImm(DataType::Int(32), role.nreg),
-                         IntImm(DataType::Int(32), role.NregAction())})));
+      stmts.push_back(Evaluate(
+          Call(DataType::Handle(), set_max_nreg(),
+               {IntImm(DataType::Int(32), role.nreg),
+                IntImm(DataType::Int(32), role.NregAction(avg_nreg_))})));
     }
 
     // Runtime phase counters where linearization is unsound.
@@ -2643,7 +2644,7 @@ private:
     return Evaluate(
         Call(DataType::Handle(), set_max_nreg(),
              {IntImm(DataType::Int(32), nreg),
-              IntImm(DataType::Int(32), nreg >= kNregIncThreshold ? 1 : 0)}));
+              IntImm(DataType::Int(32), nreg >= avg_nreg_ ? 1 : 0)}));
   }
 
   // Emit the `if (tx < ...)` role branches ordered by warp range,
@@ -2665,8 +2666,6 @@ private:
     };
     int cursor = 0;
     for (const auto &role : roles_) {
-      ICHECK_GE(role->warp_lo, cursor)
-          << "ws_schedule: overlapping role warp ranges";
       fill_idle(cursor, role->warp_lo);
       conds.push_back(thread_var_ <
                       IntImm(DataType::Int(32), role->warp_hi * 32));
@@ -2678,6 +2677,14 @@ private:
     for (int i = static_cast<int>(branches.size()) - 2; i >= 0; --i)
       body = IfThenElse(conds[i], branches[i], std::move(body));
     return body;
+  }
+
+  // The roles carry their own setmaxnreg calls: mark the kernel as
+  // custom warp specialization so AnnotateWarpGroupRegAlloc stays out.
+  Stmt MarkCustomWS(Stmt body) const {
+    return AttrStmt(IntImm(DataType::Int(32), 0),
+                    attr::kCustomWarpSpecialization,
+                    IntImm(DataType::Int(32), 1), std::move(body));
   }
 
   // Rebuild the block: versioned buffers, barrier allocations with
@@ -2759,6 +2766,7 @@ private:
   Var thread_var_;
   Target target_;
   int num_warps_ = 0;
+  int avg_nreg_ = 0;
   std::vector<std::unique_ptr<RoleSpec>> roles_;
   std::vector<std::unique_ptr<PipelineSpec>> pipelines_;
   std::vector<std::shared_ptr<Scope>> scopes_;

--- a/src/cuda/transform/materialize_ws_schedule.cc
+++ b/src/cuda/transform/materialize_ws_schedule.cc
@@ -2737,8 +2737,12 @@ private:
           auto entry = layout_map.Get(orig->data);
           if (!entry.has_value())
             continue;
-          layout_map.Set(orig->data,
-                         entry.value()->Expand({versioned->shape[0]}));
+          // One leading dimension per binding.
+          Array<PrimExpr> prefix;
+          size_t n_bindings = buffer_pipeline_.at(orig->data).size();
+          for (size_t i = 0; i < n_bindings; ++i)
+            prefix.push_back(versioned->shape[i]);
+          layout_map.Set(orig->data, entry.value()->Expand(prefix));
           changed = true;
         }
         if (changed)

--- a/src/cuda/transform/materialize_ws_schedule.cc
+++ b/src/cuda/transform/materialize_ws_schedule.cc
@@ -3,66 +3,63 @@
  * \brief Materialize a user-provided warp-specialization schedule.
  *
  * The schedule — a T.WSSchedule annotation on the kernel's block (see
- * T.annotate_ws_schedule) — declares:
- *  - roles: named warp ranges, each with an optional register budget;
- *  - pipelines: one producer/consumer handshake each — a "full" and an
- *    "empty" mbarrier array protecting a set of buffers, which this
- *    pass replicates into `depth` versions;
- *  - scopes: the scheduled loops plus an implicit root. A scope gives
- *    each participating role a body: the ops, child scopes, and sync
- *    points that role executes per iteration.
- *
- * The pass rewrites the kernel into explicit form — role branches,
- * versioned buffers, mbarrier waits/arrives, TMA copies completing
- * through barriers, asynchronous tcgen05 MMAs — before
+ * T.annotate_ws_schedule) — declares roles (named warp ranges with
+ * register budgets), pipelines, and scopes (the scheduled loops plus an
+ * implicit root; each gives participating roles a per-iteration body of
+ * ops, child scopes, and sync points). The pass rewrites the kernel
+ * into explicit form — role branches, versioned buffers, mbarrier
+ * waits/arrives, asynchronous copies and MMAs — before
  * PipelinePlanning / LayoutInference / LowerTileOp, so downstream
  * passes see the same tile-op IR a hand-written kernel would produce.
  *
- * Ids. The schedulable op is one statement, named by a "tl.ws_op_id"
- * annotation on a tile op or loop, or a `with T.ws_op(id):` wrapper
- * for anything else (possibly several plain statements, which become
- * ONE opaque op). Scope loops are serial loops (the pass consumes
- * num_stages) or T.ws_op-wrapped while loops (phases under them use
- * runtime counters; the condition must be role-uniform). A T.unroll /
- * T.Parallel loop is one opaque op. Every statement must be placed by
- * the schedule — anything unplaced is a fatal error. Several roles may
- * place the same op only when it touches no pipeline buffers; each
- * role then runs its own copy.
+ * A pipeline is one producer/consumer handshake: a "full" and an
+ * "empty" mbarrier array protecting a set of buffers. It synchronizes
+ * exactly ONE scope, between exactly two roles. A buffer may be bound
+ * to several pipelines with strictly nested scopes; the analysis is
+ * hierarchical — at the enclosing level, the deeper binding's scope is
+ * one opaque use, synchronous by default (a tcgen05 watermark covers
+ * the role's own in-flight MMA issue), and inner synchronization never
+ * penetrates outward. Each level replicates the buffer by its own depth
+ * and hands ONE version down, so the buffer holds the PRODUCT of the
+ * depths, outer-major.
  *
- * Dependencies are computed, not declared: QueryAccess derives each
- * op's operands; an operand's def is the pipeline protecting its
- * buffer.
+ * Ids: a schedulable op is one statement, named by a "tl.ws_op_id"
+ * annotation or a `with T.ws_op(id):` wrapper. Scope loops are serial
+ * loops or wrapped while loops (runtime phase counters; role-uniform
+ * condition). Every statement must be placed; several roles may place
+ * an op only when it touches no pipeline buffers. Dependencies are
+ * computed, not declared (QueryAccess).
  *
- * Synchronization. producer_acquire / producer_commit and
- * consumer_wait / consumer_release bracket a role's work on a
- * pipeline. An op must run inside an open span of every pipeline
- * protecting one of its operands; its accesses are rebound to buffer
- * version (phase % depth). Sync entries carry a software-pipeline
- * stage: an entry at stage s runs (s - s_min) iterations behind,
- * emitted as unrolled prologue/epilogue steps around a steady-state
- * loop with no per-iteration boundary checks.
- *
- * Arrive counts derive from each signaling op's atom (see OpAtom and
- * BarrierSidePlan).
- *
- * Source `if`s around statements become per-op guards; sync entries
- * stay unconditional in every role. An `if` around a scope loop guards
- * the whole scope; its condition must be uniform across roles.
- *
+ * Synchronization: acquire/commit and wait/release bracket a role's
+ * work on a pipeline; an op runs inside an open span of the pipeline
+ * owning each access, and accesses rebind to version (phase % depth).
+ * Sync entries carry a software-pipeline stage: an entry at stage s
+ * runs (s - s_min) iterations behind, unrolled into prologue/epilogue
+ * steps around a boundary-check-free steady-state loop. Arrive counts
+ * derive from the signaling ops' atoms; an op inside several brackets
+ * signals each of them (a tcgen05 commit is a watermark on the role's
+ * in-order queue, so one MMA validly signals several sides). Source
+ * `if`s become per-op guards; sync entries stay unconditional; an `if`
+ * around a scope loop guards the whole scope, role-uniformly.
  * VerifySchedule rejects broken schedules at compile time: span
- * coverage, cycle balance, and deadlock freedom under the mbarrier
- * parity model.
+ * coverage, cycle balance, deadlock freedom under the mbarrier parity
+ * model.
  *
  * TODO: cluster launch control; data-dependent synchronization; 2-CTA
- * GEMM; epilogue sub-tiling; stage shifts on counter-tracked
- * pipelines; try_acquire/try_wait split sync entries; shared-barrier
- * pipeline groups; else branches around ops and scope loops.
+ * GEMM; epilogue sub-tiling; try_acquire/try_wait split sync entries;
+ * multi-signer barrier sides (FA4's merged S/P/O barrier) and, with
+ * them, pipelines sharing one storage (the P-in-S TMEM overlay); sync
+ * elision on the synchronization dependence graph (issue-order-
+ * dependent; elided empty sides need a lap-freedom proof; proxy fences
+ * must be re-placed); cross-scope software pipelining of an op INSIDE a
+ * child scope relative to its siblings; else branches; region-granular
+ * pipeline protection.
  */
 
-#include <tvm/arith/analyzer.h>
 #include <tvm/ffi/extra/structural_equal.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/target/target.h>
+#include <tvm/tirx/analysis.h>
 #include <tvm/tirx/buffer.h>
 #include <tvm/tirx/builtin.h>
 #include <tvm/tirx/op.h>
@@ -75,6 +72,7 @@
 #include <functional>
 #include <limits>
 #include <map>
+#include <memory>
 #include <optional>
 #include <set>
 #include <sstream>
@@ -90,8 +88,12 @@
 #include "op/copy.h"
 #include "op/gemm.h"
 #include "op/operator.h"
+#include "op/utils.h"
 #include "transform/common/mbarrier.h"
 #include "transform/common/warp_specialize.h"
+
+#include "./auto_schedule/memory_detector.h"
+#include "./ws_analysis.h"
 
 namespace tvm {
 namespace tl {
@@ -104,20 +106,6 @@ namespace {
 // Below this register budget a role donates registers (setmaxnreg.dec);
 // at or above it the role receives (setmaxnreg.inc).
 constexpr int kNregIncThreshold = 128;
-
-// Positions in the materializer's roles_ / pipelines_ / scopes_ vectors,
-// resolved once from schedule names at the parse boundary; -1 = none.
-// Quantities that are not indices (stages, depths, warp counts) stay int.
-using RoleIndex = int;
-using PipelineIndex = int;
-using ScopeIndex = int;
-
-// Identity-keyed maps on Buffer handles. Iteration order is hash order
-// and never observable: consumers renormalize into ordered containers.
-using BufferDefMap =
-    std::unordered_map<Buffer, PipelineIndex, ObjectPtrHash, ObjectPtrEqual>;
-using BufferVersionMap =
-    std::unordered_map<Buffer, Buffer, ObjectPtrHash, ObjectPtrEqual>;
 
 // ---------------------------------------------------------------------------
 // Small helpers
@@ -160,97 +148,58 @@ const Op &Tcgen05GemmOp() {
 }
 
 // ---------------------------------------------------------------------------
-// QueryAccess: the buffers a statement reads and writes — the pass's
-// dependency oracle. Tile ops report their own access regions;
-// granularity is the whole buffer. Plain loads and stores count
-// directly, except address-only root loads (region / access_ptr
-// arguments), which are not data reads.
+// The schedule object model. Everything a scope body contains derives
+// from BodyEntry; a Scope IS an Operation (at its parent's level it is
+// one opaque op). Polymorphic body entries are shared_ptr-owned (the
+// registries and every referencing body share them); the flat specs
+// (RoleSpec, PipelineSpec) are uniquely owned by the materializer and
+// referenced by plain pointer.
 // ---------------------------------------------------------------------------
-struct AccessSet {
-  // Operand buffer -> defining pipeline: the pipeline protecting the
-  // buffer, or -1 while unresolved / unprotected. QueryAccess records
-  // the operands; BuildUseChains resolves the defs.
-  BufferDefMap reads, writes;
+struct RoleSpec;
+struct PipelineSpec;
+struct Synchronization;
+struct Operation;
+struct Scope;
 
-  // The defs of all operands, unprotected operands excluded.
-  std::set<PipelineIndex> Defs() const {
-    std::set<PipelineIndex> defs;
-    for (const auto *operands : {&reads, &writes})
-      for (const auto &[buf, def] : *operands)
-        if (def >= 0)
-          defs.insert(def);
-    return defs;
-  }
-
-  bool HasDef(PipelineIndex pipeline_idx) const {
-    for (const auto *operands : {&reads, &writes})
-      for (const auto &[buf, def] : *operands)
-        if (def == pipeline_idx)
-          return true;
-    return false;
-  }
+struct RoleSpec {
+  String name;
+  int warp_lo = 0, warp_hi = 0; // [lo, hi) in warps
+  int nreg = 0;                 // 0 = absent
+  int index = -1;               // position in the sorted role list
+  int NumThreads() const { return (warp_hi - warp_lo) * 32; }
+  int NregAction() const { return nreg >= kNregIncThreshold ? 1 : 0; }
 };
 
-// Unions the statement's accesses into *acc. The owning tile op reports
-// a region argument's accesses; an access_ptr's rw mask says how the
-// intrinsic accesses its buffer.
-void QueryAccess(const Stmt &stmt, AccessSet *acc) {
-  std::unordered_set<BufferLoad, ObjectPtrHash, ObjectPtrEqual> address_roots;
-  PostOrderVisit(stmt, [&](const ObjectRef &node) {
-    const auto *call = node.as<CallNode>();
-    if (!call)
-      return;
-    if (call->op.same_as(region())) {
-      const auto *load = call->args[0].as<BufferLoadNode>();
-      ICHECK(load) << "ws_schedule: region arg0 must be a BufferLoad";
-      address_roots.insert(GetRef<BufferLoad>(load));
-      return;
-    }
-    if (call->op.same_as(access_ptr())) {
-      // access_ptr(base_load, extent, rw_mask)
-      const auto *load = call->args[0].as<BufferLoadNode>();
-      ICHECK(load) << "ws_schedule: access_ptr arg0 must be a BufferLoad";
-      address_roots.insert(GetRef<BufferLoad>(load));
-      const auto *mask = call->args[2].as<IntImmNode>();
-      ICHECK(mask) << "ws_schedule: access_ptr rw mask must be constant:\n"
-                   << GetRef<Call>(call);
-      if (mask->value & 1)
-        acc->reads.emplace(load->buffer, -1);
-      if (mask->value & 2)
-        acc->writes.emplace(load->buffer, -1);
-      return;
-    }
-    TileOperator tile_op = ParseOperator(GetRef<Call>(call));
-    if (!tile_op.defined())
-      return; // a non-tile-op intrinsic (exp2, any_sync, ...)
-    AccessRegions access = tile_op->GetAccessRegions();
-    for (const BufferRegion &r : access.reads)
-      acc->reads.emplace(r->buffer, -1);
-    for (const BufferRegion &r : access.writes)
-      acc->writes.emplace(r->buffer, -1);
-  });
-  PostOrderVisit(stmt, [&](const ObjectRef &node) {
-    if (const auto *load = node.as<BufferLoadNode>()) {
-      if (!address_roots.count(GetRef<BufferLoad>(load)))
-        acc->reads.emplace(load->buffer, -1);
-    } else if (const auto *store = node.as<BufferStoreNode>()) {
-      acc->writes.emplace(store->buffer, -1);
-    }
-  });
-}
+// Identity-keyed maps on Buffer handles. Iteration order is hash order
+// and never observable: consumers renormalize into ordered containers.
+// BufferDefMap maps each buffer a schedulable op accesses to its defs:
+// the pipelines protecting the buffer, outermost scope first (resolved
+// by BuildUseChains; empty = unprotected).
+using BufferDefMap = std::unordered_map<Buffer, std::vector<PipelineSpec *>,
+                                        ObjectPtrHash, ObjectPtrEqual>;
+using BufferVersionMap =
+    std::unordered_map<Buffer, Buffer, ObjectPtrHash, ObjectPtrEqual>;
+using VarSet = std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual>;
+// Pipeline ownership is storage-keyed: T.view / T.reshape aliases that share
+// one data var join the same pipelines and physical versioning. The
+// bindings are sorted outermost scope first (a strictly nested chain).
+using StoragePipelineMap = std::unordered_map<Var, std::vector<PipelineSpec *>,
+                                              ObjectPtrHash, ObjectPtrEqual>;
+
+// Orders pipeline-keyed containers by declaration position, never by
+// address: generated kernels must be byte-identical across runs.
+struct PipelineOrder {
+  bool operator()(const PipelineSpec *a, const PipelineSpec *b) const;
+};
+using PipelineSet = std::set<const PipelineSpec *, PipelineOrder>;
 
 // ---------------------------------------------------------------------------
-// Op atoms: which asynchronous instruction (if any) an op lowers to.
-// Classified once and consumed by both arrive-count planning and call
-// conversion, so planner and emitter cannot disagree.
-//  - kSync: synchronous compute; arrives per thread.
-//  - kTmaCopy: bulk-async copy; the data rides the barrier's
-//    transaction count.
-//  - kTcgen05Gemm: one tcgen05.commit arrives once for all outstanding
-//    MMAs.
-//  - kCpAsyncCopy: a cp.async copy (T.async_copy or
-//    prefer_instruction="cp_async"); completion rides the commit
-//    entry's deferred per-thread cp.async.mbarrier.arrive.
+// Op atoms: the asynchronous instruction (if any) an op lowers to,
+// classified once so planner and emitter cannot disagree. kSync arrives
+// per thread; kTmaCopy rides the barrier's transaction count;
+// kTcgen05Gemm signals through tcgen05.commit (a watermark on the role's
+// in-order MMA queue); kCpAsyncCopy through a deferred per-thread
+// cp.async.mbarrier.arrive.
 // ---------------------------------------------------------------------------
 enum class OpAtom : uint8_t {
   kSync = 0,
@@ -259,87 +208,214 @@ enum class OpAtom : uint8_t {
   kCpAsyncCopy = 3,
 };
 
-// Classify one call with the same instruction-selection helpers the
-// lowering uses, so the atom matches what the op actually lowers to.
-OpAtom ClassifyCall(const Call &call, const Target &target) {
-  TileOperator tile_op = ParseOperator(call);
-  if (!tile_op.defined())
-    return OpAtom::kSync; // a non-tile-op intrinsic
-  if (const auto *copy = tile_op.as<CopyNode>()) {
-    cuda::CopyInstSelection sel =
-        cuda::ClassifyWarpSpecializedProducerCopy(*copy, target);
-    ICHECK(sel.supported)
-        << "ws_schedule: producer copy instruction selection failed: "
-        << sel.reason;
-    if (cuda::CopyInstIsTMA(sel.inst))
-      return OpAtom::kTmaCopy;
-    if (cuda::CopyInstIsCPAsync(sel.inst))
-      return OpAtom::kCpAsyncCopy;
-    return OpAtom::kSync;
-  }
-  if (const auto *gemm = tile_op.as<GemmNode>()) {
-    return gemm->cRegion_->buffer.scope() == "shared.tmem"
-               ? OpAtom::kTcgen05Gemm
-               : OpAtom::kSync;
-  }
-  return OpAtom::kSync;
+struct AccessSet {
+  // QueryAccess records the accesses; BuildUseChains resolves the defs.
+  BufferDefMap reads, writes;
+
+  // The defs of all accesses, unprotected buffers excluded.
+  PipelineSet Defs() const;
+};
+
+// Collects the statement's accesses with the same MemoryAccessDetector the
+// automatic scheduler uses, so both layers share one oracle. Pipeline
+// protection is whole-buffer.
+void QueryAccess(const Stmt &stmt, AccessSet *acc) {
+  MemoryAccessDetector detector;
+  detector.Analyze(stmt);
+  for (const BufferRegion &r : detector.GetReadRegions())
+    acc->reads.emplace(r->buffer, std::vector<PipelineSpec *>());
+  for (const BufferRegion &r : detector.GetWriteRegions())
+    acc->writes.emplace(r->buffer, std::vector<PipelineSpec *>());
+  // TODO: Add variable-induced dependencies
 }
 
-// ---------------------------------------------------------------------------
-// Parsed schedule structures
-// ---------------------------------------------------------------------------
-struct RoleSpec {
-  String name;
-  int warp_lo = 0, warp_hi = 0; // [lo, hi) in warps
-  int nreg = 0;                 // 0 = absent
-  int NumThreads() const { return (warp_hi - warp_lo) * 32; }
-  int NregAction() const { return nreg >= kNregIncThreshold ? 1 : 0; }
+// One entry of a scope body: a Synchronization, a leaf Operation, or a
+// child Scope (which is itself an Operation).
+struct BodyEntry {
+  virtual ~BodyEntry() = default;
+  virtual Synchronization *AsSync() { return nullptr; }
+  virtual Operation *AsOperation() { return nullptr; }
+  virtual Scope *AsScope() { return nullptr; }
+  const Synchronization *AsSync() const {
+    return const_cast<BodyEntry *>(this)->AsSync();
+  }
+  const Operation *AsOperation() const {
+    return const_cast<BodyEntry *>(this)->AsOperation();
+  }
+  const Scope *AsScope() const {
+    return const_cast<BodyEntry *>(this)->AsScope();
+  }
+};
+using BodyEntryPtr = std::shared_ptr<BodyEntry>;
+
+struct Synchronization : BodyEntry {
+  WSSyncKind kind; // set at parse time; never null afterwards
+  PipelineSpec *pipeline = nullptr;
+  int stage = 0;
+  Synchronization *AsSync() override { return this; }
 };
 
 // One schedulable op: declared by ParseSchedule, completed by
 // RecordOpStmt with the matched statement, filled in by later phases.
-struct OpInfo {
+struct Operation : BodyEntry {
   String id;
-  Stmt stmt;                     // the single matched original statement
-  Optional<PrimExpr> guard;      // original guard, if any
-  AccessSet access;              // operands (whole buffers) and their defs
-  OpAtom atom = OpAtom::kSync;   // classified once by BuildOpAtoms
-  PipelineIndex write_def = -1;  // the written operands' single def
-  std::set<RoleIndex> role_idxs; // the placing roles
-  ScopeIndex sched_scope = -1;   // scope whose body references this op
+  Stmt stmt;                   // the single matched original statement
+  Optional<PrimExpr> guard;    // original guard, if any
+  AccessSet access;            // buffer accesses and their defs
+  OpAtom atom = OpAtom::kSync; // classified once by BuildOpAtoms
+  // The written storage's binding at the op's level: the pipeline whose
+  // barrier carries the op's completion signal (a TMA copy's
+  // transaction). Always null for a Scope — a scope is never
+  // completion-wired.
+  const PipelineSpec *write_def = nullptr;
+  std::set<const RoleSpec *> roles; // the placing roles
+  Scope *sched_scope = nullptr;     // scope whose body references this
+  bool uses_async_proxy = false;    // touches buffers through the async proxy
+  bool fused_arrive = false;        // this copy carries its cycle's arrive
+
+  Operation *AsOperation() override { return this; }
+  virtual bool PlacedBy(const RoleSpec &role) const {
+    return roles.count(&role) != 0;
+  }
+  // The atom the role's arrive must match; a leaf op has one placing
+  // role, so its atom is role-independent.
+  virtual OpAtom AtomFor(const RoleSpec &role) const { return atom; }
+  // Whether anything below touches buffers through the async proxy.
+  virtual bool TouchesAsyncProxy() const { return uses_async_proxy; }
+};
+
+struct Scope : Operation {
+  For orig_loop; // undefined for the root scope (until matched, for others)
+  // Set when the scope is a T.ws_op-wrapped while loop: phases under it
+  // use runtime counters, and the condition must be role-uniform.
+  While orig_while;
+  // Per-role instruction sequence (by RoleSpec::index); empty when the
+  // role has no body here. The parent scope is Operation::sched_scope.
+  std::vector<std::vector<BodyEntryPtr>> bodies;
+
+  Scope *AsScope() override { return this; }
+
+  // The implicit root is the only scope without a loop.
+  bool IsRoot() const { return !orig_loop.defined() && !orig_while.defined(); }
+
+  const std::vector<BodyEntryPtr> &BodyOf(const RoleSpec &role) const {
+    return bodies[role.index];
+  }
+
+  // Whether this scope is `ancestor` or nested somewhere below it.
+  bool IsNestedIn(const Scope *ancestor) const {
+    for (const Scope *s = this; s != nullptr; s = s->sched_scope)
+      if (s == ancestor)
+        return true;
+    return false;
+  }
+
+  // The scope's nesting depth: the root is 0, each level below adds one.
+  int Depth() const {
+    int depth = 0;
+    for (const Scope *s = sched_scope; s != nullptr; s = s->sched_scope)
+      ++depth;
+    return depth;
+  }
+
+  // Whether cycles in this scope advance once per counted iteration of
+  // the enclosing for-loop nest, so a phase can be linearized over it:
+  // no while ancestor (no iteration expression), no guard on this scope
+  // or an ancestor (a skipped cycle would still advance the linear
+  // phase), and a rectangular nest (no bound reading an outer loop var).
+  bool HasLinearPhase() const {
+    std::vector<const Scope *> chain; // this -> root
+    for (const Scope *s = this; s != nullptr; s = s->sched_scope)
+      chain.push_back(s);
+    std::unordered_set<const VarNode *> outer;
+    for (auto it = chain.rbegin(); it != chain.rend(); ++it) {
+      const Scope *s = *it;
+      if (s->orig_while.defined() || s->guard.defined())
+        return false;
+      if (!s->orig_loop.defined())
+        continue; // the root
+      auto uses_outer = [&outer](const PrimExpr &e) {
+        return UsesVar(
+            e, [&outer](const VarNode *v) { return outer.count(v) != 0; });
+      };
+      if (uses_outer(s->orig_loop->min) || uses_outer(s->orig_loop->extent))
+        return false;
+      outer.insert(s->orig_loop->loop_var.get());
+    }
+    return true;
+  }
+
+  bool PlacedBy(const RoleSpec &role) const override {
+    return !bodies[role.index].empty();
+  }
+
+  // To its parent a scope is one opaque op; BuildOpAtoms folds its
+  // summary once: per role, the watermarkable work (tcgen05 commit /
+  // cp.async deferred arrive) possibly still in flight at exit — TMA
+  // transactions ride their issue's own barrier and leave no residue —
+  // and the async-proxy bit into the inherited uses_async_proxy.
+  // TODO: reject the unobservable corner — a doubly-bound storage whose
+  // inner binding is written by a TMA copy while a different role
+  // signals the outer side; nothing orders that arrive after the data
+  // lands.
+  struct Residue {
+    bool tcgen05 = false;
+    bool cp_async = false;
+  };
+  std::vector<Residue> role_residues;
+  OpAtom AtomFor(const RoleSpec &role) const override {
+    const Residue &r = role_residues[role.index];
+    return r.tcgen05    ? OpAtom::kTcgen05Gemm
+           : r.cp_async ? OpAtom::kCpAsyncCopy
+                        : OpAtom::kSync;
+  }
 };
 
 // Orders a pipeline's uses by op id: deterministic, one entry per op.
 struct OpIdLess {
-  bool operator()(const OpInfo *a, const OpInfo *b) const {
+  bool operator()(const Operation *a, const Operation *b) const {
     return a->id < b->id;
   }
 };
-using UseSet = std::set<const OpInfo *, OpIdLess>;
+using UseSet = std::set<const Operation *, OpIdLess>;
 
-// How one side (full or empty) of a pipeline's barrier pair is
-// signaled, derived from the atoms of the signaling role's uses:
-//   count = has_tcgen05_arrival
+// How one side of a pipeline's barrier pair is signaled, derived from
+// the signaling role's uses:
+//   count = has_tcgen05_arrival + fused_tma_arrive
 //         + (has_cpasync_arrival + has_thread_arrive) * role threads.
-// The deferred cp.async arrive orders only the thread's prior cp.async
-// ops (PTX memory model, Program Order - Async Operations), so it never
-// replaces the plain per-thread arrive of synchronous work.
+// The deferred cp.async arrive orders only prior cp.async ops, so it
+// never replaces the per-thread arrive of synchronous work.
+// Cross-proxy invariant (PTX 9.7.9.26.2): generic- and async-proxy
+// accesses to one location are unordered without a fence.proxy.async in
+// the synchronization chain, executed by the generic-access thread. A
+// role publishing generic WRITES to pipeline buffers therefore fences
+// before its arrive when the other side touches them through the async
+// proxy; per-thread InjectFenceProxy cannot see a cross-role handoff.
+// TMEM ordering is InjectTcgen05Fence's job.
 struct BarrierSidePlan {
   bool has_transaction = false;     // TMA transactions ride the tx-count
   bool has_tcgen05_arrival = false; // one tcgen05.commit covers all MMAs
   bool has_cpasync_arrival = false; // per-thread deferred cp.async arrive
   bool has_thread_arrive = false;   // per-thread arrive at the sync entry
-  RoleIndex signal_role_idx = -1;   // the signaling role
-  int64_t count = 0;                // resulting mbarrier.init arrival count
+  bool fused_tma_arrive = false;    // one elected arrive rides the last copy
+  bool needs_proxy_fence = false;   // generic writes published by the arrive
+  const RoleSpec *signal_role = nullptr; // the signaling role
+  int64_t count = 0;                     // resulting mbarrier.init count
 };
 
 struct PipelineSpec {
   String name;
   int depth = 1;
+  int index = -1; // declaration position; keys deterministic ordering
+  // The single scope whose bodies hold this pipeline's sync entries
+  // (resolved by ResolvePipelineScopes; a pipeline synchronizes exactly
+  // one scope).
+  Scope *sync_scope = nullptr;
   std::vector<Buffer> buffers; // original buffers
   Buffer full, empty;          // materialized barrier buffers
-  // Ops whose operands this pipeline protects: producers write them,
-  // consumers read them.
+  // Uses at THIS pipeline's level: leaf ops it owns (their innermost
+  // containing binding) plus the collapsed scopes of deeper bindings.
+  // Producers write the storage, consumers read it.
   UseSet producers, consumers;
   const UseSet &Uses(bool producer_side) const {
     return producer_side ? producers : consumers;
@@ -348,36 +424,73 @@ struct PipelineSpec {
   BarrierSidePlan full_plan, empty_plan;
 };
 
-struct SyncEntry {
-  WSSyncKind kind; // set at parse time; never null afterwards
-  PipelineIndex pipeline_idx = -1;
-  int stage = 0;
-};
+bool PipelineOrder::operator()(const PipelineSpec *a,
+                               const PipelineSpec *b) const {
+  return a->index < b->index;
+}
 
-struct BodyEntry {
-  enum Kind { kOp, kScope, kSync };
-  Kind kind = kOp;
-  String id; // op id or scope id
-  SyncEntry sync;
-};
+PipelineSet AccessSet::Defs() const {
+  PipelineSet defs;
+  for (const auto *side : {&reads, &writes})
+    for (const auto &[buf, buf_defs] : *side)
+      for (const PipelineSpec *def : buf_defs)
+        defs.insert(def);
+  return defs;
+}
 
-struct ScopeSpec {
-  String id;
-  For orig_loop; // undefined for the root scope (until matched, for others)
-  // Set when the scope is a T.ws_op-wrapped while loop: phases under it
-  // use runtime counters, and the condition must be role-uniform.
-  While orig_while;
-  // Source guard around the scope loop; must be role-uniform, so a
-  // false guard skips the scope's sync entries in all roles together.
-  Optional<PrimExpr> guard;
-  // The scope whose bodies reference this one (-1 for the root).
-  ScopeIndex parent = -1;
-  // Per-role instruction sequence; empty when the role has no body here.
-  std::vector<std::vector<BodyEntry>> bodies;
+// The innermost binding whose scope contains `scope` (null if none):
+// the pipeline that owns an access there. Enclosing bindings see the
+// access only through their level's collapsed scope.
+PipelineSpec *
+InnermostContainingBinding(const std::vector<PipelineSpec *> &bindings,
+                           const Scope *scope) {
+  PipelineSpec *found = nullptr;
+  if (scope == nullptr)
+    return found;
+  for (PipelineSpec *p : bindings) // outermost first
+    if (scope->IsNestedIn(p->sync_scope))
+      found = p;
+  return found;
+}
 
-  // The implicit root is the only scope without a loop.
-  bool IsRoot() const { return !orig_loop.defined() && !orig_while.defined(); }
-};
+// Classify one parsed tile op with the same instruction-selection helpers
+// the lowering uses, so the atom matches what the op actually lowers to.
+OpAtom ClassifyTileOp(const TileOperator &tile_op, const Target &target) {
+  if (!tile_op.defined())
+    return OpAtom::kSync; // a non-tile-op intrinsic
+  if (const auto *copy = tile_op.as<CopyNode>()) {
+    cuda::CopyInstSelection sel =
+        cuda::ClassifyWarpSpecializedCopy(*copy, target);
+    ICHECK(sel.supported) << "ws_schedule: copy instruction selection failed: "
+                          << sel.reason;
+    // Only TMA loads ride the pipeline barrier's transaction count; TMA
+    // stores complete through the commit-group machinery and stay kSync.
+    if (cuda::CopyInstIsTMALoad(sel.inst))
+      return OpAtom::kTmaCopy;
+    if (cuda::CopyInstIsCPAsync(sel.inst))
+      return OpAtom::kCpAsyncCopy;
+    return OpAtom::kSync;
+  }
+  if (const auto *gemm = tile_op.as<GemmNode>()) {
+    return IsTmemBuffer(gemm->cRegion_->buffer) ? OpAtom::kTcgen05Gemm
+                                                : OpAtom::kSync;
+  }
+  return OpAtom::kSync;
+}
+
+// Whether a tile op touches its buffers through the async proxy: TMA
+// copies, tcgen05 MMAs, and — conservatively — every gemm (wgmma reads
+// shared operands through the async proxy). TODO: exempt Ampere MMAs.
+bool UsesAsyncProxy(const Call &call, const Target &target) {
+  switch (ClassifyStmt(Evaluate(call), target)) {
+  case TileStmtKind::kTmaProducer:
+  case TileStmtKind::kTmaStore:
+  case TileStmtKind::kTcgen05Mma:
+    return true;
+  default:
+    return ParseOperator(call).as<GemmNode>() != nullptr;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // The materializer
@@ -392,10 +505,11 @@ public:
 
   SBlock Run() {
     ParseSchedule();
+    ResolvePipelineScopes();
     MatchKernel();
     PlanVersionedBuffers();
+    BuildOpAtoms(); // before BuildUseChains: scope atoms fold the leaf atoms
     BuildUseChains();
-    BuildOpAtoms();
     PlanArriveCounts();
     VerifySchedule();
     return RebuildBlock(EmitRoleBranches());
@@ -438,44 +552,50 @@ private:
 
     // Roles.
     for (const WSRole &r : sched->roles) {
-      RoleSpec role;
-      role.name = r->name;
-      role.warp_lo = static_cast<int>(r->warp_lo);
-      role.warp_hi = static_cast<int>(r->warp_hi);
-      role.nreg = static_cast<int>(r->max_nreg);
-      ICHECK_GE(role.warp_lo, 0) << "ws_schedule: role " << role.name
-                                 << " has a negative warp range start";
-      ICHECK_LT(role.warp_lo, role.warp_hi)
-          << "ws_schedule: role " << role.name << " has an empty warp range";
-      ICHECK_LE(role.warp_hi, num_warps_)
-          << "ws_schedule: role " << role.name << " exceeds num_warps";
+      auto role = std::make_unique<RoleSpec>();
+      role->name = r->name;
+      role->warp_lo = static_cast<int>(r->warp_lo);
+      role->warp_hi = static_cast<int>(r->warp_hi);
+      role->nreg = static_cast<int>(r->max_nreg);
+      ICHECK_GE(role->warp_lo, 0) << "ws_schedule: role " << role->name
+                                  << " has a negative warp range start";
+      ICHECK_LT(role->warp_lo, role->warp_hi)
+          << "ws_schedule: role " << role->name << " has an empty warp range";
+      ICHECK_LE(role->warp_hi, num_warps_)
+          << "ws_schedule: role " << role->name << " exceeds num_warps";
+      for (const auto &other : roles_)
+        ICHECK(other->name != role->name)
+            << "ws_schedule: duplicate role name '" << role->name << "'";
       roles_.push_back(std::move(role));
     }
     std::stable_sort(roles_.begin(), roles_.end(),
-                     [](const RoleSpec &a, const RoleSpec &b) {
-                       return a.warp_lo < b.warp_lo;
+                     [](const std::unique_ptr<RoleSpec> &a,
+                        const std::unique_ptr<RoleSpec> &b) {
+                       return a->warp_lo < b->warp_lo;
                      });
+    for (size_t i = 0; i < roles_.size(); ++i)
+      roles_[i]->index = static_cast<int>(i);
     for (size_t i = 1; i < roles_.size(); ++i) {
-      ICHECK_LE(roles_[i - 1].warp_hi, roles_[i].warp_lo)
-          << "ws_schedule: roles " << roles_[i - 1].name << " ["
-          << roles_[i - 1].warp_lo << ", " << roles_[i - 1].warp_hi << ") and "
-          << roles_[i].name << " [" << roles_[i].warp_lo << ", "
-          << roles_[i].warp_hi << ") have overlapping warp ranges";
+      ICHECK_LE(roles_[i - 1]->warp_hi, roles_[i]->warp_lo)
+          << "ws_schedule: roles " << roles_[i - 1]->name << " ["
+          << roles_[i - 1]->warp_lo << ", " << roles_[i - 1]->warp_hi
+          << ") and " << roles_[i]->name << " [" << roles_[i]->warp_lo << ", "
+          << roles_[i]->warp_hi << ") have overlapping warp ranges";
     }
 
     // setmaxnreg allocates per warpgroup: roles sharing one must agree
     // on max_nreg. Idle warps adopt their warpgroup's request; a fully
     // idle warpgroup donates down to the smallest donor budget.
     warpgroup_nreg_.assign(num_warps_ / 4, -1); // -1 = no covering role
-    for (const RoleSpec &r : roles_) {
-      for (int w = r.warp_lo; w < r.warp_hi; ++w) {
+    for (const auto &r : roles_) {
+      for (int w = r->warp_lo; w < r->warp_hi; ++w) {
         int &wg = warpgroup_nreg_[w / 4];
         if (wg == -1) {
-          wg = r.nreg;
+          wg = r->nreg;
         } else {
-          ICHECK_EQ(wg, r.nreg)
-              << "ws_schedule: role " << r.name << " requests max_nreg "
-              << r.nreg << " but another role of warpgroup " << w / 4
+          ICHECK_EQ(wg, r->nreg)
+              << "ws_schedule: role " << r->name << " requests max_nreg "
+              << r->nreg << " but another role of warpgroup " << w / 4
               << " (warps " << w / 4 * 4 << ".." << w / 4 * 4 + 3
               << ") requests " << wg << " (0 = none); setmaxnreg "
               << "allocates per warpgroup, so all four warps must "
@@ -484,9 +604,9 @@ private:
       }
     }
     int donor = 0;
-    for (const RoleSpec &r : roles_) {
-      if (r.nreg > 0 && r.NregAction() == 0)
-        donor = donor == 0 ? r.nreg : std::min(donor, r.nreg);
+    for (const auto &r : roles_) {
+      if (r->nreg > 0 && r->NregAction() == 0)
+        donor = donor == 0 ? r->nreg : std::min(donor, r->nreg);
     }
     for (int &v : warpgroup_nreg_) {
       if (v == -1)
@@ -495,132 +615,178 @@ private:
 
     // Pipelines.
     for (const WSPipeline &p : sched->pipelines) {
-      PipelineSpec pipeline;
-      pipeline.name = p->name;
-      pipeline.depth = static_cast<int>(p->depth);
-      ICHECK_GE(pipeline.depth, 1);
-      for (const tirx::Buffer &b : p->buffers)
-        pipeline.buffers.push_back(FindBlockBuffer(b));
+      ICHECK(FindPipeline(p->name) == nullptr)
+          << "ws_schedule: duplicate pipeline name '" << p->name << "'";
+      auto pipeline = std::make_unique<PipelineSpec>();
+      pipeline->name = p->name;
+      pipeline->depth = static_cast<int>(p->depth);
+      pipeline->index = static_cast<int>(pipelines_.size());
+      ICHECK_GE(pipeline->depth, 1);
+      for (const tirx::Buffer &b : p->buffers) {
+        Buffer buffer = FindBlockBuffer(b);
+        ICHECK(IsSharedBuffer(buffer) || IsTmemBuffer(buffer))
+            << "ws_schedule: pipeline '" << p->name << "' buffer '"
+            << buffer->name << "' must live in shared or tensor memory; "
+            << "each role has its own instance of private storage";
+        pipeline->buffers.push_back(std::move(buffer));
+      }
       pipelines_.push_back(std::move(pipeline));
     }
 
-    // Scopes.
+    // Scopes: create the shells first so body references resolve in
+    // any declaration order, then build the typed bodies.
     for (const WSScope &s : sched->scopes) {
-      ScopeSpec scope;
-      scope.id = s->id;
-      scope.bodies.resize(roles_.size());
-      for (const auto &[role_name, instrs] : s->bodies) {
-        RoleIndex role_idx = RoleIndexOf(role_name);
-        ICHECK_GE(role_idx, 0)
-            << "ws_schedule: scope " << scope.id
-            << " has a body for unknown role '" << role_name << "'";
-        std::vector<BodyEntry> entries;
-        for (const WSInstr &instr : instrs) {
-          BodyEntry entry;
-          if (const auto *op_ref = instr.as<WSOpRefNode>()) {
-            entry.kind = BodyEntry::kOp; // refined to kScope below
-            entry.id = op_ref->id;
-          } else if (const auto *sync = instr.as<WSSyncNode>()) {
-            entry.kind = BodyEntry::kSync;
-            entry.sync.kind = sync->kind;
-            entry.sync.stage = static_cast<int>(sync->stage);
-            entry.sync.pipeline_idx = PipelineIndexOf(sync->pipeline);
-            ICHECK_GE(entry.sync.pipeline_idx, 0)
-                << "ws_schedule: unknown pipeline '" << sync->pipeline
-                << "' in scope " << scope.id;
-          } else {
-            LOG(FATAL) << "ws_schedule: unknown instruction type "
-                       << instr->GetTypeKey();
-          }
-          entries.push_back(std::move(entry));
-        }
-        scope.bodies[role_idx] = std::move(entries);
-      }
+      ICHECK(FindScope(s->id) == nullptr)
+          << "ws_schedule: duplicate scope id '" << s->id << "'";
+      auto scope = std::make_shared<Scope>();
+      scope->id = s->id;
+      scope->bodies.resize(roles_.size());
       scopes_.push_back(std::move(scope));
     }
-
-    // Classify body entries as op or child-scope references and
-    // validate the reference graph: an op is placed in one scope, at
-    // most once per role; a child scope has one parent, is entered at
-    // most once per role, and is never the root.
-    std::set<std::pair<ScopeIndex, RoleIndex>> scope_refs;
+    // A body entry names a sync point, a child scope, or an op; ops are
+    // created at first reference. Validate the reference graph: an op is
+    // placed in one scope, at most once per role; a child scope has one
+    // parent, is entered at most once per role, and is never the root.
+    std::set<std::pair<const Scope *, int>> scope_refs;
     for (size_t si = 0; si < scopes_.size(); ++si) {
-      ScopeSpec &scope = scopes_[si];
-      for (size_t ri = 0; ri < scope.bodies.size(); ++ri) {
-        for (BodyEntry &e : scope.bodies[ri]) {
-          if (e.kind != BodyEntry::kOp)
-            continue;
-          ScopeIndex child_idx = ScopeIndexOf(e.id);
-          if (child_idx >= 0) {
-            e.kind = BodyEntry::kScope;
-            ICHECK(e.id != kWSRootScopeId)
-                << "ws_schedule: the root scope cannot be referenced from a "
-                   "scope body";
-            ScopeSpec &child = scopes_[child_idx];
-            if (child.parent < 0) {
-              child.parent = static_cast<ScopeIndex>(si);
-            } else {
-              ICHECK_EQ(child.parent, static_cast<ScopeIndex>(si))
-                  << "ws_schedule: scope '" << e.id
-                  << "' is referenced from multiple parent scopes ('"
-                  << scopes_[child.parent].id << "' and '" << scope.id << "')";
-            }
-            ICHECK(scope_refs.insert({child_idx, static_cast<RoleIndex>(ri)})
-                       .second)
-                << "ws_schedule: scope '" << e.id
-                << "' is referenced more than once by role " << roles_[ri].name
-                << "; each participating role enters a scope exactly once "
-                   "per parent iteration";
+      const std::shared_ptr<Scope> &scope = scopes_[si];
+      const WSScope &s = sched->scopes[si];
+      for (const auto &[role_name, instrs] : s->bodies) {
+        const std::unique_ptr<RoleSpec> *role_it = nullptr;
+        for (const auto &role : roles_)
+          if (role->name == role_name)
+            role_it = &role;
+        ICHECK(role_it != nullptr)
+            << "ws_schedule: scope " << scope->id
+            << " has a body for unknown role '" << role_name << "'";
+        const RoleSpec &role = **role_it;
+        std::vector<BodyEntryPtr> entries;
+        for (const WSInstr &instr : instrs) {
+          if (const auto *sync_node = instr.as<WSSyncNode>()) {
+            auto sync = std::make_shared<Synchronization>();
+            sync->kind = sync_node->kind;
+            sync->stage = static_cast<int>(sync_node->stage);
+            sync->pipeline = FindPipeline(sync_node->pipeline);
+            ICHECK(sync->pipeline != nullptr)
+                << "ws_schedule: unknown pipeline '" << sync_node->pipeline
+                << "' in scope " << scope->id;
+            entries.push_back(std::move(sync));
             continue;
           }
-          auto it = ops_.find(e.id);
+          const auto *op_ref = instr.as<WSOpRefNode>();
+          ICHECK(op_ref != nullptr) << "ws_schedule: unknown instruction type "
+                                    << instr->GetTypeKey();
+          if (std::shared_ptr<Scope> child = FindScope(op_ref->id)) {
+            ICHECK(child->id != kWSRootScopeId)
+                << "ws_schedule: the root scope cannot be referenced from a "
+                   "scope body";
+            if (child->sched_scope == nullptr) {
+              child->sched_scope = scope.get();
+            } else {
+              ICHECK_EQ(child->sched_scope, scope.get())
+                  << "ws_schedule: scope '" << child->id
+                  << "' is referenced from multiple parent scopes ('"
+                  << child->sched_scope->id << "' and '" << scope->id << "')";
+            }
+            ICHECK(scope_refs.insert({child.get(), role.index}).second)
+                << "ws_schedule: scope '" << child->id
+                << "' is referenced more than once by role " << role.name
+                << "; each participating role enters a scope exactly once "
+                   "per parent iteration";
+            entries.push_back(child);
+            continue;
+          }
+          std::shared_ptr<Operation> op;
+          auto it = ops_.find(op_ref->id);
           if (it == ops_.end()) {
-            OpInfo op;
-            op.id = e.id;
-            op.role_idxs.insert(static_cast<RoleIndex>(ri));
-            op.sched_scope = static_cast<ScopeIndex>(si);
-            ops_.emplace(e.id, std::move(op));
+            op = std::make_shared<Operation>();
+            op->id = op_ref->id;
+            op->sched_scope = scope.get();
+            ops_.emplace(op->id, op);
           } else {
-            ICHECK_EQ(it->second.sched_scope, static_cast<ScopeIndex>(si))
-                << "ws_schedule: op '" << e.id
+            op = it->second;
+            ICHECK_EQ(op->sched_scope, scope.get())
+                << "ws_schedule: op '" << op->id
                 << "' is scheduled in multiple scopes";
-            ICHECK(
-                it->second.role_idxs.insert(static_cast<RoleIndex>(ri)).second)
-                << "ws_schedule: op '" << e.id
-                << "' is referenced more than once in the body of scope '"
-                << scope.id << "' by role " << roles_[ri].name
-                << "; a role places an op at most once";
+          }
+          ICHECK(op->roles.insert(&role).second)
+              << "ws_schedule: op '" << op->id
+              << "' is referenced more than once in the body of scope '"
+              << scope->id << "' by role " << role.name
+              << "; a role places an op at most once";
+          entries.push_back(op);
+        }
+        scope->bodies[role.index] = std::move(entries);
+      }
+    }
+    // An unreferenced scope would silently drop its scheduled work; a
+    // body whose role never enters the scope would plan barriers that
+    // are never emitted.
+    for (const auto &scope : scopes_) {
+      if (scope->id == kWSRootScopeId) {
+        root_scope_ = scope.get();
+        continue;
+      }
+      ICHECK(scope->sched_scope != nullptr)
+          << "ws_schedule: scope '" << scope->id
+          << "' is never referenced from a parent scope body";
+      for (size_t r = 0; r < scope->bodies.size(); ++r) {
+        ICHECK(scope->bodies[r].empty() ||
+               scope_refs.count({scope.get(), static_cast<int>(r)}))
+            << "ws_schedule: scope '" << scope->id << "' has a body for role "
+            << roles_[r]->name
+            << ", but that role never enters it from the parent scope";
+      }
+    }
+    ICHECK(root_scope_ != nullptr) << "ws_schedule: missing root scope";
+  }
+
+  std::shared_ptr<Scope> FindScope(const String &id) const {
+    for (const auto &scope : scopes_)
+      if (scope->id == id)
+        return scope;
+    return nullptr;
+  }
+
+  PipelineSpec *FindPipeline(const String &name) const {
+    for (const auto &pipeline : pipelines_)
+      if (pipeline->name == name)
+        return pipeline.get();
+    return nullptr;
+  }
+
+  // Every pipeline synchronizes exactly one scope: resolve it from the
+  // sync entries and reject entries spread across scopes. Nesting of
+  // multi-bound buffers is validated in PlanVersionedBuffers, once the
+  // buffers are resolved.
+  void ResolvePipelineScopes() {
+    for (const auto &scope : scopes_) {
+      for (const std::vector<BodyEntryPtr> &body : scope->bodies) {
+        for (const BodyEntryPtr &entry : body) {
+          const Synchronization *sync = entry->AsSync();
+          if (sync == nullptr)
+            continue;
+          PipelineSpec &pipeline = *sync->pipeline;
+          if (pipeline.sync_scope == nullptr) {
+            pipeline.sync_scope = scope.get();
+          } else {
+            ICHECK_EQ(pipeline.sync_scope, scope.get())
+                << "ws_schedule: pipeline '" << pipeline.name
+                << "' has sync entries in scopes '" << pipeline.sync_scope->id
+                << "' and '" << scope->id
+                << "'; a pipeline synchronizes exactly one "
+                << "scope — protect the buffer with a second pipeline in the "
+                << "outer scope instead (nested pipelines multiply the "
+                << "buffer's versions)";
           }
         }
       }
     }
-    // An unreferenced scope would silently drop its scheduled work.
-    for (const ScopeSpec &scope : scopes_) {
-      ICHECK(scope.parent >= 0 || scope.id == kWSRootScopeId)
-          << "ws_schedule: scope '" << scope.id
-          << "' is never referenced from a parent scope body";
+    for (const auto &pipeline : pipelines_) {
+      ICHECK(pipeline->sync_scope != nullptr)
+          << "ws_schedule: pipeline '" << pipeline->name
+          << "' has no sync entries in any scope body";
     }
-  }
-
-  ScopeIndex ScopeIndexOf(const String &id) const {
-    for (size_t i = 0; i < scopes_.size(); ++i)
-      if (scopes_[i].id == id)
-        return static_cast<ScopeIndex>(i);
-    return -1;
-  }
-
-  RoleIndex RoleIndexOf(const String &name) const {
-    for (size_t i = 0; i < roles_.size(); ++i)
-      if (roles_[i].name == name)
-        return static_cast<RoleIndex>(i);
-    return -1;
-  }
-
-  PipelineIndex PipelineIndexOf(const String &name) const {
-    for (size_t i = 0; i < pipelines_.size(); ++i)
-      if (pipelines_[i].name == name)
-        return static_cast<PipelineIndex>(i);
-    return -1;
   }
 
   // ---- op matching --------------------------------------------------------
@@ -629,28 +795,30 @@ private:
   // every declared op and scope must match a statement, and (enforced in
   // MatchOp) every kernel statement must carry an id.
   void MatchKernel() {
-    ScopeIndex root = ScopeIndexOf(kWSRootScopeId);
-    ICHECK_GE(root, 0) << "ws_schedule: missing root scope";
-    MatchScopeBody(root, block_->body);
+    MatchScopeBody(root_scope_, block_->body);
     for (auto &[id, op] : ops_) {
-      ICHECK(op.stmt.defined())
+      ICHECK(op->stmt.defined())
           << "ws_schedule: op '" << id
           << "' is scheduled but no statement in the kernel carries this id";
-      QueryAccess(op.stmt, &op.access);
-      // Buffers read by the op's guard are operands too.
-      if (op.guard.defined())
-        QueryAccess(Evaluate(op.guard.value()), &op.access);
+      QueryAccess(op->stmt, &op->access);
+      // Buffers read by the op's guard are accesses too.
+      if (op->guard.defined())
+        QueryAccess(Evaluate(op->guard.value()), &op->access);
     }
-    for (const ScopeSpec &scope : scopes_) {
-      ICHECK(!scope.IsRoot() || scope.id == kWSRootScopeId)
-          << "ws_schedule: scope '" << scope.id
+    for (const auto &scope : scopes_) {
+      ICHECK(!scope->IsRoot() || scope->id == kWSRootScopeId)
+          << "ws_schedule: scope '" << scope->id
           << "' has no matching loop in the kernel";
+      // The scope's own access set: as its parent's use it is one big op
+      // over the loop statement (the hierarchical collapse).
+      if (!scope->IsRoot())
+        QueryAccess(scope->stmt, &scope->access);
     }
   }
 
-  void MatchScopeBody(ScopeIndex scope_idx, const Stmt &body) {
+  void MatchScopeBody(Scope *scope, const Stmt &body) {
     for (const Stmt &stmt : BodyStmts(body))
-      MatchOp(scope_idx, stmt, Optional<PrimExpr>());
+      MatchOp(scope, stmt, Optional<PrimExpr>());
   }
 
   // The statements of a body: a SeqStmt's list, or the single statement
@@ -662,30 +830,33 @@ private:
   }
 
   // A while scope has no extent: phases under it use runtime counters.
-  void RecordScopeWhileLoop(ScopeIndex scope_idx, const While &loop) {
-    ICHECK(scopes_[scope_idx].IsRoot())
-        << "ws_schedule: scope " << scopes_[scope_idx].id << " matched twice";
-    scopes_[scope_idx].orig_while = loop;
-    MatchScopeBody(scope_idx, loop->body);
+  void RecordScopeWhileLoop(Scope *scope, const While &loop) {
+    ICHECK(scope->IsRoot())
+        << "ws_schedule: scope " << scope->id << " matched twice";
+    scope->orig_while = loop;
+    scope->stmt = loop;
+    MatchScopeBody(scope, loop->body);
   }
 
-  void RecordScopeForLoop(ScopeIndex scope_idx, const For &loop) {
-    ICHECK(scopes_[scope_idx].IsRoot())
-        << "ws_schedule: scope " << scopes_[scope_idx].id << " matched twice";
-    // Any serial loop can be a scope (T.Pipelined is a serial loop with
-    // a num_stages annotation).
-    ICHECK(loop->kind == ForKind::kSerial)
-        << "ws_schedule: scope '" << scopes_[scope_idx].id
-        << "' must be a serial loop (T.Pipelined or T.serial); T.unroll / "
-           "T.Parallel loops are scheduled as single ops";
+  void RecordScopeForLoop(Scope *scope, const For &loop) {
+    ICHECK(scope->IsRoot())
+        << "ws_schedule: scope " << scope->id << " matched twice";
+    // Any sequential loop can be a scope (T.Pipelined is a serial loop
+    // with a num_stages annotation; a T.unroll scope keeps its unroll
+    // kind).
+    ICHECK(loop->kind == ForKind::kSerial || loop->kind == ForKind::kUnrolled)
+        << "ws_schedule: scope '" << scope->id
+        << "' must be a sequential loop (T.Pipelined, T.serial, or "
+           "T.unroll); T.Parallel loops are scheduled as single ops";
     // Phases count iterations as (loop_var - min); a non-unit step
     // would break them. TODO: divide by the step.
     ICHECK(loop->HasTrivialStep())
-        << "ws_schedule: scope '" << scopes_[scope_idx].id
+        << "ws_schedule: scope '" << scope->id
         << "' has a non-unit loop step; write the loop with unit step and "
            "scale the indices in the body instead";
-    scopes_[scope_idx].orig_loop = loop;
-    MatchScopeBody(scope_idx, loop->body);
+    scope->orig_loop = loop;
+    scope->stmt = loop;
+    MatchScopeBody(scope, loop->body);
   }
 
   // Consume the id marker as the statement is recorded, so the emitted
@@ -716,64 +887,67 @@ private:
     return stmt;
   }
 
-  void RecordOpStmt(ScopeIndex scope_idx, const String &id, const Stmt &stmt,
+  void RecordOpStmt(Scope *scope, const String &id, const Stmt &stmt,
                     const Optional<PrimExpr> &guard) {
     auto it = ops_.find(id);
     ICHECK(it != ops_.end()) << "ws_schedule: statement carries ws op id '"
                              << id << "' but the schedule never places it:\n"
                              << stmt;
-    OpInfo &op = it->second;
+    Operation &op = *it->second;
     ICHECK(!op.stmt.defined())
         << "ws_schedule: two statements carry ws op id '" << id
         << "'; every scheduled statement needs its own id";
-    ICHECK_EQ(scope_idx, op.sched_scope)
-        << "ws_schedule: op '" << id << "' lives in scope '"
-        << scopes_[scope_idx].id << "' of the kernel but is scheduled by "
-        << "scope '" << scopes_[op.sched_scope].id << "'";
+    ICHECK_EQ(scope, op.sched_scope)
+        << "ws_schedule: op '" << id << "' lives in scope '" << scope->id
+        << "' of the kernel but is scheduled by " << "scope '"
+        << op.sched_scope->id << "'";
     op.stmt = StripOpId(stmt);
     if (guard.defined())
       op.guard = guard;
   }
 
-  void MatchOp(ScopeIndex scope_idx, const Stmt &stmt,
-               Optional<PrimExpr> guard) {
-    ScopeSpec &scope = scopes_[scope_idx];
-
+  void MatchOp(Scope *scope, const Stmt &stmt, Optional<PrimExpr> guard) {
     // A `with T.ws_op(id):` wrapper. With a scope id it wraps a while
     // loop and opens that scope; otherwise the wrapped statements become
     // ONE opaque op. The wrapper is consumed here.
     if (const auto *attr = stmt.as<AttrStmtNode>()) {
       if (attr->attr_key == kWSOpIdKey) {
         String id = ExtractWSOpId(Any(attr->value));
-        ScopeIndex child = ScopeIndexOf(id);
-        if (child >= 0) {
+        if (std::shared_ptr<Scope> child = FindScope(id)) {
           const auto *wl = attr->body.as<WhileNode>();
           ICHECK(wl) << "ws_schedule: scope id '" << id << "' on a T.ws_op "
                      << "wrapper must wrap a while loop; serial loops carry "
                      << "the id in their own annotations";
-          ICHECK_EQ(scopes_[child].parent, scope_idx)
+          ICHECK_EQ(child->sched_scope, scope)
               << "ws_schedule: scope '" << id << "' lives in scope '"
-              << scope.id << "' of the kernel but is referenced from scope '"
-              << scopes_[scopes_[child].parent].id << "'";
+              << scope->id << "' of the kernel but is referenced from scope '"
+              << child->sched_scope->id << "'";
           if (guard.defined())
-            scopes_[child].guard = guard;
-          RecordScopeWhileLoop(child, GetRef<While>(wl));
+            child->guard = guard;
+          RecordScopeWhileLoop(child.get(), GetRef<While>(wl));
           return;
         }
-        RecordOpStmt(scope_idx, id, attr->body, guard);
+        RecordOpStmt(scope, id, attr->body, guard);
+        return;
+      }
+      // A T.annotate_ws_pipeline_depth wrapper: scheduler-only metadata;
+      // consume it and match the statements it wraps.
+      if (attr->attr_key == kWSPipelineDepthKey) {
+        for (const Stmt &sub : BodyStmts(attr->body))
+          MatchOp(scope, sub, guard);
         return;
       }
       // Kernel-level metadata (T.use_swizzle,
       // T.annotate_min_blocks_per_sm, ...) wraps the statements that
       // follow it. Record the wrapper, keep matching inside it, and
       // re-wrap the rebuilt kernel body (RebuildBlock).
-      ICHECK(scope.id == kWSRootScopeId && !guard.defined())
+      ICHECK(scope->id == kWSRootScopeId && !guard.defined())
           << "ws_schedule: AttrStmt '" << attr->attr_key
           << "' must be at the top level of the kernel:\n"
           << stmt;
       metadata_attrs_.push_back(GetRef<AttrStmt>(attr));
       for (const Stmt &sub : BodyStmts(attr->body))
-        MatchOp(scope_idx, sub, guard);
+        MatchOp(scope, sub, guard);
       return;
     }
 
@@ -782,18 +956,17 @@ private:
     if (const auto *loop = stmt.as<ForNode>()) {
       if (auto id_ann = loop->annotations.Get(kWSOpIdKey)) {
         String id = ExtractWSOpId(id_ann.value());
-        ScopeIndex child = ScopeIndexOf(id);
-        if (child >= 0) {
-          ICHECK_EQ(scopes_[child].parent, scope_idx)
+        if (std::shared_ptr<Scope> child = FindScope(id)) {
+          ICHECK_EQ(child->sched_scope, scope)
               << "ws_schedule: scope '" << id << "' lives in scope '"
-              << scope.id << "' of the kernel but is referenced from scope '"
-              << scopes_[scopes_[child].parent].id << "'";
+              << scope->id << "' of the kernel but is referenced from scope '"
+              << child->sched_scope->id << "'";
           if (guard.defined())
-            scopes_[child].guard = guard;
-          RecordScopeForLoop(child, GetRef<For>(loop));
+            child->guard = guard;
+          RecordScopeForLoop(child.get(), GetRef<For>(loop));
           return;
         }
-        RecordOpStmt(scope_idx, id, stmt, guard);
+        RecordOpStmt(scope, id, stmt, guard);
         return;
       }
     }
@@ -802,7 +975,7 @@ private:
     if (const auto *ev = stmt.as<EvaluateNode>()) {
       if (const auto *call = ev->value.as<CallNode>()) {
         if (auto id = call->annotations.Get(kWSOpIdKey)) {
-          RecordOpStmt(scope_idx, ExtractWSOpId(id.value()), stmt, guard);
+          RecordOpStmt(scope, ExtractWSOpId(id.value()), stmt, guard);
           return;
         }
       }
@@ -816,13 +989,13 @@ private:
       PrimExpr cond =
           guard.defined() ? (guard.value() && ite->condition) : ite->condition;
       for (const Stmt &sub : BodyStmts(ite->then_case))
-        MatchOp(scope_idx, sub, cond);
+        MatchOp(scope, sub, cond);
       return;
     }
 
     // Every statement of a scheduled kernel must be placed by the
     // schedule; nothing is silently dropped or replicated.
-    LOG(FATAL) << "ws_schedule: statement in scope '" << scope.id
+    LOG(FATAL) << "ws_schedule: statement in scope '" << scope->id
                << "' carries no ws op id; tile ops and loops take "
                   "annotations={\"tl.ws_op_id\": ...}, other statements "
                   "(a scalar Bind) are wrapped in T.ws_op(...):\n"
@@ -831,168 +1004,367 @@ private:
 
   // ---- planning -----------------------------------------------------------
 
-  void PlanVersionedBuffers() {
-    for (PipelineIndex i = 0; i < static_cast<PipelineIndex>(pipelines_.size());
-         ++i) {
-      PipelineSpec &pipeline = pipelines_[i];
-      for (const Buffer &buf : pipeline.buffers) {
-        ICHECK(!buffer_pipeline_.count(buf))
-            << "ws_schedule: buffer " << buf->name
-            << " belongs to multiple pipelines";
-        buffer_pipeline_[buf] = i;
-        if (pipeline.depth > 1) {
-          ObjectPtr<BufferNode> n = make_object<BufferNode>(*buf.get());
-          n->shape.insert(n->shape.begin(),
-                          IntImm(DataType::Int(32), pipeline.depth));
-          if (!n->strides.empty()) {
-            PrimExpr stride0 = n->strides[0] * n->shape[1];
-            n->strides.insert(n->strides.begin(), std::move(stride0));
-          }
-          versioned_[buf] = Buffer(std::move(n));
-        }
+  // Give one logical buffer (an allocation, or a view/reshape alias of it)
+  // its versioned counterpart with one leading dimension PER BINDING,
+  // outermost first — each level replicates the buffer by its own depth
+  // and hands one version down. Every binding gets its dimension, extent
+  // 1 included, so downstream never distinguishes versioned from
+  // unversioned. Views cover their whole allocation (T.view / T.reshape
+  // enforce equal sizes), so every alias shares the version strides.
+  void EnsureVersionedAlias(const Buffer &buf) {
+    if (versioned_.count(buf))
+      return;
+    const std::vector<PipelineSpec *> &bindings =
+        buffer_pipeline_.at(buf->data);
+    ObjectPtr<BufferNode> n = make_object<BufferNode>(*buf.get());
+    for (auto it = bindings.rbegin(); it != bindings.rend(); ++it) {
+      if (!n->strides.empty()) {
+        PrimExpr stride0 = n->strides[0] * n->shape[0];
+        n->strides.insert(n->strides.begin(), std::move(stride0));
       }
-      pipeline.full =
-          CreateMBarrierBuffer(pipeline.name + "_full", pipeline.depth);
-      pipeline.empty =
-          CreateMBarrierBuffer(pipeline.name + "_empty", pipeline.depth);
+      n->shape.insert(n->shape.begin(),
+                      IntImm(DataType::Int(32), (*it)->depth));
     }
+    versioned_[buf] = Buffer(std::move(n));
+  }
+
+  void PlanVersionedBuffers() {
+    for (const auto &pipeline : pipelines_) {
+      for (const Buffer &buf : pipeline->buffers)
+        buffer_pipeline_[buf->data].push_back(pipeline.get());
+      pipeline->full =
+          CreateMBarrierBuffer(pipeline->name + "_full", pipeline->depth);
+      pipeline->empty =
+          CreateMBarrierBuffer(pipeline->name + "_empty", pipeline->depth);
+    }
+    // A multi-bound storage's pipelines must form a strictly nested scope
+    // chain; sort them outermost first so version indices compose
+    // outer-major.
+    for (auto &[storage, bindings] : buffer_pipeline_) {
+      std::stable_sort(bindings.begin(), bindings.end(),
+                       [](const PipelineSpec *a, const PipelineSpec *b) {
+                         return a->sync_scope->Depth() < b->sync_scope->Depth();
+                       });
+      for (size_t i = 1; i < bindings.size(); ++i) {
+        const PipelineSpec &outer = *bindings[i - 1];
+        const PipelineSpec &inner = *bindings[i];
+        ICHECK(outer.sync_scope != inner.sync_scope &&
+               inner.sync_scope->IsNestedIn(outer.sync_scope))
+            << "ws_schedule: pipelines '" << outer.name << "' (scope '"
+            << outer.sync_scope->id << "') and '" << inner.name << "' (scope '"
+            << inner.sync_scope->id
+            << "') both protect one storage but their scopes are not "
+            << "strictly nested";
+      }
+    }
+    for (const auto &pipeline : pipelines_)
+      for (const Buffer &buf : pipeline->buffers)
+        EnsureVersionedAlias(buf);
   }
 
   // ---- def/use chains -------------------------------------------------------
 
-  // Resolve each operand's defining pipeline and build the pipelines'
-  // use sets. An op's written operands must all resolve to ONE pipeline
-  // (its completion signal can only trigger one); reads are
-  // unconstrained. An op placed by several roles must have NO
-  // pipeline-protected operands — duplicated accesses would race.
+  // Resolve one access set's defining pipelines from the storage map.
+  void ResolveAccessDefs(AccessSet *access) {
+    for (auto *side : {&access->writes, &access->reads}) {
+      for (auto &[buf, defs] : *side) {
+        auto it = buffer_pipeline_.find(buf->data);
+        if (it != buffer_pipeline_.end()) {
+          defs = it->second;
+          EnsureVersionedAlias(buf);
+        }
+      }
+    }
+  }
+
+  // Join the use sets of the innermost binding containing the
+  // operation's position — one rule for leaves and scopes alike (a
+  // scope's detector-summarized accesses make it the enclosing
+  // binding's opaque producer/consumer). An access with no containing
+  // binding is rejected by VerifySpanCoverage.
+  void RegisterUses(Operation *op) {
+    for (auto &[buf, defs] : op->access.writes) {
+      PipelineSpec *owner = InnermostContainingBinding(defs, op->sched_scope);
+      if (owner != nullptr)
+        owner->producers.insert(op);
+    }
+    for (auto &[buf, defs] : op->access.reads) {
+      PipelineSpec *owner = InnermostContainingBinding(defs, op->sched_scope);
+      if (owner != nullptr)
+        owner->consumers.insert(op);
+    }
+  }
+
+  // Build the pipelines' use sets HIERARCHICALLY: every operation —
+  // leaf or scope — joins the innermost binding whose scope contains
+  // its position. An enclosing binding sees a nested binding's work
+  // only as the collapsed scope operation (a role that merely observed
+  // the inner writes still publishes them with its arrive); inner
+  // synchronization never penetrates outward. Leaf-only rules: an op's
+  // written buffers must share ONE owning binding (one completion
+  // signal), and a multi-role op must touch no pipeline buffers.
   void BuildUseChains() {
-    for (auto &[id, op] : ops_) {
+    for (auto &[id, op_ptr] : ops_) {
+      Operation &op = *op_ptr;
       Buffer write_buf;
-      for (auto &[buf, def] : op.access.writes) {
-        auto it = buffer_pipeline_.find(buf);
-        if (it == buffer_pipeline_.end())
-          continue;
-        def = it->second;
-        pipelines_[def].producers.insert(&op);
-        if (op.write_def < 0) {
-          op.write_def = def;
+      ResolveAccessDefs(&op.access);
+      RegisterUses(&op);
+      for (auto &[buf, defs] : op.access.writes) {
+        PipelineSpec *owner = InnermostContainingBinding(defs, op.sched_scope);
+        if (owner == nullptr)
+          continue; // unprotected, or rejected by VerifySpanCoverage
+        if (op.write_def == nullptr) {
+          op.write_def = owner;
           write_buf = buf;
         } else {
-          ICHECK_EQ(op.write_def, def)
+          ICHECK_EQ(op.write_def, owner)
               << "ws_schedule: op '" << id << "' writes " << write_buf->name
-              << " of pipeline '" << pipelines_[op.write_def].name << "' and "
-              << buf->name << " of pipeline '" << pipelines_[def].name
+              << " of pipeline '" << op.write_def->name << "' and " << buf->name
+              << " of pipeline '" << owner->name
               << "'; an op's synchronization can only trigger one pipeline, "
                  "so split the op";
         }
       }
-      for (auto &[buf, def] : op.access.reads) {
-        auto it = buffer_pipeline_.find(buf);
-        if (it == buffer_pipeline_.end())
-          continue;
-        def = it->second;
-        pipelines_[def].consumers.insert(&op);
-      }
-      if (op.role_idxs.size() > 1) {
-        std::set<PipelineIndex> defs = op.access.Defs();
+      if (op.roles.size() > 1) {
+        PipelineSet defs = op.access.Defs();
         ICHECK(defs.empty())
-            << "ws_schedule: op '" << id << "' is placed by "
-            << op.role_idxs.size() << " roles but touches buffer(s) of "
-            << "pipeline '" << pipelines_[*defs.begin()].name
+            << "ws_schedule: op '" << id << "' is placed by " << op.roles.size()
+            << " roles but touches buffer(s) of " << "pipeline '"
+            << (*defs.begin())->name
             << "'; only ops touching no pipeline buffers may be duplicated "
                "across roles";
+        for (const auto &[buf, def] : op.access.writes) {
+          ICHECK((IsLocalBuffer(buf, true) || IsFragmentBuffer(buf)))
+              << "ws_schedule: op '" << id << "' is placed by "
+              << op.roles.size() << " roles but writes non-local buffer '"
+              << buf->name << "'; every role would repeat the write";
+        }
       }
     }
-    // A scope guard or while condition must not read pipeline buffers:
-    // it has to be uniform across roles.
-    for (const ScopeSpec &scope : scopes_) {
+    for (const auto &scope : scopes_) {
+      ResolveAccessDefs(&scope->access);
+      RegisterUses(scope.get()); // the root has no position: a no-op
+    }
+    // A scope guard or while condition must be uniform across roles: it may
+    // read role-private locals or storage no op writes.
+    VarSet written;
+    for (const auto &[id, op] : ops_)
+      for (const auto &[buf, def] : op->access.writes)
+        written.insert(buf->data);
+    for (const auto &scope : scopes_) {
       auto check_uniform = [&](const PrimExpr &expr, const char *what) {
         AccessSet access;
         QueryAccess(Evaluate(expr), &access);
-        for (const auto *operands : {&access.reads, &access.writes}) {
-          for (const auto &[buf, def] : *operands) {
-            ICHECK(!buffer_pipeline_.count(buf))
-                << "ws_schedule: the " << what << " of scope '" << scope.id
-                << "' touches pipeline buffer " << buf->name << "; it must "
-                << "be uniform across roles";
-          }
+        for (const auto &[buf, def] : access.reads) {
+          ICHECK(!buffer_pipeline_.count(buf->data))
+              << "ws_schedule: the " << what << " of scope '" << scope->id
+              << "' touches pipeline buffer " << buf->name << "; it must "
+              << "be uniform across roles";
+          ICHECK((IsLocalBuffer(buf, true) || IsFragmentBuffer(buf)) ||
+                 !written.count(buf->data))
+              << "ws_schedule: the " << what << " of scope '" << scope->id
+              << "' reads buffer '" << buf->name << "' that scheduled ops "
+              << "write; its value could diverge between roles";
         }
       };
-      if (scope.guard.defined())
-        check_uniform(scope.guard.value(), "guard");
-      if (scope.orig_while.defined())
-        check_uniform(scope.orig_while->condition, "condition");
+      if (scope->guard.defined())
+        check_uniform(scope->guard.value(), "guard");
+      if (scope->orig_while.defined())
+        check_uniform(scope->orig_while->condition, "condition");
     }
   }
 
   // ---- op atoms -------------------------------------------------------------
 
   void BuildOpAtoms() {
-    for (auto &[id, op] : ops_) {
+    for (auto &[id, op_ptr] : ops_) {
+      Operation &op = *op_ptr;
+      // Classify every call once: the direct tile-op call sets the op's
+      // atom, while an asynchronous instruction nested below a compound
+      // statement (an op-node loop, a T.ws_op group) is rejected — its
+      // barrier could not be wired. Either way each call contributes its
+      // async-proxy accesses. (Locals because C++17 lambdas cannot
+      // capture structured bindings.)
       const auto *ev = op.stmt.as<EvaluateNode>();
-      if (ev && ev->value.as<CallNode>()) {
-        op.atom = ClassifyCall(Downcast<Call>(ev->value), target_);
-        continue;
-      }
-      // A compound statement (an op-node loop, a T.ws_op group) stays
-      // synchronous; a nested asynchronous instruction could not be
-      // wired to its barrier, so it is rejected. (Locals because C++17
-      // lambdas cannot capture structured bindings.)
+      const CallNode *direct = ev ? ev->value.as<CallNode>() : nullptr;
       const String &op_id = id;
-      const Stmt &stmt = op.stmt;
-      PostOrderVisit(stmt, [&](const ObjectRef &node) {
+      PostOrderVisit(op.stmt, [&](const ObjectRef &node) {
         const auto *call = node.as<CallNode>();
         if (!call || call->op.same_as(region()))
           return;
-        ICHECK(ClassifyCall(GetRef<Call>(call), target_) == OpAtom::kSync)
-            << "ws_schedule: op '" << op_id << "' nests an asynchronous "
-            << "instruction inside a compound statement; make it a "
-            << "directly scheduled op so its barrier can be wired:\n"
-            << stmt;
+        TileOperator tile_op = ParseOperator(GetRef<Call>(call));
+        OpAtom atom = ClassifyTileOp(tile_op, target_);
+        if (call == direct) {
+          op.atom = atom;
+        } else {
+          ICHECK(atom == OpAtom::kSync)
+              << "ws_schedule: op '" << op_id << "' nests an asynchronous "
+              << "instruction inside a compound statement; make it a "
+              << "directly scheduled op so its barrier can be wired:\n"
+              << op.stmt;
+        }
+        op.uses_async_proxy =
+            op.uses_async_proxy || UsesAsyncProxy(GetRef<Call>(call), target_);
       });
     }
+    // Fold the scope summaries, children first.
+    std::vector<Scope *> by_depth;
+    for (const auto &scope : scopes_)
+      by_depth.push_back(scope.get());
+    std::stable_sort(
+        by_depth.begin(), by_depth.end(),
+        [](const Scope *a, const Scope *b) { return a->Depth() > b->Depth(); });
+    for (Scope *scope : by_depth) {
+      scope->role_residues.assign(roles_.size(), {});
+      for (size_t r = 0; r < roles_.size(); ++r) {
+        Scope::Residue &folded = scope->role_residues[r];
+        for (const BodyEntryPtr &entry : scope->bodies[r]) {
+          if (entry->AsSync())
+            continue;
+          scope->uses_async_proxy = scope->uses_async_proxy ||
+                                    entry->AsOperation()->TouchesAsyncProxy();
+          if (const Scope *child = entry->AsScope()) {
+            folded.tcgen05 = folded.tcgen05 || child->role_residues[r].tcgen05;
+            folded.cp_async =
+                folded.cp_async || child->role_residues[r].cp_async;
+          } else {
+            OpAtom atom = entry->AsOperation()->atom;
+            folded.tcgen05 = folded.tcgen05 || atom == OpAtom::kTcgen05Gemm;
+            folded.cp_async = folded.cp_async || atom == OpAtom::kCpAsyncCopy;
+          }
+        }
+      }
+    }
+  }
+
+  // Fuse the full-side arrive into each commit cycle's last TMA copy:
+  // init(1) plus one elected arrive replace the per-thread arrives.
+  // Requires every cycle of the signaling role to end with an unguarded
+  // copy in the same body — a guarded copy may skip its arrive; a copy
+  // inside a child scope would arrive once per child iteration.
+  bool TryFuseTmaArrival(const PipelineSpec *p, const BarrierSidePlan &plan) {
+    // All of p's brackets live in its one scope; a producing entry is
+    // either a copy owned by p or a collapsed scope (a use of p).
+    std::vector<Operation *> cycle_copies;
+    Operation *last = nullptr; // last pipeline-writing op of the open cycle
+    bool open = false;
+    for (const BodyEntryPtr &entry :
+         p->sync_scope->bodies[plan.signal_role->index]) {
+      if (const Synchronization *sync = entry->AsSync()) {
+        if (sync->pipeline != p)
+          continue;
+        if (sync->kind.IsProducerAcquire()) {
+          open = true;
+          last = nullptr;
+        } else if (sync->kind.IsProducerCommit()) {
+          if (last == nullptr || last->guard.defined())
+            return false;
+          cycle_copies.push_back(last);
+          open = false;
+        }
+        continue;
+      }
+      if (!open)
+        continue;
+      Operation *op = entry->AsOperation();
+      if (op->AsScope()) {
+        if (p->producers.count(op))
+          return false;
+        continue;
+      }
+      if (op->write_def == p)
+        last = op;
+    }
+    for (Operation *copy : cycle_copies)
+      copy->fused_arrive = true;
+    return true;
   }
 
   // Fill each pipeline's two BarrierSidePlans: find the unique
   // signaling role of each side and derive the count from its uses.
   void PlanArriveCounts() {
     // The signaling role of a side is the role holding its commit /
-    // release entries; it must be unique.
-    for (const ScopeSpec &scope : scopes_) {
-      for (size_t ri = 0; ri < scope.bodies.size(); ++ri) {
-        for (const BodyEntry &e : scope.bodies[ri]) {
-          if (e.kind != BodyEntry::kSync)
+    // release entries (all in the pipeline's one scope); it must be
+    // unique.
+    for (const auto &pipeline : pipelines_) {
+      for (const auto &role : roles_) {
+        for (const BodyEntryPtr &entry :
+             pipeline->sync_scope->bodies[role->index]) {
+          const Synchronization *sync = entry->AsSync();
+          if (sync == nullptr || sync->pipeline != pipeline.get() ||
+              sync->kind.IsWait())
             continue;
-          if (e.sync.kind.IsWait())
-            continue;
-          PipelineSpec &pipeline = pipelines_[e.sync.pipeline_idx];
-          bool producer_side = e.sync.kind.IsProducerCommit();
+          bool producer_side = sync->kind.IsProducerCommit();
           BarrierSidePlan &plan =
-              producer_side ? pipeline.full_plan : pipeline.empty_plan;
-          if (plan.signal_role_idx < 0) {
-            plan.signal_role_idx = static_cast<RoleIndex>(ri);
+              producer_side ? pipeline->full_plan : pipeline->empty_plan;
+          if (plan.signal_role == nullptr) {
+            plan.signal_role = role.get();
           } else {
-            ICHECK_EQ(plan.signal_role_idx, static_cast<RoleIndex>(ri))
-                << "ws_schedule: pipeline " << pipeline.name
+            ICHECK_EQ(plan.signal_role, role.get())
+                << "ws_schedule: pipeline " << pipeline->name
                 << " is committed/released by multiple roles";
           }
         }
       }
     }
-    for (PipelineIndex p = 0; p < static_cast<PipelineIndex>(pipelines_.size());
-         ++p) {
-      PipelineSpec &pipeline = pipelines_[p];
+    // An asynchronous op's completion signal is wired to a barrier of the
+    // pipeline protecting its destination: a copy's transaction / deferred
+    // arrive rides the full side, a tcgen05 commit rides whichever side
+    // counted the op. The op must therefore appear in the use set of a
+    // side its own role signals, or the protocol never observes it
+    // finishing (an unmatched expect_tx hangs the barrier at run time).
+    for (const auto &[id, op] : ops_) {
+      if (op->atom == OpAtom::kSync)
+        continue;
+      if (op->write_def == nullptr) {
+        // Copies fall back to their own completion machinery
+        // (ConvertAtomCall); a tcgen05 gemm has none.
+        ICHECK(op->atom != OpAtom::kTcgen05Gemm)
+            << "ws_schedule: tcgen05 gemm '" << id << "' accumulates into an "
+            << "unprotected buffer; nothing would observe its completion";
+        continue;
+      }
+      const PipelineSpec &pipeline = *op->write_def;
+      if (pipeline.full_plan.signal_role == nullptr ||
+          pipeline.empty_plan.signal_role == nullptr)
+        continue; // "has no producer / consumer" is reported below
+      bool counted = false;
+      for (bool producer_side : {true, false}) {
+        const BarrierSidePlan &plan =
+            producer_side ? pipeline.full_plan : pipeline.empty_plan;
+        if (op->PlacedBy(*plan.signal_role) &&
+            pipeline.Uses(producer_side).count(op.get()))
+          counted = true;
+      }
+      ICHECK(counted)
+          << "ws_schedule: asynchronous op '" << id << "' writes pipeline '"
+          << pipeline.name << "', but no barrier side signaled by its role "
+          << "counts the op; the protocol never observes it finishing";
+    }
+
+    for (const auto &pipeline_ptr : pipelines_) {
+      PipelineSpec &pipeline = *pipeline_ptr;
       for (bool producer_side : {true, false}) {
         BarrierSidePlan &plan =
             producer_side ? pipeline.full_plan : pipeline.empty_plan;
-        if (plan.signal_role_idx < 0)
+        if (plan.signal_role == nullptr)
           continue; // reported below
-        // Selects the signaling role's uses (such ops have exactly one
-        // placing role).
-        for (const OpInfo *op : pipeline.Uses(producer_side)) {
-          if (!op->role_idxs.count(plan.signal_role_idx))
+        const RoleSpec &signal_role = *plan.signal_role;
+        // Selects the signaling role's uses (leaf ops have exactly one
+        // placing role; a collapsed scope answers per role).
+        for (const Operation *op : pipeline.Uses(producer_side)) {
+          if (!op->PlacedBy(signal_role))
             continue;
-          switch (op->atom) {
+          // A scope contributes every residue it holds for the role.
+          if (const Scope *scope = op->AsScope()) {
+            const Scope::Residue &res = scope->role_residues[signal_role.index];
+            plan.has_tcgen05_arrival = plan.has_tcgen05_arrival || res.tcgen05;
+            plan.has_cpasync_arrival = plan.has_cpasync_arrival || res.cp_async;
+            if (!res.tcgen05 && !res.cp_async)
+              plan.has_thread_arrive = true;
+            continue;
+          }
+          switch (op->AtomFor(signal_role)) {
           case OpAtom::kTmaCopy:
             plan.has_transaction = true;
             break;
@@ -1007,22 +1379,65 @@ private:
             break;
           }
         }
-        // Transactions alone cannot complete a phase: a side with TMA
-        // copies keeps the per-thread arrive.
-        if (plan.has_transaction)
+        // Transactions alone cannot complete a phase. A pure-TMA producer
+        // side fuses one elected arrive into each cycle's last copy (the
+        // legacy protocol); any other side with TMA copies keeps the
+        // per-thread arrive.
+        if (plan.has_transaction && !plan.has_thread_arrive &&
+            !plan.has_cpasync_arrival && !plan.has_tcgen05_arrival &&
+            producer_side && TryFuseTmaArrival(&pipeline, plan))
+          plan.fused_tma_arrive = true;
+        else if (plan.has_transaction)
           plan.has_thread_arrive = true;
-        const RoleSpec &role = roles_[plan.signal_role_idx];
+        // The arrive publishes the signaling role's generic-proxy writes
+        // to the pipeline's shared buffers; a fence is required when the
+        // observing side touches them through the async proxy (see
+        // BarrierSidePlan).
+        bool generic_writes = false;
+        for (const Operation *op : pipeline.producers) {
+          if (generic_writes)
+            break;
+          if (!op->PlacedBy(signal_role) ||
+              op->AtomFor(signal_role) != OpAtom::kSync)
+            continue;
+          for (const auto &[buf, defs] : op->access.writes) {
+            bool of_pipeline = false;
+            for (const PipelineSpec *def : defs)
+              of_pipeline = of_pipeline || def == &pipeline;
+            if (of_pipeline && !IsTmemBuffer(buf)) {
+              generic_writes = true;
+              break;
+            }
+          }
+        }
+        if (generic_writes) {
+          for (const Operation *op : pipeline.Uses(!producer_side)) {
+            if (op->TouchesAsyncProxy()) {
+              plan.needs_proxy_fence = true;
+              break;
+            }
+          }
+        }
+        // tcgen05_mma_arrive elects one lane PER WARP; a wider role
+        // would arrive once per warp against a count of one.
+        ICHECK(!plan.has_tcgen05_arrival ||
+               signal_role.warp_hi - signal_role.warp_lo == 1)
+            << "ws_schedule: role " << signal_role.name << " signals pipeline "
+            << pipeline.name << " through a tcgen05 commit but spans "
+            << (signal_role.warp_hi - signal_role.warp_lo)
+            << " warps; tcgen05 issue and commit require a single-warp role";
         plan.count = (plan.has_tcgen05_arrival ? 1 : 0) +
+                     (plan.fused_tma_arrive ? 1 : 0) +
                      ((plan.has_cpasync_arrival ? 1 : 0) +
                       (plan.has_thread_arrive ? 1 : 0)) *
-                         static_cast<int64_t>(role.NumThreads());
+                         static_cast<int64_t>(signal_role.NumThreads());
       }
     }
-    for (PipelineSpec &pipeline : pipelines_) {
-      ICHECK_GT(pipeline.full_plan.count, 0)
-          << "ws_schedule: pipeline " << pipeline.name << " has no producer";
-      ICHECK_GT(pipeline.empty_plan.count, 0)
-          << "ws_schedule: pipeline " << pipeline.name << " has no consumer";
+    for (const auto &pipeline : pipelines_) {
+      ICHECK_GT(pipeline->full_plan.count, 0)
+          << "ws_schedule: pipeline " << pipeline->name << " has no producer";
+      ICHECK_GT(pipeline->empty_plan.count, 0)
+          << "ws_schedule: pipeline " << pipeline->name << " has no consumer";
     }
   }
 
@@ -1031,101 +1446,169 @@ private:
   // A broken schedule would hang or race on the GPU; these checks reject
   // it at compile time instead.
 
-  // Per role: sync brackets must pair up within one scope body, a role
-  // is the producer or the consumer of a pipeline but never both, and
-  // every op must run inside an open span of each pipeline protecting
-  // one of its operands. Spans opened in an enclosing scope cover ops
-  // in child scopes.
+  // Per role: sync brackets pair up within one scope body, a role is
+  // never both producer and consumer of a pipeline, and every access
+  // runs inside an open span of the innermost binding whose scope
+  // contains the op. A producer-flavored role additionally holds every
+  // enclosing binding (its nested writes publish through the outer
+  // commit); a consumer's nested accesses ride the nested pipeline plus
+  // same-role program order.
   void VerifySpanCoverage() const {
-    for (RoleIndex ri = 0; ri < static_cast<RoleIndex>(roles_.size()); ++ri) {
-      std::map<PipelineIndex, bool> flavor; // pipeline -> role is producer
-      std::set<PipelineIndex> open; // union of all enclosing bodies' spans
-      std::function<void(ScopeIndex)> walk = [&](ScopeIndex scope_idx) {
-        const ScopeSpec &scope = scopes_[scope_idx];
-        std::set<PipelineIndex> local; // spans opened in THIS body
-        for (const BodyEntry &e : scope.bodies[ri]) {
-          if (e.kind == BodyEntry::kSync) {
-            PipelineIndex p = e.sync.pipeline_idx;
-            const String &pname = pipelines_[p].name;
-            auto [fit, first] = flavor.emplace(p, e.sync.kind.IsProducer());
-            ICHECK(first || fit->second == e.sync.kind.IsProducer())
-                << "ws_schedule: role " << roles_[ri].name
-                << " is both a producer and a consumer of pipeline '" << pname
-                << "'; the flavors are the two parties of the handshake, and "
-                   "a role handing data to itself needs no pipeline";
-            if (e.sync.kind.IsWait()) {
+    for (const auto &role_ptr : roles_) {
+      const RoleSpec &role = *role_ptr;
+      // pipeline -> role is producer, resolved up front from the
+      // pipeline's one scope: an op in a nested scope may need its
+      // role's flavor for a pipeline whose entries only appear later in
+      // an outer body.
+      std::map<const PipelineSpec *, bool, PipelineOrder> flavor;
+      for (const auto &p : pipelines_) {
+        for (const BodyEntryPtr &entry : p->sync_scope->bodies[role.index]) {
+          const Synchronization *sync = entry->AsSync();
+          if (sync == nullptr || sync->pipeline != p.get())
+            continue;
+          auto [fit, first] = flavor.emplace(p.get(), sync->kind.IsProducer());
+          ICHECK(first || fit->second == sync->kind.IsProducer())
+              << "ws_schedule: role " << role.name
+              << " is both a producer and a consumer of pipeline '" << p->name
+              << "'; the flavors are the two parties of the handshake, and "
+                 "a role handing data to itself needs no pipeline";
+        }
+      }
+      PipelineSet open;   // union of all enclosing bodies' spans
+      PipelineSet synced; // this role's sync entries already passed:
+                          // afterwards its phase names the NEXT cycle
+                          // (see OpRewriter::BindingPhase)
+      std::function<void(const Scope &)> walk = [&](const Scope &scope) {
+        PipelineSet local; // spans opened in THIS body
+        for (const BodyEntryPtr &entry : scope.bodies[role.index]) {
+          if (const Synchronization *sync = entry->AsSync()) {
+            const PipelineSpec *p = sync->pipeline;
+            synced.insert(p);
+            if (sync->kind.IsWait()) {
               ICHECK(!open.count(p))
-                  << "ws_schedule: pipeline '" << pname << "' acquired twice "
+                  << "ws_schedule: pipeline '" << p->name << "' acquired twice "
                   << "without an intervening commit/release in role "
-                  << roles_[ri].name;
+                  << role.name;
               open.insert(p);
               local.insert(p);
             } else {
               ICHECK(local.count(p))
-                  << "ws_schedule: commit/release of pipeline '" << pname
-                  << "' in role " << roles_[ri].name
+                  << "ws_schedule: commit/release of pipeline '" << p->name
+                  << "' in role " << role.name
                   << " has no matching acquire/wait in the same scope body";
               open.erase(p);
               local.erase(p);
             }
             continue;
           }
-          if (e.kind == BodyEntry::kScope) {
-            walk(ScopeIndexOf(e.id));
+          if (const Scope *child = entry->AsScope()) {
+            walk(*child);
             continue;
           }
-          const OpInfo &op = ops_.at(e.id);
-          auto check_operand = [&](const Buffer &buf, PipelineIndex def,
-                                   const char *how) {
-            if (def < 0)
+          const Operation &op = *entry->AsOperation();
+          auto check_access = [&](const Buffer &buf,
+                                  const std::vector<PipelineSpec *> &defs,
+                                  const char *how) {
+            if (defs.empty())
               return;
-            ICHECK(open.count(def))
-                << "ws_schedule: op '" << op.id << "' in role "
-                << roles_[ri].name << " " << how << " " << buf->name
-                << " outside an open span of pipeline '" << pipelines_[def].name
+            // The innermost binding whose scope contains the op owns the
+            // alternation at the op's level.
+            const PipelineSpec *innermost =
+                InnermostContainingBinding(defs, op.sched_scope);
+            ICHECK(innermost != nullptr)
+                << "ws_schedule: op '" << op.id << "' in role " << role.name
+                << " " << how << " " << buf->name
+                << " outside the scope of every pipeline protecting it";
+            ICHECK(open.count(innermost))
+                << "ws_schedule: op '" << op.id << "' in role " << role.name
+                << " " << how << " " << buf->name
+                << " outside an open span of pipeline '" << innermost->name
                 << "'; bracket the op with producer_acquire/producer_commit "
                 << "or consumer_wait/consumer_release (the stage may be "
                 << "concurrently overwritten or still read by an "
                 << "asynchronous op)";
+            for (const PipelineSpec *def : defs) {
+              if (def == innermost)
+                continue;
+              if (!op.sched_scope->IsNestedIn(def->sync_scope)) {
+                // Resolved to the adjacent version (a read the
+                // last-completed slot, a write the next-produced one);
+                // needs the binding's scope below the access's.
+                ICHECK(def->depth == 1 ||
+                       def->sync_scope->IsNestedIn(op.sched_scope))
+                    << "ws_schedule: op '" << op.id << "' in role " << role.name
+                    << " " << how << " " << buf->name
+                    << " outside the scope of pipeline '" << def->name
+                    << "' (depth " << def->depth
+                    << "), which is not nested below the op's scope; no "
+                    << "version is adjacent there";
+                continue;
+              }
+              auto fit = flavor.find(def);
+              if (fit != flavor.end() && fit->second) {
+                ICHECK(open.count(def))
+                    << "ws_schedule: op '" << op.id << "' in role " << role.name
+                    << " " << how << " " << buf->name
+                    << " outside an open span of enclosing pipeline '"
+                    << def->name << "', which this role produces; "
+                    << "bracket the nested scope reference with "
+                    << "producer_acquire/producer_commit";
+                continue;
+              }
+              // Consumer side, span not held: the emitted access derives
+              // the slot from the role's own phase, which names the
+              // in-production version only until the role's sync entries
+              // of the pipeline run.
+              if (def->depth > 1 && !open.count(def)) {
+                ICHECK(!synced.count(def))
+                    << "ws_schedule: op '" << op.id << "' in role " << role.name
+                    << " " << how << " " << buf->name << " of pipeline '"
+                    << def->name << "' (depth " << def->depth
+                    << ") after this role's sync "
+                    << "entries; the role's phase no longer names the "
+                    << "in-production version — move the access before the "
+                    << "wait or hold the span across it";
+              }
+            }
           };
-          for (const auto &[buf, def] : op.access.writes)
-            check_operand(buf, def, "writes");
-          for (const auto &[buf, def] : op.access.reads)
-            check_operand(buf, def, "reads");
+          for (const auto &[buf, defs] : op.access.writes)
+            check_access(buf, defs, "writes");
+          for (const auto &[buf, defs] : op.access.reads)
+            check_access(buf, defs, "reads");
         }
         ICHECK(local.empty())
-            << "ws_schedule: role " << roles_[ri].name << " leaves pipeline '"
-            << pipelines_[*local.begin()].name
+            << "ws_schedule: role " << role.name << " leaves pipeline '"
+            << (*local.begin())->name
             << "' acquired at the end of a scope body; every acquire/wait "
                "must be paired with a commit/release in the same body";
       };
-      walk(ScopeIndexOf(kWSRootScopeId));
+      walk(*root_scope_);
     }
   }
 
   // Within every loop scope, a pipeline's producer and consumer sides
   // must cycle equally often per iteration; an imbalance drifts the
-  // full/empty parity apart every trip. Balance also lets the deadlock
-  // model run every loop for just two iterations.
+  // full/empty parity apart every trip. Balance also keeps the deadlock
+  // model's bounded unrolling faithful.
   void VerifyCycleBalance() const {
-    for (size_t si = 0; si < scopes_.size(); ++si) {
-      const ScopeSpec &scope = scopes_[si];
-      if (scope.IsRoot())
+    for (const auto &scope : scopes_) {
+      if (scope->IsRoot())
         continue; // the root runs once; the deadlock model covers it exactly
-      std::map<PipelineIndex, std::array<int, 2>>
+      std::map<const PipelineSpec *, std::array<int, 2>, PipelineOrder>
           cycles; // [consumer, producer]
-      for (RoleIndex ri = 0; ri < static_cast<RoleIndex>(roles_.size()); ++ri) {
-        for (const BodyEntry &e : scope.bodies[ri]) {
-          if (e.kind == BodyEntry::kSync && e.sync.kind.IsCommit())
-            cycles[e.sync.pipeline_idx][e.sync.kind.IsProducer() ? 1 : 0]++;
+      for (const auto &body : scope->bodies) {
+        for (const BodyEntryPtr &entry : body) {
+          const Synchronization *sync = entry->AsSync();
+          if (sync && sync->kind.IsCommit())
+            cycles[sync->pipeline][sync->kind.IsProducer() ? 1 : 0]++;
         }
       }
-      for (const auto &[pipeline_idx, sides] : cycles) {
+      for (const auto &[pipeline, sides] : cycles) {
         ICHECK_EQ(sides[1], sides[0])
-            << "ws_schedule: pipeline '" << pipelines_[pipeline_idx].name
-            << "' cycles " << sides[1] << " time(s) on the producer side but "
-            << sides[0] << " time(s) on the consumer side per iteration of "
-            << "scope '" << scope.id << "'; the full/empty parity diverges "
+            << "ws_schedule: pipeline '" << pipeline->name << "' cycles "
+            << sides[1] << " time(s) on the producer side but " << sides[0]
+            << " time(s) on the consumer side per iteration of " << "scope '"
+            << scope->id << "'; the full/empty parity diverges "
             << "as the loop advances — cycle both sides equally often "
             << "within the scope";
       }
@@ -1133,33 +1616,32 @@ private:
   }
 
   // Flatten one role's sync entries into emitted-code order: loops are
-  // modeled for two iterations, and the stage deltas reproduce the
-  // software-pipelined reordering (an entry at delta d executes at
+  // modeled for `loop_trips` iterations, and the stage deltas reproduce
+  // the software-pipelined reordering (an entry at delta d executes at
   // steps d .. d + trips - 1).
-  std::vector<SyncEntry> FlattenRoleEvents(RoleIndex role_idx) const {
-    std::vector<SyncEntry> events;
-    std::function<void(ScopeIndex)> emit = [&](ScopeIndex scope_idx) {
-      const ScopeSpec &scope = scopes_[scope_idx];
-      const std::vector<BodyEntry> &entries = scope.bodies[role_idx];
+  std::vector<Synchronization> FlattenRoleEvents(const RoleSpec &role,
+                                                 int loop_trips) const {
+    std::vector<Synchronization> events;
+    std::function<void(const Scope &)> emit = [&](const Scope &scope) {
+      const std::vector<BodyEntryPtr> &entries = scope.bodies[role.index];
       if (entries.empty())
         return;
-      StagePlan plan = PlanStages(role_idx, entries);
-      int trips = scope.IsRoot() ? 1 : 2;
+      StagePlan plan = PlanStages(role, entries);
+      int trips = scope.IsRoot() ? 1 : loop_trips;
       int steps = scope.IsRoot() ? 1 : trips + plan.shift;
       for (int t = 0; t < steps; ++t) {
         for (size_t i = 0; i < entries.size(); ++i) {
           if (!scope.IsRoot() &&
               (t < plan.delta[i] || t >= plan.delta[i] + trips))
             continue; // outside this entry's step window
-          const BodyEntry &e = entries[i];
-          if (e.kind == BodyEntry::kScope)
-            emit(ScopeIndexOf(e.id));
-          else if (e.kind == BodyEntry::kSync)
-            events.push_back(e.sync);
+          if (const Scope *child = entries[i]->AsScope())
+            emit(*child);
+          else if (const Synchronization *sync = entries[i]->AsSync())
+            events.push_back(*sync);
         }
       }
     };
-    emit(ScopeIndexOf(kWSRootScopeId));
+    emit(*root_scope_);
     return events;
   }
 
@@ -1169,25 +1651,31 @@ private:
   // Enabled events never become disabled, so one greedy execution
   // suffices; a role still blocked at quiescence is a real hang.
   void VerifyDeadlockFree() const {
+    // A capacity deadlock (a producer run-ahead exhausting a pipeline's
+    // depth) surfaces within depth+1 cycles, so model each loop for
+    // max-depth+1 iterations.
+    int trips = 2;
+    for (const auto &pipeline : pipelines_)
+      trips = std::max(trips, pipeline->depth + 1);
     int n_roles = static_cast<int>(roles_.size());
-    std::vector<std::vector<SyncEntry>> events(n_roles);
-    for (RoleIndex r = 0; r < n_roles; ++r)
-      events[r] = FlattenRoleEvents(r);
+    std::vector<std::vector<Synchronization>> events(n_roles);
+    for (int r = 0; r < n_roles; ++r)
+      events[r] = FlattenRoleEvents(*roles_[r], trips);
 
     std::vector<int> cursors(n_roles, 0);
     // commits[p] / releases[p]: totals across all roles so far; waits and
     // acquires are counted per (role, pipeline) observer.
-    std::map<PipelineIndex, int> commits, releases;
-    std::vector<std::map<PipelineIndex, int>> waits(n_roles), acquires(n_roles);
+    std::map<const PipelineSpec *, int> commits, releases;
+    std::vector<std::map<const PipelineSpec *, int>> waits(n_roles),
+        acquires(n_roles);
 
     auto enabled = [&](int r) {
-      const SyncEntry &e = events[r][cursors[r]];
+      const Synchronization &e = events[r][cursors[r]];
       if (e.kind.IsConsumerWait())
-        return waits[r][e.pipeline_idx] < commits[e.pipeline_idx];
+        return waits[r][e.pipeline] < commits[e.pipeline];
       if (e.kind.IsProducerAcquire())
-        return acquires[r][e.pipeline_idx] <
-               static_cast<int>(pipelines_[e.pipeline_idx].depth) +
-                   releases[e.pipeline_idx];
+        return acquires[r][e.pipeline] <
+               e.pipeline->depth + releases[e.pipeline];
       return true; // commit / release never block
     };
 
@@ -1196,15 +1684,15 @@ private:
       progressed = false;
       for (int r = 0; r < n_roles; ++r) {
         while (cursors[r] < static_cast<int>(events[r].size()) && enabled(r)) {
-          const SyncEntry &e = events[r][cursors[r]];
+          const Synchronization &e = events[r][cursors[r]];
           if (e.kind.IsProducerAcquire())
-            acquires[r][e.pipeline_idx] += 1;
+            acquires[r][e.pipeline] += 1;
           else if (e.kind.IsProducerCommit())
-            commits[e.pipeline_idx] += 1;
+            commits[e.pipeline] += 1;
           else if (e.kind.IsConsumerWait())
-            waits[r][e.pipeline_idx] += 1;
+            waits[r][e.pipeline] += 1;
           else
-            releases[e.pipeline_idx] += 1;
+            releases[e.pipeline] += 1;
           cursors[r] += 1;
           progressed = true;
         }
@@ -1217,39 +1705,157 @@ private:
       if (cursors[r] >= static_cast<int>(events[r].size()))
         continue;
       deadlocked = true;
-      const SyncEntry &e = events[r][cursors[r]];
-      blocked << "\n  role " << roles_[r].name << " blocked at " << e.kind
-              << "(\"" << pipelines_[e.pipeline_idx].name << "\") after "
-              << cursors[r] << " of " << events[r].size() << " sync events";
+      const Synchronization &e = events[r][cursors[r]];
+      blocked << "\n  role " << roles_[r]->name << " blocked at " << e.kind
+              << "(\"" << e.pipeline->name << "\") after " << cursors[r]
+              << " of " << events[r].size() << " sync events";
     }
     ICHECK(!deadlocked)
         << "ws_schedule: schedule deadlocks: the roles' sync events reach a "
            "state where every unfinished role is blocked (mbarrier parity "
-           "model; loops modeled at two iterations):"
-        << blocked.str();
+           "model; loops modeled at "
+        << trips << " iterations):" << blocked.str();
+  }
+
+  // Scalar Binds inside ops define vars that later ops (or their guards) may
+  // use. Each role re-evaluates only the ops placed in it, so a use is
+  // well-defined only when the defining op runs in the same role, earlier,
+  // unguarded (a guarded definition would sit in its own `if` scope), and —
+  // under a stage shift — in the same software-pipeline step, or the unrolled
+  // prologue/epilogue would split the definition from the use.
+  void VerifyVarDefUse() const {
+    std::unordered_map<Var, const Operation *, ObjectPtrHash, ObjectPtrEqual>
+        def_op;
+    for (const auto &[id, op] : ops_) {
+      const Operation *op_ptr = op.get();
+      PostOrderVisit(op->stmt, [&](const ObjectRef &node) {
+        if (const auto *bind = node.as<BindNode>()) {
+          auto [it, inserted] = def_op.emplace(bind->var, op_ptr);
+          ICHECK(inserted || it->second == op_ptr)
+              << "ws_schedule: var '" << bind->var->name_hint
+              << "' is bound by ops '" << it->second->id << "' and '"
+              << op_ptr->id << "'";
+        }
+      });
+    }
+    if (def_op.empty())
+      return;
+
+    // The vars an op (or a guard expression) uses that other ops define.
+    auto scan_uses = [&](const ObjectRef &root, const Operation *self,
+                         std::vector<Var> *uses) {
+      PostOrderVisit(root, [&](const ObjectRef &node) {
+        if (const auto *v = node.as<VarNode>()) {
+          Var var = GetRef<Var>(v);
+          auto it = def_op.find(var);
+          if (it == def_op.end() || it->second == self)
+            return;
+          auto seen =
+              std::find_if(uses->begin(), uses->end(),
+                           [&](const Var &u) { return u.same_as(var); });
+          if (seen == uses->end())
+            uses->push_back(var);
+        }
+      });
+    };
+
+    for (const auto &role_ptr : roles_) {
+      const RoleSpec &role = *role_ptr;
+      auto check_use = [&](const String &where, const Var &v,
+                           const VarSet &defined) {
+        const Operation *def = def_op.at(v);
+        ICHECK(defined.count(v))
+            << "ws_schedule: " << where << " in role " << role.name
+            << " uses var '" << v->name_hint << "' defined by op '" << def->id
+            << "', which does not run earlier in that role";
+        // TODO: legalize guarded scalar definitions instead of rejecting
+        // them — when every use shares the definition's guard and stays in
+        // one contiguous guarded run, the emitted `if` already scopes them
+        // together; escaping uses need the scalar lowered to a role-local
+        // local.var (allocation outside the guard, guarded store, loads at
+        // the uses).
+        ICHECK(!def->guard.defined())
+            << "ws_schedule: op '" << def->id << "' defines var '"
+            << v->name_hint << "' used by " << where
+            << " but runs under a source guard; the definition would not be "
+               "visible outside its branch";
+      };
+
+      // Defs are C-scoped: a child scope sees the defs accumulated so far,
+      // but its own defs do not escape back to the parent body.
+      std::function<void(const Scope &, VarSet)> walk = [&](const Scope &scope,
+                                                            VarSet defined) {
+        const std::vector<BodyEntryPtr> &entries = scope.bodies[role.index];
+        if (entries.empty())
+          return;
+        StagePlan plan = PlanStages(role, entries);
+        std::map<String, int> body_delta;
+        for (size_t i = 0; i < entries.size(); ++i) {
+          if (!entries[i]->AsSync() && !entries[i]->AsScope())
+            body_delta[entries[i]->AsOperation()->id] = plan.delta[i];
+        }
+        for (size_t i = 0; i < entries.size(); ++i) {
+          if (entries[i]->AsSync())
+            continue;
+          if (const Scope *child = entries[i]->AsScope()) {
+            std::vector<Var> uses;
+            if (child->guard.defined())
+              scan_uses(child->guard.value(), nullptr, &uses);
+            if (child->orig_while.defined())
+              scan_uses(child->orig_while->condition, nullptr, &uses);
+            for (const Var &v : uses)
+              check_use("scope '" + std::string(child->id) + "'", v, defined);
+            walk(*child, defined);
+            continue;
+          }
+          const Operation &op = *entries[i]->AsOperation();
+          std::vector<Var> uses;
+          scan_uses(op.stmt, &op, &uses);
+          if (op.guard.defined())
+            scan_uses(op.guard.value(), &op, &uses);
+          for (const Var &v : uses) {
+            check_use("op '" + std::string(op.id) + "'", v, defined);
+            auto dit = body_delta.find(def_op.at(v)->id);
+            if (plan.shift > 0 && dit != body_delta.end()) {
+              ICHECK_EQ(dit->second, plan.delta[i])
+                  << "ws_schedule: op '" << op.id << "' uses var '"
+                  << v->name_hint << "' defined by op '" << def_op.at(v)->id
+                  << "' at a different stage; the "
+                  << "unrolled prologue/epilogue steps would split the "
+                  << "definition from this use";
+            }
+          }
+          PostOrderVisit(op.stmt, [&](const ObjectRef &node) {
+            if (const auto *bind = node.as<BindNode>())
+              defined.insert(bind->var);
+          });
+        }
+      };
+      walk(*root_scope_, {});
+    }
   }
 
   void VerifySchedule() {
     VerifySpanCoverage();
     VerifyCycleBalance();
     VerifyDeadlockFree();
+    VerifyVarDefUse();
   }
 
   // ---- stage analysis -------------------------------------------------------
 
   // Pipelines transitively touched by a role's entries under a scope.
-  std::set<PipelineIndex> ScopePipelines(RoleIndex role_idx,
-                                         ScopeIndex scope_idx) const {
-    std::set<PipelineIndex> result;
-    const ScopeSpec &scope = scopes_[scope_idx];
-    for (const BodyEntry &e : scope.bodies[role_idx]) {
-      if (e.kind == BodyEntry::kOp) {
-        std::set<PipelineIndex> defs = ops_.at(e.id).access.Defs();
-        result.insert(defs.begin(), defs.end());
-      } else if (e.kind == BodyEntry::kScope) {
-        std::set<PipelineIndex> pipelines =
-            ScopePipelines(role_idx, ScopeIndexOf(e.id));
+  PipelineSet ScopePipelines(const RoleSpec &role, const Scope &scope) const {
+    PipelineSet result;
+    for (const BodyEntryPtr &entry : scope.bodies[role.index]) {
+      if (entry->AsSync())
+        continue;
+      if (const Scope *child = entry->AsScope()) {
+        PipelineSet pipelines = ScopePipelines(role, *child);
         result.insert(pipelines.begin(), pipelines.end());
+      } else {
+        PipelineSet defs = entry->AsOperation()->access.Defs();
+        result.insert(defs.begin(), defs.end());
       }
     }
     return result;
@@ -1265,33 +1871,33 @@ private:
     int shift = 0;          // max delta; unrolled steps on each side
   };
 
-  StagePlan PlanStages(RoleIndex role_idx,
-                       const std::vector<BodyEntry> &entries) const {
+  StagePlan PlanStages(const RoleSpec &role,
+                       const std::vector<BodyEntryPtr> &entries) const {
     StagePlan plan;
     plan.delta.assign(entries.size(), 0);
 
     int s_min = std::numeric_limits<int>::max();
-    for (const BodyEntry &e : entries) {
-      if (e.kind == BodyEntry::kSync)
-        s_min = std::min(s_min, e.sync.stage);
+    for (const BodyEntryPtr &entry : entries) {
+      if (const Synchronization *sync = entry->AsSync())
+        s_min = std::min(s_min, sync->stage);
     }
     if (s_min == std::numeric_limits<int>::max())
       return plan; // no syncs in this body
 
     // pipeline -> stage of its open span; only the pair's stage
     // agreement still needs checking here.
-    std::map<PipelineIndex, int> pipeline_stage;
-    auto span_delta = [&](const std::set<PipelineIndex> &touched_pipelines,
+    std::map<const PipelineSpec *, int, PipelineOrder> pipeline_stage;
+    auto span_delta = [&](const PipelineSet &touched,
                           const String &what) -> int {
       int stage = std::numeric_limits<int>::min();
-      for (const auto &[pipeline_idx, open_stage] : pipeline_stage) {
-        if (!touched_pipelines.count(pipeline_idx))
+      for (const auto &[pipeline, open_stage] : pipeline_stage) {
+        if (!touched.count(pipeline))
           continue;
         if (stage == std::numeric_limits<int>::min()) {
           stage = open_stage;
         } else {
           ICHECK_EQ(stage, open_stage)
-              << "ws_schedule: " << what << " in role " << roles_[role_idx].name
+              << "ws_schedule: " << what << " in role " << role.name
               << " touches pipelines whose open spans sit at different "
                  "stages; split the op or align the stages";
         }
@@ -1300,28 +1906,27 @@ private:
     };
 
     for (size_t i = 0; i < entries.size(); ++i) {
-      const BodyEntry &e = entries[i];
-      if (e.kind == BodyEntry::kSync) {
-        plan.delta[i] = e.sync.stage - s_min;
-        if (e.sync.kind.IsWait()) {
-          pipeline_stage[e.sync.pipeline_idx] = e.sync.stage;
+      if (const Synchronization *sync = entries[i]->AsSync()) {
+        plan.delta[i] = sync->stage - s_min;
+        if (sync->kind.IsWait()) {
+          pipeline_stage[sync->pipeline] = sync->stage;
         } else {
           // Bracket verified: the matching open exists in this body.
-          auto oit = pipeline_stage.find(e.sync.pipeline_idx);
-          ICHECK_EQ(oit->second, e.sync.stage)
+          auto oit = pipeline_stage.find(sync->pipeline);
+          ICHECK_EQ(oit->second, sync->stage)
               << "ws_schedule: acquire/wait of pipeline '"
-              << pipelines_[e.sync.pipeline_idx].name << "' in role "
-              << roles_[role_idx].name << " is at stage " << oit->second
-              << " but its commit/release is at stage " << e.sync.stage
+              << sync->pipeline->name << "' in role " << role.name
+              << " is at stage " << oit->second
+              << " but its commit/release is at stage " << sync->stage
               << "; pairs must share one stage";
           pipeline_stage.erase(oit);
         }
-      } else if (e.kind == BodyEntry::kOp) {
-        plan.delta[i] = span_delta(ops_.at(e.id).access.Defs(), e.id) - s_min;
-      } else { // kScope
+      } else if (const Scope *child = entries[i]->AsScope()) {
         plan.delta[i] =
-            span_delta(ScopePipelines(role_idx, ScopeIndexOf(e.id)), e.id) -
-            s_min;
+            span_delta(ScopePipelines(role, *child), child->id) - s_min;
+      } else {
+        const Operation &op = *entries[i]->AsOperation();
+        plan.delta[i] = span_delta(op.access.Defs(), op.id) - s_min;
       }
     }
     // Bracket verified: every span opened in this body has closed.
@@ -1341,17 +1946,21 @@ private:
 
   struct RoleCtx {
     const RoleSpec *role = nullptr;
-    RoleIndex role_idx = -1;
     Map<Var, PrimExpr> subs;      // orig vars -> per-role expressions
     std::vector<LoopLevel> chain; // enclosing loops, outer->inner
     // Pipeline -> phase at acquire/wait / runtime phase counter.
-    std::map<PipelineIndex, PrimExpr> pipeline_phase;
-    std::map<PipelineIndex, Buffer> counters;
+    // Lookup-only maps: pointer keys never order any emitted output.
+    std::map<const PipelineSpec *, PrimExpr> pipeline_phase;
+    std::map<const PipelineSpec *, Buffer> counters;
   };
 
-  static PrimExpr LinearPhase(const RoleCtx &ctx) {
+  // Linearize the phase over the outermost `levels` loops of the chain
+  // (all of them for a sync entry at the current level; a prefix when a
+  // deeper access resolves an enclosing pipeline's phase).
+  static PrimExpr LinearPhase(const RoleCtx &ctx, size_t levels) {
     PrimExpr phase;
-    for (const LoopLevel &lvl : ctx.chain) {
+    for (size_t i = 0; i < levels; ++i) {
+      const LoopLevel &lvl = ctx.chain[i];
       // The phase counts completed iterations, so a non-zero loop min is
       // subtracted (T.Pipelined(3, 7) starts at phase 0, not 3).
       PrimExpr iter = is_zero(lvl.min) ? lvl.iter : lvl.iter - lvl.min;
@@ -1359,51 +1968,31 @@ private:
     }
     return phase.defined() ? phase : PrimExpr(IntImm(DataType::Int(32), 0));
   }
-
-  // Whether a scope or any of its ancestors is a while scope: no
-  // iteration expression exists there to linearize a phase against.
-  bool UnderWhileScope(ScopeIndex scope_idx) const {
-    for (ScopeIndex s = scope_idx; s >= 0; s = scopes_[s].parent) {
-      if (scopes_[s].orig_while.defined())
-        return true;
-    }
-    return false;
+  static PrimExpr LinearPhase(const RoleCtx &ctx) {
+    return LinearPhase(ctx, ctx.chain.size());
   }
 
   // A (role, pipeline) pair needs a runtime phase counter when its
-  // cycles are not one-per-iteration of a single for loop: several
-  // cycles in one body, sync points at several loop depths, or any
-  // sync under a while scope.
-  bool NeedsCounter(RoleIndex role_idx, PipelineIndex pipeline_idx) const {
-    std::set<ScopeIndex> sync_scopes;
-    bool multi_cycle = false;
-    std::function<void(ScopeIndex)> scan = [&](ScopeIndex scope_idx) {
-      int closes_here = 0;
-      for (const BodyEntry &e : scopes_[scope_idx].bodies[role_idx]) {
-        if (e.kind == BodyEntry::kScope) {
-          scan(ScopeIndexOf(e.id));
-        } else if (e.kind == BodyEntry::kSync &&
-                   e.sync.pipeline_idx == pipeline_idx) {
-          sync_scopes.insert(scope_idx);
-          if (e.sync.kind.IsCommit())
-            closes_here += 1;
-        }
-      }
-      if (closes_here > 1)
-        multi_cycle = true;
-    };
-    scan(ScopeIndexOf(kWSRootScopeId));
-    if (multi_cycle || sync_scopes.size() > 1)
-      return true;
-    for (ScopeIndex s : sync_scopes) {
-      if (UnderWhileScope(s))
-        return true;
+  // cycles are not one-per-counted-iteration of the enclosing for
+  // chain: several cycles per body, or a scope with no linearizable
+  // phase (while ancestor, guard, non-rectangular nest). All of the
+  // pipeline's sync entries live in its one scope; a role without any
+  // never counts.
+  bool NeedsCounter(const RoleSpec &role, const PipelineSpec &pipeline) const {
+    int closes = 0;
+    for (const BodyEntryPtr &entry : pipeline.sync_scope->bodies[role.index]) {
+      const Synchronization *sync = entry->AsSync();
+      if (sync && sync->pipeline == &pipeline && sync->kind.IsCommit())
+        ++closes;
     }
-    return false;
+    if (closes == 0)
+      return false; // the role never syncs this pipeline
+    return closes > 1 || !pipeline.sync_scope->HasLinearPhase();
   }
 
-  PrimExpr PipelinePhase(const RoleCtx &ctx, PipelineIndex pipeline_idx) const {
-    auto cit = ctx.counters.find(pipeline_idx);
+  PrimExpr PipelinePhase(const RoleCtx &ctx,
+                         const PipelineSpec *pipeline) const {
+    auto cit = ctx.counters.find(pipeline);
     if (cit != ctx.counters.end())
       return BufferLoad(cit->second, {IntImm(DataType::Int(32), 0)});
     return LinearPhase(ctx);
@@ -1418,10 +2007,19 @@ private:
   // Arrivals for one commit/release entry — exactly plan.count arrivals
   // per phase.
   void MakeArrive(const PipelineSpec &pipeline, bool full, PrimExpr idx,
-                  Array<Stmt> *out) const {
+                  bool &proxy_fenced, Array<Stmt> *out) const {
     const Buffer &bar = full ? pipeline.full : pipeline.empty;
     const BarrierSidePlan &plan =
         full ? pipeline.full_plan : pipeline.empty_plan;
+    // fence.proxy.async orders ALL of the thread's prior generic accesses
+    // against its subsequent async-proxy accesses (PTX Proxies /
+    // membar.proxy), so one fence covers every arrive until the next
+    // emitted op can write again.
+    if (plan.needs_proxy_fence && !proxy_fenced) {
+      out->push_back(
+          Evaluate(Call(DataType::Handle(), fence_proxy_async(), {})));
+      proxy_fenced = true;
+    }
     if (plan.has_tcgen05_arrival) {
       PrimExpr ptr = bar.access_ptr(3, DataType::Handle(), 1, idx);
       out->push_back(
@@ -1443,30 +2041,31 @@ private:
     }
   }
 
-  void EmitSync(RoleCtx &ctx, const SyncEntry &sync, Array<Stmt> *out) {
-    PipelineSpec &pipeline = pipelines_[sync.pipeline_idx];
+  void EmitSync(RoleCtx &ctx, const Synchronization &sync, bool &proxy_fenced,
+                Array<Stmt> *out) {
+    const PipelineSpec &pipeline = *sync.pipeline;
     PrimExpr depth = IntImm(DataType::Int(32), pipeline.depth);
-    PrimExpr phase = PipelinePhase(ctx, sync.pipeline_idx);
+    PrimExpr phase = PipelinePhase(ctx, &pipeline);
     PrimExpr idx = floormod(phase, depth);
     PrimExpr parity =
         bitwise_and(floordiv(phase, depth), IntImm(DataType::Int(32), 1));
 
     if (sync.kind.IsProducerAcquire()) {
-      ctx.pipeline_phase[sync.pipeline_idx] = std::move(phase);
+      ctx.pipeline_phase[&pipeline] = std::move(phase);
       out->push_back(MakeWait(
           pipeline.empty, std::move(idx),
           bitwise_xor(std::move(parity), IntImm(DataType::Int(32), 1))));
     } else if (sync.kind.IsConsumerWait()) {
-      ctx.pipeline_phase[sync.pipeline_idx] = std::move(phase);
+      ctx.pipeline_phase[&pipeline] = std::move(phase);
       out->push_back(
           MakeWait(pipeline.full, std::move(idx), std::move(parity)));
     } else if (sync.kind.IsProducerCommit()) {
-      MakeArrive(pipeline, /*full=*/true, std::move(idx), out);
+      MakeArrive(pipeline, /*full=*/true, std::move(idx), proxy_fenced, out);
     } else { // consumer release
-      MakeArrive(pipeline, /*full=*/false, std::move(idx), out);
+      MakeArrive(pipeline, /*full=*/false, std::move(idx), proxy_fenced, out);
     }
-    if (sync.kind.IsCommit() && ctx.counters.count(sync.pipeline_idx)) {
-      Buffer cnt = ctx.counters.at(sync.pipeline_idx);
+    if (sync.kind.IsCommit() && ctx.counters.count(&pipeline)) {
+      Buffer cnt = ctx.counters.at(&pipeline);
       PrimExpr zero = IntImm(DataType::Int(32), 0);
       out->push_back(BufferStore(cnt, BufferLoad(cnt, {zero}) + 1, {zero}));
     }
@@ -1477,32 +2076,107 @@ private:
   struct OpRewriter : public StmtExprMutator {
     const WSScheduleMaterializer &self;
     const RoleCtx &ctx;
-    OpRewriter(const WSScheduleMaterializer &self, const RoleCtx &ctx)
-        : self(self), ctx(ctx) {}
+    // The scope of the op being rewritten (null for guard/condition
+    // expressions, which may not touch versioned buffers).
+    const Scope *sched_scope;
+    bool region_write_ = false; // rewriting a write region's root load
+    OpRewriter(const WSScheduleMaterializer &self, const RoleCtx &ctx,
+               const Scope *sched_scope)
+        : self(self), ctx(ctx), sched_scope(sched_scope) {}
 
-    PrimExpr VersionIndex(const Buffer &orig) {
-      // The pipeline and its phase are always present: versioned_ keys
-      // are pipeline buffers, and span coverage was verified.
-      PipelineIndex p = self.buffer_pipeline_.at(orig);
-      return floormod(ctx.pipeline_phase.at(p),
-                      IntImm(DataType::Int(32), self.pipelines_[p].depth));
+    // The phase of one binding at this access: the role's acquire/wait
+    // bound it, or — for an unheld access cooperating inside the
+    // pipeline's scope (FA's rescale) — the role's own phase names the
+    // in-production slot. Sound only before the role's sync entries of
+    // the pipeline (VerifySpanCoverage checked).
+    PrimExpr BindingPhase(const PipelineSpec &pipeline, const Buffer &orig) {
+      auto pit = ctx.pipeline_phase.find(&pipeline);
+      if (pit != ctx.pipeline_phase.end())
+        return pit->second;
+      auto cit = ctx.counters.find(&pipeline);
+      if (cit != ctx.counters.end())
+        return BufferLoad(cit->second, {IntImm(DataType::Int(32), 0)});
+      ICHECK(pipeline.sync_scope->HasLinearPhase())
+          << "ws_schedule: an access to " << orig->name << " needs pipeline '"
+          << pipeline.name << "'s phase, which cannot be linearized here, "
+          << "and this role has no phase counter for it (no sync entries)";
+      return LinearPhase(ctx, pipeline.sync_scope->Depth());
     }
 
-    // The BufferLoad path below prepends the version index to a
-    // versioned region's root load; insert the matching unit extent to
-    // keep the region's indices-per-extent invariant.
+    // The binding's completed-cycle count at an access AFTER its scope:
+    // the role's counter, or (enclosing iteration + 1) x the cycles the
+    // scope runs per enclosing iteration (static For extents only —
+    // VerifySpanCoverage admitted the access).
+    PrimExpr CompletedCycles(const PipelineSpec &pipeline, const Buffer &orig) {
+      auto cit = ctx.counters.find(&pipeline);
+      if (cit != ctx.counters.end())
+        return BufferLoad(cit->second, {IntImm(DataType::Int(32), 0)});
+      int64_t below = 1;
+      for (const Scope *s = pipeline.sync_scope;
+           s != nullptr && s != sched_scope; s = s->sched_scope) {
+        const auto *extent = s->orig_loop.defined()
+                                 ? s->orig_loop->extent.as<IntImmNode>()
+                                 : nullptr;
+        ICHECK(extent) << "ws_schedule: an access to " << orig->name
+                       << " after pipeline '" << pipeline.name
+                       << "'s scope needs its completed cycle count, but "
+                       << "the scope's trip count is not static";
+        below *= extent->value;
+      }
+      return (LinearPhase(ctx) + IntImm(DataType::Int(32), 1)) *
+             IntImm(DataType::Int(32), below);
+    }
+
+    // One index per binding, outermost first. A depth-1 binding's slot
+    // is 0 without consulting any phase; an access outside a deeper
+    // binding's scope takes its LAST-COMPLETED version (reads only —
+    // VerifySpanCoverage rejects the rest).
+    std::vector<PrimExpr> VersionIndices(const Buffer &orig, bool is_read) {
+      std::vector<PrimExpr> out;
+      for (const PipelineSpec *p : self.buffer_pipeline_.at(orig->data)) {
+        int depth = p->depth;
+        if (depth == 1) {
+          out.push_back(IntImm(DataType::Int(32), 0));
+        } else if (sched_scope != nullptr &&
+                   sched_scope->IsNestedIn(p->sync_scope)) {
+          out.push_back(floormod(BindingPhase(*p, orig),
+                                 IntImm(DataType::Int(32), depth)));
+        } else {
+          // Outside the binding's scope, the ADJACENT version: a read
+          // the last-completed slot, a write the next-produced one.
+          PrimExpr cycle = CompletedCycles(*p, orig);
+          if (is_read)
+            cycle = cycle - IntImm(DataType::Int(32), 1);
+          out.push_back(floormod(cycle, IntImm(DataType::Int(32), depth)));
+        }
+      }
+      return out;
+    }
+
+    // The BufferLoad path below prepends the version indices to a
+    // versioned region's root load; insert matching unit extents to keep
+    // the region's indices-per-extent invariant (the op touches exactly
+    // the one acquired version of each binding).
     PrimExpr VisitExpr_(const CallNode *op) final {
+      bool is_region = op->op.same_as(region()) && op->args.size() >= 2;
+      if (is_region) {
+        // The root BufferLoad stands for the whole region; its version
+        // resolution needs the region's read/write direction.
+        const auto *mask = op->args[1].as<IntImmNode>();
+        region_write_ = mask && (mask->value & kAccessWrite);
+      }
       Call call = Downcast<Call>(StmtExprMutator::VisitExpr_(op));
+      if (is_region)
+        region_write_ = false;
       if (call->op.same_as(region()) && call->args.size() >= 2) {
         if (const auto *load = call->args[0].as<BufferLoadNode>()) {
           size_t num_extents = call->args.size() - 2;
-          if (load->indices.size() == num_extents + 1) {
+          if (load->indices.size() > num_extents) {
             Array<PrimExpr> args;
             args.push_back(call->args[0]);
             args.push_back(call->args[1]);
-            // The op touches exactly the one acquired version, so the
-            // version dimension's extent is 1.
-            args.push_back(IntImm(DataType::Int(32), 1));
+            for (size_t i = num_extents; i < load->indices.size(); ++i)
+              args.push_back(IntImm(DataType::Int(32), 1));
             for (size_t i = 2; i < call->args.size(); ++i)
               args.push_back(call->args[i]);
             return Call(call->dtype, call->op, std::move(args),
@@ -1513,45 +2187,66 @@ private:
       return call;
     }
 
+    // versioned_ is identity-keyed: a miss must mean an unpipelined
+    // storage, never an alias object the analysis did not see (that
+    // access would silently stay at version 0).
+    void CheckMissIsUnpipelined(const Buffer &buf) const {
+      ICHECK(!self.buffer_pipeline_.count(buf->data))
+          << "ws_schedule: access to '" << buf->name << "' aliases pipelined "
+          << "storage '" << buf->data->name_hint << "' through a buffer "
+          << "object the access analysis never saw; it cannot be versioned";
+    }
+
     PrimExpr VisitExpr_(const BufferLoadNode *op) final {
       BufferLoad load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
       auto vit = self.versioned_.find(load->buffer);
-      if (vit == self.versioned_.end())
+      if (vit == self.versioned_.end()) {
+        CheckMissIsUnpipelined(load->buffer);
         return load;
+      }
       Array<PrimExpr> indices;
-      indices.push_back(VersionIndex(load->buffer));
+      for (PrimExpr &v : VersionIndices(load->buffer, !region_write_))
+        indices.push_back(std::move(v));
       for (const PrimExpr &i : load->indices)
         indices.push_back(i);
-      return BufferLoad(vit->second, std::move(indices));
+      return BufferLoad(vit->second, std::move(indices), load->predicate,
+                        load->span);
     }
 
     Stmt VisitStmt_(const BufferStoreNode *op) final {
       BufferStore store =
           Downcast<BufferStore>(StmtExprMutator::VisitStmt_(op));
       auto vit = self.versioned_.find(store->buffer);
-      if (vit == self.versioned_.end())
+      if (vit == self.versioned_.end()) {
+        CheckMissIsUnpipelined(store->buffer);
         return store;
+      }
       Array<PrimExpr> indices;
-      indices.push_back(VersionIndex(store->buffer));
+      for (PrimExpr &v : VersionIndices(store->buffer, false))
+        indices.push_back(std::move(v));
       for (const PrimExpr &i : store->indices)
         indices.push_back(i);
-      return BufferStore(vit->second, store->value, std::move(indices));
+      return BufferStore(vit->second, store->value, std::move(indices),
+                         store->predicate, store->span);
     }
   };
 
-  Stmt RewriteOpStmt(const RoleCtx &ctx, Stmt stmt) const {
-    OpRewriter rewriter(*this, ctx);
+  Stmt RewriteOpStmt(const RoleCtx &ctx, Stmt stmt,
+                     const Scope *sched_scope) const {
+    OpRewriter rewriter(*this, ctx, sched_scope);
     return rewriter(std::move(stmt));
   }
 
-  PrimExpr RewriteOpExpr(const RoleCtx &ctx, PrimExpr expr) const {
-    OpRewriter rewriter(*this, ctx);
+  PrimExpr RewriteOpExpr(const RoleCtx &ctx, PrimExpr expr,
+                         const Scope *sched_scope = nullptr) const {
+    OpRewriter rewriter(*this, ctx, sched_scope);
     return rewriter(std::move(expr));
   }
 
   // Rewrite an asynchronous atom's call: swap it to its explicit async
   // op (TMA, tcgen05) or annotate it (cp.async).
-  Stmt ConvertAtomCall(const RoleCtx &ctx, const OpInfo &op, Stmt stmt) const {
+  Stmt ConvertAtomCall(const RoleCtx &ctx, const Operation &op,
+                       Stmt stmt) const {
     const auto *ev = stmt.as<EvaluateNode>();
     ICHECK(ev);
     Call call = Downcast<Call>(ev->value);
@@ -1560,17 +2255,22 @@ private:
       // The transaction completes the full barrier of the pipeline
       // protecting the destination. A copy into an unprotected buffer
       // has no barrier to wire and stays a plain copy.
-      if (op.write_def < 0)
+      if (op.write_def == nullptr)
         return stmt;
-      const PipelineSpec &pipeline = pipelines_[op.write_def];
+      const PipelineSpec &pipeline = *op.write_def;
       // Span coverage verified: the pipeline was acquired.
-      PrimExpr idx = floormod(ctx.pipeline_phase.at(op.write_def),
+      PrimExpr idx = floormod(ctx.pipeline_phase.at(&pipeline),
                               IntImm(DataType::Int(32), pipeline.depth));
       ann.Set("barrier", BufferLoad(pipeline.full, {std::move(idx)}));
       ann.Set("is_tma_copy", IntImm(DataType::Int(32), 1));
+      if (op.fused_arrive)
+        ann.Set("emit_arrive", IntImm(DataType::Int(32), 1));
       return Evaluate(Call(call->dtype, TmaCopyOp(), call->args, std::move(ann),
                            call->span));
     } else if (op.atom == OpAtom::kCpAsyncCopy) {
+      // A copy into an unprotected buffer keeps its own commit/wait.
+      if (op.write_def == nullptr)
+        return stmt;
       // Skip the copy's implicit commit_group + wait_group(0):
       // completion rides the commit entry's deferred arrive instead.
       ann.Set(attr::kAsyncCopyNoImplicitCommitWait,
@@ -1588,11 +2288,82 @@ private:
 
   // The op's source guard is NOT applied here: EmitScopeBody folds it
   // into the entry's guard.
-  Stmt EmitOp(const RoleCtx &ctx, const OpInfo &op) const {
-    Stmt body = RewriteOpStmt(ctx, Substitute(op.stmt, ctx.subs));
+  Stmt EmitOp(const RoleCtx &ctx, const Operation &op) const {
+    Stmt body = RewriteOpStmt(
+        ctx, RebindBufferData(Substitute(op.stmt, ctx.subs), ctx.subs),
+        op.sched_scope);
     if (op.atom != OpAtom::kSync)
       body = ConvertAtomCall(ctx, op, std::move(body));
     return body;
+  }
+
+  // Rebind an emitted statement's scalar defs and their uses within it.
+  struct BindDefRewriter : public StmtExprMutator {
+    const Map<Var, Var> &fresh;
+    explicit BindDefRewriter(const Map<Var, Var> &fresh) : fresh(fresh) {}
+
+    Stmt VisitStmt_(const BindNode *op) final {
+      Bind bind = Downcast<Bind>(StmtExprMutator::VisitStmt_(op));
+      if (auto replacement = fresh.Get(bind->var))
+        return Bind(replacement.value(), bind->value, bind->span);
+      return bind;
+    }
+    PrimExpr VisitExpr_(const VarNode *op) final {
+      if (auto replacement = fresh.Get(GetRef<Var>(op)))
+        return replacement.value();
+      return GetRef<PrimExpr>(op);
+    }
+  };
+
+  // tirx::Substitute rebinds a buffer's data var only where the buffer is
+  // DEFINED (IRSubstitute::VisitBufferDef); ops are emitted one statement
+  // at a time and make_tensor views carry no definition statement, so
+  // buffers on substituted handle vars are rebuilt at their use sites.
+  static Stmt RebindBufferData(Stmt stmt, const Map<Var, PrimExpr> &subs) {
+    BufferRemap remap;
+    PostOrderVisit(stmt, [&](const ffi::ObjectRef &node) {
+      Buffer buffer;
+      if (const auto *load = node.as<BufferLoadNode>())
+        buffer = load->buffer;
+      else if (const auto *store = node.as<BufferStoreNode>())
+        buffer = store->buffer;
+      else
+        return;
+      if (remap.count(buffer))
+        return;
+      auto replacement = subs.Get(buffer->data);
+      if (!replacement.has_value())
+        return;
+      if (const auto *var = replacement->as<VarNode>()) {
+        auto n = make_object<BufferNode>(*buffer.get());
+        n->data = GetRef<Var>(var);
+        remap.emplace(std::move(buffer), Buffer(std::move(n)));
+      }
+    });
+    return RemapBuffers(std::move(stmt), remap);
+  }
+
+  // Every emitted copy of an op re-binds its scalar defs with fresh vars:
+  // role branches and unrolled pipeline steps re-emit the same source
+  // statement, and each TIR var must have a single definition. Later ops
+  // of the same emitted slice see the fresh names through ctx.subs, which
+  // EmitScopeBody scopes per slice.
+  Stmt FreshenBindDefs(RoleCtx &ctx, Stmt stmt) {
+    std::vector<Var> bound;
+    PostOrderVisit(stmt, [&](const ObjectRef &node) {
+      if (const auto *bind = node.as<BindNode>())
+        bound.push_back(bind->var);
+    });
+    if (bound.empty())
+      return stmt;
+    Map<Var, Var> fresh;
+    for (const Var &var : bound) {
+      Var replacement =
+          var.copy_with_suffix("_ws" + std::to_string(fresh_bind_count_++));
+      fresh.Set(var, replacement);
+      ctx.subs.Set(var, replacement);
+    }
+    return RebindBufferData(BindDefRewriter(fresh)(std::move(stmt)), ctx.subs);
   }
 
   // Emit one (role, scope) body, keeping only entries with stage delta
@@ -1600,17 +2371,20 @@ private:
   // slice of the software pipeline this way. `base` is the step
   // expression of a for scope (an entry at delta d runs iteration
   // base - d); undefined for the root and for while scopes.
-  Array<Stmt> EmitScopeBody(RoleCtx &ctx, ScopeIndex scope_idx,
+  Array<Stmt> EmitScopeBody(RoleCtx &ctx, const Scope &scope,
                             const StagePlan &plan,
                             const Optional<PrimExpr> &base,
                             const Var &orig_loop_var, int delta_lo,
                             int delta_hi) {
-    ScopeSpec &scope = scopes_[scope_idx];
-    const std::vector<BodyEntry> &entries = scope.bodies[ctx.role_idx];
+    const std::vector<BodyEntryPtr> &entries = scope.bodies[ctx.role->index];
     if (entries.empty())
       return {};
 
+    Map<Var, PrimExpr> saved_subs = ctx.subs;
     Array<Stmt> stmts;
+    // Whether a proxy fence was emitted since the last op; only ops can
+    // add generic accesses, so subsequent arrives need no second fence.
+    bool proxy_fenced = false;
 
     // Point the substitution and phase chain at entry i's iteration
     // and return its guard (iteration bound + the op's source guard).
@@ -1629,14 +2403,12 @@ private:
         if (delta_hi < plan.shift)
           guard = iter < ctx.chain.back().extent;
       }
-      const BodyEntry &e = entries[i];
-      if (e.kind == BodyEntry::kOp) {
-        const OpInfo &op = ops_.at(e.id);
-        if (op.guard.defined()) {
-          PrimExpr src =
-              RewriteOpExpr(ctx, Substitute(op.guard.value(), ctx.subs));
-          guard = guard.defined() ? guard.value() && src : src;
-        }
+      const Operation *op =
+          entries[i]->AsScope() ? nullptr : entries[i]->AsOperation();
+      if (op != nullptr && op->guard.defined()) {
+        PrimExpr src = RewriteOpExpr(
+            ctx, Substitute(op->guard.value(), ctx.subs), op->sched_scope);
+        guard = guard.defined() ? guard.value() && src : src;
       }
       return guard;
     };
@@ -1655,7 +2427,6 @@ private:
     };
 
     for (size_t i = 0; i < entries.size(); ++i) {
-      const BodyEntry &e = entries[i];
       if (plan.delta[i] < delta_lo || plan.delta[i] > delta_hi)
         continue;
       Optional<PrimExpr> guard = focus_entry(i);
@@ -1667,22 +2438,25 @@ private:
         cur_guard = guard;
       }
       Array<Stmt> *out = cur_guard.defined() ? &guarded : &stmts;
-      if (e.kind == BodyEntry::kScope) {
-        Stmt child = EmitChildScope(ctx, ScopeIndexOf(e.id));
-        if (child.defined())
-          out->push_back(std::move(child));
-      } else if (e.kind == BodyEntry::kSync) {
-        EmitSync(ctx, e.sync, out);
+      if (const Scope *child = entries[i]->AsScope()) {
+        Stmt emitted = EmitChildScope(ctx, *child);
+        if (emitted.defined())
+          out->push_back(std::move(emitted));
+        proxy_fenced = false; // the child's ops may write generically
+      } else if (const Synchronization *sync = entries[i]->AsSync()) {
+        EmitSync(ctx, *sync, proxy_fenced, out);
       } else {
-        out->push_back(EmitOp(ctx, ops_.at(e.id)));
+        out->push_back(
+            FreshenBindDefs(ctx, EmitOp(ctx, *entries[i]->AsOperation())));
+        proxy_fenced = false;
       }
     }
     close_guard();
-    // Restore the steady-state iteration for any parent-level use.
-    if (base.defined()) {
-      ctx.subs.Set(orig_loop_var, base.value());
+    // Fresh scalar defs are slice-local; restore the caller's substitutions
+    // and the steady-state iteration for any parent-level use.
+    ctx.subs = saved_subs;
+    if (base.defined())
       ctx.chain.back().iter = base.value();
-    }
     return stmts;
   }
 
@@ -1696,14 +2470,13 @@ private:
   //   prologue step t (t = 0 .. shift-1): the entries at delta <= t;
   //   steady state:                       every entry, unguarded;
   //   epilogue step t (t = 1 .. shift):   the entries at delta >= t.
-  Stmt EmitChildScope(RoleCtx &ctx, ScopeIndex scope_idx) {
-    ScopeSpec &scope = scopes_[scope_idx];
-    if (scope.bodies[ctx.role_idx].empty())
+  Stmt EmitChildScope(RoleCtx &ctx, const Scope &scope) {
+    if (scope.bodies[ctx.role->index].empty())
       return Stmt(); // role does not participate in this scope
-    StagePlan plan = PlanStages(ctx.role_idx, scope.bodies[ctx.role_idx]);
+    StagePlan plan = PlanStages(*ctx.role, scope.bodies[ctx.role->index]);
     Stmt out = scope.orig_while.defined()
-                   ? EmitChildScopeWhileLoop(ctx, scope_idx, plan)
-                   : EmitChildScopeForLoop(ctx, scope_idx, plan);
+                   ? EmitChildScopeWhileLoop(ctx, scope, plan)
+                   : EmitChildScopeForLoop(ctx, scope, plan);
     // The uniform source guard: false skips the scope in all roles
     // together.
     if (scope.guard.defined()) {
@@ -1719,9 +2492,8 @@ private:
   // extent + t - 1 - delta iff extent > shift - t. Short and dynamic
   // extents are handled by the emitted bounds alone; the simplifier
   // folds the static cases.
-  Stmt EmitChildScopeForLoop(RoleCtx &ctx, ScopeIndex scope_idx,
+  Stmt EmitChildScopeForLoop(RoleCtx &ctx, const Scope &scope,
                              const StagePlan &plan) {
-    ScopeSpec &scope = scopes_[scope_idx];
     constexpr int kMaxDelta = std::numeric_limits<int>::max();
     PrimExpr zero = IntImm(DataType::Int(32), 0);
 
@@ -1740,13 +2512,13 @@ private:
     Array<Stmt> result;
     for (int t = 0; t < plan.shift; ++t) {
       Array<Stmt> step = EmitScopeBody(
-          ctx, scope_idx, plan, IntImm(DataType::Int(32), t), orig_var, 0, t);
+          ctx, scope, plan, IntImm(DataType::Int(32), t), orig_var, 0, t);
       for (const Stmt &stmt : step)
         result.push_back(stmt);
     }
 
     Array<Stmt> body =
-        EmitScopeBody(ctx, scope_idx, plan, fresh, orig_var, 0, kMaxDelta);
+        EmitScopeBody(ctx, scope, plan, fresh, orig_var, 0, kMaxDelta);
     // The steady state covers iterations [shift, extent). Preserve the
     // source loop kind and annotations, minus the consumed markers.
     Map<String, Any> ann =
@@ -1764,8 +2536,8 @@ private:
 
     for (int t = 1; t <= plan.shift; ++t) {
       Array<Stmt> step = EmitScopeBody(
-          ctx, scope_idx, plan, extent + IntImm(DataType::Int(32), t - 1),
-          orig_var, t, kMaxDelta);
+          ctx, scope, plan, extent + IntImm(DataType::Int(32), t - 1), orig_var,
+          t, kMaxDelta);
       // The step runs iff extent > shift - t.
       result.push_back(
           IfThenElse(IntImm(DataType::Int(32), plan.shift - t) < extent,
@@ -1779,9 +2551,8 @@ private:
   // counters). Prologue steps run under the loop condition and bump a
   // completed-trip counter; epilogue step t runs iff t <= trips, which
   // drains exactly what a short loop started.
-  Stmt EmitChildScopeWhileLoop(RoleCtx &ctx, ScopeIndex scope_idx,
+  Stmt EmitChildScopeWhileLoop(RoleCtx &ctx, const Scope &scope,
                                const StagePlan &plan) {
-    ScopeSpec &scope = scopes_[scope_idx];
     constexpr int kMaxDelta = std::numeric_limits<int>::max();
     PrimExpr zero = IntImm(DataType::Int(32), 0);
     // The condition is re-evaluated at every use.
@@ -1803,21 +2574,21 @@ private:
     };
 
     for (int t = 0; t < plan.shift; ++t) {
-      Array<Stmt> step = EmitScopeBody(ctx, scope_idx, plan,
-                                       Optional<PrimExpr>(), Var(), 0, t);
+      Array<Stmt> step =
+          EmitScopeBody(ctx, scope, plan, Optional<PrimExpr>(), Var(), 0, t);
       step.push_back(bump_trips());
       result.push_back(IfThenElse(cond(), SeqOrSingle(std::move(step))));
     }
 
-    Array<Stmt> body = EmitScopeBody(ctx, scope_idx, plan, Optional<PrimExpr>(),
+    Array<Stmt> body = EmitScopeBody(ctx, scope, plan, Optional<PrimExpr>(),
                                      Var(), 0, kMaxDelta);
     if (plan.shift > 0)
       body.push_back(bump_trips());
     result.push_back(While(cond(), SeqOrSingle(std::move(body))));
 
     for (int t = 1; t <= plan.shift; ++t) {
-      Array<Stmt> step = EmitScopeBody(
-          ctx, scope_idx, plan, Optional<PrimExpr>(), Var(), t, kMaxDelta);
+      Array<Stmt> step = EmitScopeBody(ctx, scope, plan, Optional<PrimExpr>(),
+                                       Var(), t, kMaxDelta);
       result.push_back(
           IfThenElse(IntImm(DataType::Int(32), t) <= BufferLoad(trips, {zero}),
                      SeqOrSingle(std::move(step))));
@@ -1825,11 +2596,9 @@ private:
     return SeqOrSingle(std::move(result));
   }
 
-  Stmt EmitRole(RoleIndex role_idx) {
-    const RoleSpec &role = roles_[role_idx];
+  Stmt EmitRole(const RoleSpec &role) {
     RoleCtx ctx;
     ctx.role = &role;
-    ctx.role_idx = role_idx;
 
     Array<Stmt> stmts;
     if (role.nreg > 0) {
@@ -1840,32 +2609,25 @@ private:
     }
 
     // Runtime phase counters where linearization is unsound.
-    for (PipelineIndex p = 0; p < static_cast<PipelineIndex>(pipelines_.size());
-         ++p) {
-      bool used = false;
-      for (const ScopeSpec &scope : scopes_) {
-        for (const BodyEntry &e : scope.bodies[role_idx])
-          if (e.kind == BodyEntry::kSync && e.sync.pipeline_idx == p)
-            used = true;
-      }
-      if (used && NeedsCounter(role_idx, p)) {
+    for (const auto &pipeline : pipelines_) {
+      if (NeedsCounter(role, *pipeline)) {
         Buffer cnt =
             decl_buffer({IntImm(DataType::Int(32), 1)}, DataType::Int(32),
-                        pipelines_[p].name + "_phase", "local");
-        ctx.counters[p] = cnt;
+                        pipeline->name + "_phase", "local");
+        ctx.counters[pipeline.get()] = cnt;
         stmts.push_back(AllocBuffer(cnt));
         stmts.push_back(BufferStore(cnt, IntImm(DataType::Int(32), 0),
                                     {IntImm(DataType::Int(32), 0)}));
       }
     }
 
-    ScopeIndex root = ScopeIndexOf(kWSRootScopeId);
-    StagePlan plan = PlanStages(role_idx, scopes_[root].bodies[role_idx]);
+    StagePlan plan = PlanStages(role, root_scope_->bodies[role.index]);
     ICHECK_EQ(plan.shift, 0)
         << "ws_schedule: stage offsets require a loop scope; role " << role.name
         << " has offset sync stages in its root body";
-    Array<Stmt> body = EmitScopeBody(ctx, root, plan, Optional<PrimExpr>(),
-                                     Var(), 0, std::numeric_limits<int>::max());
+    Array<Stmt> body =
+        EmitScopeBody(ctx, *root_scope_, plan, Optional<PrimExpr>(), Var(), 0,
+                      std::numeric_limits<int>::max());
     ICHECK(!body.empty()) << "ws_schedule: role " << role.name
                           << " has an empty root body";
     for (const Stmt &s : body)
@@ -1902,15 +2664,14 @@ private:
       }
     };
     int cursor = 0;
-    for (size_t ri = 0; ri < roles_.size(); ++ri) {
-      const RoleSpec &role = roles_[ri];
-      ICHECK_GE(role.warp_lo, cursor)
+    for (const auto &role : roles_) {
+      ICHECK_GE(role->warp_lo, cursor)
           << "ws_schedule: overlapping role warp ranges";
-      fill_idle(cursor, role.warp_lo);
+      fill_idle(cursor, role->warp_lo);
       conds.push_back(thread_var_ <
-                      IntImm(DataType::Int(32), role.warp_hi * 32));
-      branches.push_back(EmitRole(static_cast<RoleIndex>(ri)));
-      cursor = role.warp_hi;
+                      IntImm(DataType::Int(32), role->warp_hi * 32));
+      branches.push_back(EmitRole(*role));
+      cursor = role->warp_hi;
     }
     fill_idle(cursor, num_warps_);
     Stmt body = branches[branches.size() - 1];
@@ -1935,18 +2696,18 @@ private:
       allocs.push_back(vit == versioned_.end() ? buf : vit->second);
     }
     Map<Var, Array<PrimExpr>> barrier_init;
-    for (const PipelineSpec &pipeline : pipelines_) {
-      allocs.push_back(pipeline.full);
-      allocs.push_back(pipeline.empty);
+    for (const auto &pipeline : pipelines_) {
+      allocs.push_back(pipeline->full);
+      allocs.push_back(pipeline->empty);
       Array<PrimExpr> full_counts, empty_counts;
-      for (int i = 0; i < pipeline.depth; ++i) {
+      for (int i = 0; i < pipeline->depth; ++i) {
         full_counts.push_back(
-            IntImm(DataType::Int(32), pipeline.full_plan.count));
+            IntImm(DataType::Int(32), pipeline->full_plan.count));
         empty_counts.push_back(
-            IntImm(DataType::Int(32), pipeline.empty_plan.count));
+            IntImm(DataType::Int(32), pipeline->empty_plan.count));
       }
-      barrier_init.Set(pipeline.full->data, std::move(full_counts));
-      barrier_init.Set(pipeline.empty->data, std::move(empty_counts));
+      barrier_init.Set(pipeline->full->data, std::move(full_counts));
+      barrier_init.Set(pipeline->empty->data, std::move(empty_counts));
     }
 
     SBlock new_block = block_;
@@ -1969,7 +2730,10 @@ private:
       if (auto lm_opt = lm_ref.value().as<Map<Var, Layout>>()) {
         Map<Var, Layout> layout_map = lm_opt.value();
         bool changed = false;
+        VarSet expanded_storage;
         for (const auto &[orig, versioned] : versioned_) {
+          if (!expanded_storage.insert(orig->data).second)
+            continue;
           auto entry = layout_map.Get(orig->data);
           if (!entry.has_value())
             continue;
@@ -1991,15 +2755,18 @@ private:
   Var thread_var_;
   Target target_;
   int num_warps_ = 0;
-  std::vector<RoleSpec> roles_;
-  std::vector<PipelineSpec> pipelines_;
-  std::vector<ScopeSpec> scopes_;
-  std::map<String, OpInfo> ops_;
+  std::vector<std::unique_ptr<RoleSpec>> roles_;
+  std::vector<std::unique_ptr<PipelineSpec>> pipelines_;
+  std::vector<std::shared_ptr<Scope>> scopes_;
+  Scope *root_scope_ = nullptr;
+  std::map<String, std::shared_ptr<Operation>> ops_;
   // Kernel-level metadata AttrStmts, re-wrapped around the rebuilt body.
   std::vector<AttrStmt> metadata_attrs_;
   // Per-warpgroup register request (index = warp / 4, 0 = none).
   std::vector<int> warpgroup_nreg_;
-  BufferDefMap buffer_pipeline_;
+  // Suffix counter making every emitted Bind definition unique.
+  int fresh_bind_count_ = 0;
+  StoragePipelineMap buffer_pipeline_;
   BufferVersionMap versioned_;
 };
 

--- a/src/cuda/transform/producer_consumer_ws.cc
+++ b/src/cuda/transform/producer_consumer_ws.cc
@@ -45,6 +45,7 @@
 #include "op/operator.h"
 #include "op/utils.h"
 #include "transform/common/mbarrier.h"
+#include "ws_analysis.h"
 
 namespace tvm {
 namespace tl {
@@ -150,18 +151,16 @@ private:
 // Statement classification
 // ---------------------------------------------------------------------------
 
+// BufferLayoutMap / TileStmtKind and the statement classifiers live in
+// ws_analysis.h, shared with the automatic schedulers.
 using BufferDataToBufferMap =
     std::unordered_map<Var, Buffer, ObjectPtrHash, ObjectPtrEqual>;
 using BufferSet = std::unordered_set<Buffer, ObjectPtrHash, ObjectPtrEqual>;
 using VarSet = std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual>;
-using BufferMap =
-    std::unordered_map<Buffer, Buffer, ObjectPtrHash, ObjectPtrEqual>;
 using VarExprMap =
     std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual>;
 using StmtRewriteMap =
     std::unordered_map<Stmt, Stmt, ObjectPtrHash, ObjectPtrEqual>;
-using BufferLayoutMap = std::unordered_map<Var, std::pair<Buffer, Layout>,
-                                           ObjectPtrHash, ObjectPtrEqual>;
 
 struct LocalAccessSummary {
   BufferSet read_buffers;
@@ -219,144 +218,6 @@ static Buffer CloneBranchPrivateBuffer(const Buffer &buffer,
                 buffer->elem_offset, buffer->name + suffix,
                 buffer->data_alignment, buffer->offset_factor,
                 buffer->buffer_type);
-}
-
-class BufferRemapper : public StmtExprMutator {
-public:
-  static Stmt Rewrite(const Stmt &stmt, const BufferMap &buffer_remap) {
-    if (buffer_remap.empty()) {
-      return stmt;
-    }
-    BufferRemapper remapper(buffer_remap);
-    return remapper.VisitStmt(stmt);
-  }
-
-private:
-  explicit BufferRemapper(const BufferMap &buffer_remap)
-      : buffer_remap_(buffer_remap) {
-    for (const auto &[old_buf, new_buf] : buffer_remap_) {
-      var_remap_.emplace(old_buf->data, new_buf->data);
-    }
-  }
-
-  Buffer RemapBuffer(const Buffer &buffer) const {
-    auto it = buffer_remap_.find(buffer);
-    if (it != buffer_remap_.end()) {
-      return it->second;
-    }
-    return buffer;
-  }
-
-  PrimExpr VisitExpr_(const VarNode *op) final {
-    auto it = var_remap_.find(ffi::GetRef<Var>(op));
-    if (it != var_remap_.end()) {
-      return it->second;
-    }
-    return StmtExprMutator::VisitExpr_(op);
-  }
-
-  PrimExpr VisitExpr_(const BufferLoadNode *op) final {
-    BufferLoad load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
-    Buffer new_buffer = RemapBuffer(load->buffer);
-    if (!new_buffer.same_as(load->buffer)) {
-      return BufferLoad(new_buffer, load->indices, load->predicate, load->span);
-    }
-    return load;
-  }
-
-  Stmt VisitStmt_(const BufferStoreNode *op) final {
-    BufferStore store = Downcast<BufferStore>(StmtExprMutator::VisitStmt_(op));
-    Buffer new_buffer = RemapBuffer(store->buffer);
-    if (!new_buffer.same_as(store->buffer)) {
-      return BufferStore(new_buffer, store->value, store->indices,
-                         store->predicate, store->span);
-    }
-    return store;
-  }
-
-  const BufferMap &buffer_remap_;
-  VarExprMap var_remap_;
-};
-
-enum class TileStmtKind {
-  kTmaProducer,     // TMA load producer (global->shared)
-  kCpAsyncProducer, // Explicit cp.async / commit / wait_group producer stmt
-  kSimtProducer, // Non-tile-op SIMT copy: For loop writing shared from global
-  kConsumer,     // Compute (gemm, reduce, element-wise, etc.)
-  kOther         // Unclassified
-};
-
-/// Detect if a statement is a SIMT global-to-shared memory copy.
-/// Matches any statement that writes to shared memory and reads from global
-/// memory, without reading shared or local buffers (which would indicate
-/// consumer-side compute).  This is intentionally broader than "pure direct
-/// copy" so that T.Parallel with complex indexing / if_then_else (later
-/// lowered to cp.async) is also captured.
-class SimtProducerDetector : public StmtExprVisitor {
-public:
-  static bool Detect(const Stmt &stmt) {
-    SimtProducerDetector d;
-    d(stmt);
-    return d.writes_shared_ && d.reads_global_ && !d.reads_shared_local_;
-  }
-
-private:
-  void VisitStmt_(const BufferStoreNode *op) final {
-    if (IsSharedBuffer(op->buffer)) {
-      writes_shared_ = true;
-    }
-    StmtExprVisitor::VisitStmt_(op);
-  }
-
-  void VisitExpr_(const BufferLoadNode *op) final {
-    if (IsGlobalBuffer(op->buffer)) {
-      reads_global_ = true;
-    }
-    if (IsSharedBuffer(op->buffer) || IsLocalBuffer(op->buffer, true)) {
-      reads_shared_local_ = true;
-    }
-    StmtExprVisitor::VisitExpr_(op);
-  }
-
-  bool writes_shared_{false};
-  bool reads_global_{false};
-  bool reads_shared_local_{false};
-};
-
-class EvaluateCallInSimpleWrapperExtractor
-    : public StmtFunctor<Optional<Call>(const Stmt &)> {
-public:
-  Optional<Call> VisitStmt_(const EvaluateNode *op) final {
-    return op->value.as<Call>();
-  }
-
-  Optional<Call> VisitStmt_(const IfThenElseNode *op) final {
-    if (op->else_case.defined()) {
-      return Optional<Call>();
-    }
-    return VisitStmt(op->then_case);
-  }
-
-  Optional<Call> VisitStmt_(const AttrStmtNode *op) final {
-    return VisitStmt(op->body);
-  }
-
-  Optional<Call> VisitStmt_(const SBlockNode *op) final {
-    return VisitStmt(op->body);
-  }
-
-  Optional<Call> VisitStmt_(const SBlockRealizeNode *op) final {
-    return VisitStmt(op->block->body);
-  }
-
-  Optional<Call> VisitStmtDefault_(const Object *) final {
-    return Optional<Call>();
-  }
-};
-
-static Optional<Call> GetEvaluateCallInSimpleWrapper(const Stmt &stmt) {
-  EvaluateCallInSimpleWrapperExtractor extractor;
-  return extractor(stmt);
 }
 
 class BufferDataToBufferCollector : public StmtExprVisitor {
@@ -617,59 +478,9 @@ ClassifyPreludeStmt(const Stmt &stmt, const BufferDataToBufferMap &buffer_map,
   return PreludeStmtPlacement::kKeepSharedPrelude;
 }
 
-static bool ContainsPtxCpAsync(const Stmt &stmt) {
-  bool found = false;
-  PostOrderVisit(stmt, [&](const ObjectRef &node) {
-    if (found) {
-      return;
-    }
-    if (const auto *call = node.as<CallNode>()) {
-      if (call->op.same_as(builtin::ptx_cp_async()) ||
-          call->op.same_as(tl::ptx_cp_async())) {
-        found = true;
-      }
-    }
-  });
-  return found;
-}
-
-static bool IsPtxCommitGroup(const Stmt &stmt) {
-  Optional<Call> call = GetEvaluateCallInSimpleWrapper(stmt);
-  return call.defined() &&
-         call.value()->op.same_as(builtin::ptx_commit_group());
-}
-
-static bool IsPtxWaitGroup(const Stmt &stmt) {
-  Optional<Call> call = GetEvaluateCallInSimpleWrapper(stmt);
-  return call.defined() && call.value()->op.same_as(builtin::ptx_wait_group());
-}
-
-static bool IsBarrierOrTmaControlCall(const CallNode *call) {
-  return call->op.same_as(mbarrier_wait_parity()) ||
-         call->op.same_as(mbarrier_expect_tx()) ||
-         call->op.same_as(builtin::ptx_arrive_barrier()) ||
-         call->op.same_as(tl::ptx_arrive_cluster_barrier()) ||
-         call->op.same_as(builtin::ptx_arrive_barrier_expect_tx()) ||
-         call->op.same_as(builtin::ptx_cp_async_barrier()) ||
-         call->op.same_as(tl::ptx_cp_async_barrier_noinc()) ||
-         call->op.same_as(tma_load()) || call->op.same_as(tma_load_im2col()) ||
-         call->op.same_as(tma_store()) ||
-         call->op.same_as(tma_store_arrive()) ||
-         call->op.same_as(tma_store_wait()) ||
-         call->op.same_as(builtin::tvm_storage_sync());
-}
-
 static bool HasGlobalToSharedCopyShape(const CopyNode *copy) {
   return copy != nullptr && IsGlobalBuffer(copy->src) &&
          IsSharedBuffer(copy->dst) && copy->src->dtype == copy->dst->dtype;
-}
-
-static cuda::CopyInstSelection ClassifyWarpSpecializedCopy(const CopyNode *copy,
-                                                           Target target) {
-  if (copy == nullptr) {
-    return {cuda::CopyInst::kNormal, true, ""};
-  }
-  return cuda::ClassifyWarpSpecializedProducerCopy(*copy, target);
 }
 
 static bool CheckPipelineManagedCPAsyncCopy(const CopyNode *copy,
@@ -694,9 +505,11 @@ static bool IsSyncGlobalToSharedCopyLikeStmt(const Stmt &stmt, Target target) {
     return false;
   }
 
-  cuda::CopyInstSelection result = ClassifyWarpSpecializedCopy(copy, target);
+  cuda::CopyInstSelection result =
+      cuda::ClassifyWarpSpecializedCopy(*copy, target);
   return HasGlobalToSharedCopyShape(copy) && result.supported &&
-         !cuda::CopyInstIsTMA(result.inst) &&
+         !cuda::CopyInstIsTMALoad(result.inst) &&
+         !cuda::CopyInstIsTMAStore(result.inst) &&
          !cuda::CopyInstIsCPAsync(result.inst);
 }
 
@@ -745,63 +558,6 @@ static bool IsProducerMovableLoopPrefixStmt(const Stmt &stmt, Target target) {
     }
   });
   return has_allowed_work && !has_disallowed;
-}
-
-/// Classify a tile-op copy as TMA load producer, cp.async producer, or
-/// consumer using coarse pre-layout checks.
-static TileStmtKind ClassifyCopy(const CopyNode *copy, Target target) {
-  if (copy == nullptr) {
-    return TileStmtKind::kConsumer;
-  }
-
-  cuda::CopyInstSelection result = ClassifyWarpSpecializedCopy(copy, target);
-  if (cuda::CopyInstIsTMA(result.inst)) {
-    return TileStmtKind::kTmaProducer;
-  }
-  if (cuda::CopyInstIsCPAsync(result.inst)) {
-    return TileStmtKind::kCpAsyncProducer;
-  }
-
-  return TileStmtKind::kConsumer;
-}
-
-/// Classify a single statement in the pipeline loop body.
-TileStmtKind ClassifyStmt(const Stmt &stmt, Target target) {
-  // Tile-op Calls: classify directly via CopyNode checks.
-  if (auto *eval = stmt.as<EvaluateNode>()) {
-    if (auto *call = eval->value.as<CallNode>()) {
-      auto tile_op = ParseOperator(GetRef<Call>(call));
-      if (tile_op.defined()) {
-        if (auto *copy = tile_op.as<CopyNode>()) {
-          return ClassifyCopy(copy, target);
-        }
-        // Im2Col lowers to tma_load_im2col on Hopper — treat as TMA
-        // producer so it goes to the producer warp group.
-        if (tile_op.as<Im2ColOpNode>()) {
-          if (TargetIsHopper(target)) {
-            return TileStmtKind::kTmaProducer;
-          }
-        }
-        return TileStmtKind::kConsumer; // non-copy tile-op
-      }
-    }
-  }
-  // Explicit cp.async producer-side statements are already low-level builtins.
-  if (ContainsPtxCpAsync(stmt) || IsPtxCommitGroup(stmt) ||
-      IsPtxWaitGroup(stmt)) {
-    return TileStmtKind::kCpAsyncProducer;
-  }
-  // Non-tile-op: check for SIMT global-to-shared copy.
-  if (SimtProducerDetector::Detect(stmt)) {
-    return TileStmtKind::kSimtProducer;
-  }
-  return TileStmtKind::kConsumer;
-}
-
-bool IsProducer(TileStmtKind kind) {
-  return kind == TileStmtKind::kTmaProducer ||
-         kind == TileStmtKind::kCpAsyncProducer ||
-         kind == TileStmtKind::kSimtProducer;
 }
 
 // ---------------------------------------------------------------------------
@@ -1444,7 +1200,7 @@ private:
         ++num_producer_groups;
       if (k == TileStmtKind::kSimtProducer)
         has_simt_producer = true;
-      if (k == TileStmtKind::kCpAsyncProducer)
+      if (k == TileStmtKind::kCpAsyncProducer || k == TileStmtKind::kCpAsyncRaw)
         has_cp_async_producer = true;
     }
 
@@ -1540,7 +1296,8 @@ private:
       int earliest_async_read = static_cast<int>(consumer_compute_stmts.size());
       for (size_t i = 0; i < flat_stmts.size(); ++i) {
         if (kinds[i] != TileStmtKind::kSimtProducer &&
-            kinds[i] != TileStmtKind::kCpAsyncProducer) {
+            kinds[i] != TileStmtKind::kCpAsyncProducer &&
+            kinds[i] != TileStmtKind::kCpAsyncRaw) {
           continue;
         }
         int first_read = FindFirstAsyncProducerConsumerRead(
@@ -2033,7 +1790,7 @@ private:
     // LayoutInference: a single fragment layout cannot represent both thread
     // ranges. Clone every branch-private buffer touched by the producer so
     // LayoutInference can infer an independent producer-side thread range.
-    BufferMap producer_buffer_remap;
+    BufferRemap producer_buffer_remap;
     Array<Buffer> producer_private_buffers;
     {
       BufferSet block_alloc_buffers;
@@ -2067,11 +1824,11 @@ private:
     }
     if (!producer_buffer_remap.empty()) {
       rewritten_producer =
-          BufferRemapper::Rewrite(rewritten_producer, producer_buffer_remap);
+          RemapBuffers(rewritten_producer, producer_buffer_remap);
       Array<Stmt> remapped_producer_init;
       for (const auto &stmt : extracted_producer_init_) {
         remapped_producer_init.push_back(
-            BufferRemapper::Rewrite(stmt, producer_buffer_remap));
+            RemapBuffers(stmt, producer_buffer_remap));
       }
       extracted_producer_init_ = remapped_producer_init;
     }
@@ -2701,47 +2458,9 @@ private:
 // Detect if manual WS is already present (skip if so)
 // ---------------------------------------------------------------------------
 
-class ManualWSDetector : public StmtExprVisitor {
-public:
-  static bool HasManualWS(const Stmt &stmt) {
-    ManualWSDetector d;
-    d(stmt);
-    return d.found_;
-  }
-
-private:
-  void VisitStmt_(const AttrStmtNode *op) final {
-    // Detect both the T.ws() language-level attr ("warp_specialize") and
-    // the compiler-level attr (kWarpSpecializationScope).
-    if (op->attr_key == "warp_specialize" ||
-        op->attr_key == attr::kWarpSpecializationScope) {
-      found_ = true;
-      return;
-    }
-    StmtExprVisitor::VisitStmt_(op);
-  }
-
-  bool found_{false};
-};
-
 /// Quick pre-scan: check if the function contains a pipelined loop (num_stages
 /// >= 1) with at least one TMA load producer tile op and no manual layout
 /// annotations (which are incompatible with early MVB expansion).
-/// Check whether a layout annotation on a shared buffer is compatible with
-/// TMA.  TMA supports identity (linear) layouts and the three standard
-/// swizzle modes (32B / 64B / 128B).  Any other layout (e.g. padded,
-/// Volta-style) cannot be used with TMA.
-static bool IsTmaCompatibleLayout(const Layout &layout, const Buffer &buffer) {
-  Optional<cute::ComposedLayout> composed =
-      cute::ComposedLayoutFromTileLang(layout);
-  if (!composed.defined())
-    return false;
-  // Recast to byte space (the swizzle atom is defined on byte addresses).
-  cute::ComposedLayout composed_bytes =
-      composed.value().Recast(buffer->dtype.bits(), /*new_bits=*/8);
-  return composed_bytes->swizzle->IsTMACompatible();
-}
-
 class TiledWSCandidate : public StmtExprVisitor {
 public:
   static bool Check(const Stmt &stmt, Target target) {
@@ -2786,26 +2505,7 @@ private:
 
   void VisitStmt_(const SBlockNode *op) final {
     // Collect layout_map entries so we can cross-check TMA copy targets.
-    if (op->annotations.count("layout_map")) {
-      auto anno = op->annotations.Get("layout_map");
-      if (auto gmap = anno->as<Map<ObjectRef, ObjectRef>>(); gmap.has_value()) {
-        for (const auto &[key, val] : gmap.value()) {
-          Layout layout;
-          if (auto l = val.as<Layout>(); l.has_value())
-            layout = l.value();
-          if (auto buf = key.as<Buffer>(); buf.has_value()) {
-            layout_map_[buf.value()->data] = {buf.value(), layout};
-          } else if (auto var = key.as<Var>(); var.has_value()) {
-            for (const auto &buf : op->alloc_buffers) {
-              if (buf->data.same_as(var.value())) {
-                layout_map_[buf->data] = {buf, layout};
-                break;
-              }
-            }
-          }
-        }
-      }
-    }
+    CollectAnnotatedLayouts(GetRef<SBlock>(op), layout_map_);
     StmtExprVisitor::VisitStmt_(op);
   }
 
@@ -2846,7 +2546,7 @@ tvm::transform::Pass ProducerConsumerWarpSpecialized() {
       return f;
     }
     // Skip if the function already has manual WS.
-    if (ManualWSDetector::HasManualWS(f->body)) {
+    if (HasManualWarpSpecialization(f->body)) {
       return f;
     }
     // Skip if TMA is not available.

--- a/src/cuda/transform/producer_consumer_ws.cc
+++ b/src/cuda/transform/producer_consumer_ws.cc
@@ -1505,7 +1505,8 @@ private:
         // commit+wait — the WS pass will emit its own commit+barrier_noinc.
         simt_producer_stmts.push_back(
             SimtProducerAnnotator::Annotate(flat_stmts[i], target_));
-      } else if (kinds[i] == TileStmtKind::kCpAsyncProducer) {
+      } else if (kinds[i] == TileStmtKind::kCpAsyncProducer ||
+                 kinds[i] == TileStmtKind::kCpAsyncRaw) {
         simt_producer_stmts.push_back(flat_stmts[i]);
       }
     }

--- a/src/cuda/transform/ws_analysis.cc
+++ b/src/cuda/transform/ws_analysis.cc
@@ -1,0 +1,345 @@
+/*!
+ * \file ws_analysis.cc
+ * \brief Statement analysis shared by the warp-specialization passes.
+ */
+
+#include "./ws_analysis.h"
+
+#include <tvm/tirx/builtin.h>
+#include <tvm/tirx/stmt_functor.h>
+
+#include "cuda/op/builtin.h"
+#include "cuda/op/copy.h"
+#include "cuda/target_utils.h"
+#include "layout/cute_layout.h"
+#include "op/gemm.h"
+#include "op/gemm_sp.h"
+#include "op/operator.h"
+#include "op/utils.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace ffi;
+
+namespace {
+
+/// Detect if a statement is a SIMT global-to-shared memory copy.
+/// Matches any statement that writes to shared memory and reads from global
+/// memory, without reading shared or local buffers (which would indicate
+/// consumer-side compute).  This is intentionally broader than "pure direct
+/// copy" so that T.Parallel with complex indexing / if_then_else (later
+/// lowered to cp.async) is also captured.
+class SimtProducerDetector : public StmtExprVisitor {
+public:
+  static bool Detect(const Stmt &stmt) {
+    SimtProducerDetector d;
+    d(stmt);
+    return d.writes_shared_ && d.reads_global_ && !d.reads_shared_local_;
+  }
+
+private:
+  void VisitStmt_(const BufferStoreNode *op) final {
+    if (IsSharedBuffer(op->buffer)) {
+      writes_shared_ = true;
+    }
+    StmtExprVisitor::VisitStmt_(op);
+  }
+
+  void VisitExpr_(const BufferLoadNode *op) final {
+    if (IsGlobalBuffer(op->buffer)) {
+      reads_global_ = true;
+    }
+    if (IsSharedBuffer(op->buffer) || IsLocalBuffer(op->buffer, true)) {
+      reads_shared_local_ = true;
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  bool writes_shared_{false};
+  bool reads_global_{false};
+  bool reads_shared_local_{false};
+};
+
+class EvaluateCallInSimpleWrapperExtractor
+    : public StmtFunctor<Optional<Call>(const Stmt &)> {
+public:
+  Optional<Call> VisitStmt_(const EvaluateNode *op) final {
+    return op->value.as<Call>();
+  }
+
+  Optional<Call> VisitStmt_(const IfThenElseNode *op) final {
+    if (op->else_case.defined()) {
+      return Optional<Call>();
+    }
+    return VisitStmt(op->then_case);
+  }
+
+  Optional<Call> VisitStmt_(const AttrStmtNode *op) final {
+    return VisitStmt(op->body);
+  }
+
+  Optional<Call> VisitStmt_(const SBlockNode *op) final {
+    return VisitStmt(op->body);
+  }
+
+  Optional<Call> VisitStmt_(const SBlockRealizeNode *op) final {
+    return VisitStmt(op->block->body);
+  }
+
+  Optional<Call> VisitStmtDefault_(const Object *) final {
+    return Optional<Call>();
+  }
+};
+
+class BufferRemapper : public StmtExprMutator {
+public:
+  static Stmt Rewrite(Stmt stmt, const BufferRemap &buffer_remap) {
+    if (buffer_remap.empty()) {
+      return stmt;
+    }
+    BufferRemapper remapper(buffer_remap);
+    return remapper.VisitStmt(stmt);
+  }
+
+private:
+  explicit BufferRemapper(const BufferRemap &buffer_remap)
+      : buffer_remap_(buffer_remap) {
+    for (const auto &[old_buf, new_buf] : buffer_remap_) {
+      var_remap_.emplace(old_buf->data, new_buf->data);
+    }
+  }
+
+  Buffer RemapBuffer(const Buffer &buffer) const {
+    auto it = buffer_remap_.find(buffer);
+    if (it != buffer_remap_.end()) {
+      return it->second;
+    }
+    return buffer;
+  }
+
+  PrimExpr VisitExpr_(const VarNode *op) final {
+    auto it = var_remap_.find(ffi::GetRef<Var>(op));
+    if (it != var_remap_.end()) {
+      return it->second;
+    }
+    return StmtExprMutator::VisitExpr_(op);
+  }
+
+  PrimExpr VisitExpr_(const BufferLoadNode *op) final {
+    BufferLoad load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
+    Buffer new_buffer = RemapBuffer(load->buffer);
+    if (!new_buffer.same_as(load->buffer)) {
+      return BufferLoad(new_buffer, load->indices, load->predicate, load->span);
+    }
+    return load;
+  }
+
+  Stmt VisitStmt_(const BufferStoreNode *op) final {
+    BufferStore store = Downcast<BufferStore>(StmtExprMutator::VisitStmt_(op));
+    Buffer new_buffer = RemapBuffer(store->buffer);
+    if (!new_buffer.same_as(store->buffer)) {
+      return BufferStore(new_buffer, store->value, store->indices,
+                         store->predicate, store->span);
+    }
+    return store;
+  }
+
+  const BufferRemap &buffer_remap_;
+  std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual> var_remap_;
+};
+
+class ManualWSDetector : public StmtExprVisitor {
+public:
+  static bool HasManualWS(const Stmt &stmt) {
+    ManualWSDetector d;
+    d(stmt);
+    return d.found_;
+  }
+
+private:
+  void VisitStmt_(const AttrStmtNode *op) final {
+    // Detect both the T.ws() language-level attr ("warp_specialize") and
+    // the compiler-level attr (kWarpSpecializationScope).
+    if (op->attr_key == "warp_specialize" ||
+        op->attr_key == attr::kWarpSpecializationScope) {
+      found_ = true;
+      return;
+    }
+    StmtExprVisitor::VisitStmt_(op);
+  }
+
+  bool found_{false};
+};
+
+} // namespace
+
+Optional<Call> GetEvaluateCallInSimpleWrapper(const Stmt &stmt) {
+  EvaluateCallInSimpleWrapperExtractor extractor;
+  return extractor(stmt);
+}
+
+static bool ContainsPtxCpAsync(const Stmt &stmt) {
+  bool found = false;
+  PostOrderVisit(stmt, [&](const ObjectRef &node) {
+    if (found) {
+      return;
+    }
+    if (const auto *call = node.as<CallNode>()) {
+      if (call->op.same_as(builtin::ptx_cp_async()) ||
+          call->op.same_as(tl::ptx_cp_async())) {
+        found = true;
+      }
+    }
+  });
+  return found;
+}
+
+static bool IsPtxCommitGroup(const Stmt &stmt) {
+  Optional<Call> call = GetEvaluateCallInSimpleWrapper(stmt);
+  return call.defined() &&
+         call.value()->op.same_as(builtin::ptx_commit_group());
+}
+
+static bool IsPtxWaitGroup(const Stmt &stmt) {
+  Optional<Call> call = GetEvaluateCallInSimpleWrapper(stmt);
+  return call.defined() && call.value()->op.same_as(builtin::ptx_wait_group());
+}
+
+bool IsBarrierOrTmaControlCall(const CallNode *call) {
+  return call->op.same_as(mbarrier_wait_parity()) ||
+         call->op.same_as(mbarrier_expect_tx()) ||
+         call->op.same_as(builtin::ptx_arrive_barrier()) ||
+         call->op.same_as(tl::ptx_arrive_cluster_barrier()) ||
+         call->op.same_as(builtin::ptx_arrive_barrier_expect_tx()) ||
+         call->op.same_as(builtin::ptx_cp_async_barrier()) ||
+         call->op.same_as(tl::ptx_cp_async_barrier_noinc()) ||
+         call->op.same_as(tma_load()) || call->op.same_as(tma_load_im2col()) ||
+         call->op.same_as(tma_store()) ||
+         call->op.same_as(tma_store_arrive()) ||
+         call->op.same_as(tma_store_wait()) ||
+         call->op.same_as(builtin::tvm_storage_sync()) ||
+         call->op.same_as(tl::sync_grid()) ||
+         call->op.same_as(tl::syncthreads_count()) ||
+         call->op.same_as(tl::syncthreads_and()) ||
+         call->op.same_as(tl::syncthreads_or());
+}
+
+std::optional<GemmInfo> GetGemmInfo(const TileOperator &op) {
+  if (const auto *gemm = op.as<GemmNode>())
+    return GemmInfo{gemm->cRegion_->buffer, gemm->wgWait_};
+  if (const auto *gemm = op.as<GemmSPNode>())
+    return GemmInfo{gemm->cRegion_->buffer, gemm->wg_wait};
+  return std::nullopt;
+}
+
+TileStmtKind ClassifyCopy(const CopyNode *copy, Target target) {
+  if (copy == nullptr) {
+    return TileStmtKind::kConsumer;
+  }
+  cuda::CopyInstSelection result =
+      cuda::ClassifyWarpSpecializedCopy(*copy, target);
+  if (!result.supported) {
+    return TileStmtKind::kConsumer;
+  }
+  if (cuda::CopyInstIsTMAStore(result.inst)) {
+    return TileStmtKind::kTmaStore;
+  }
+  if (cuda::CopyInstIsTMALoad(result.inst)) {
+    return TileStmtKind::kTmaProducer;
+  }
+  if (cuda::CopyInstIsCPAsync(result.inst)) {
+    return TileStmtKind::kCpAsyncProducer;
+  }
+  return TileStmtKind::kConsumer;
+}
+
+TileStmtKind ClassifyStmt(const Stmt &stmt, Target target) {
+  // Tile-op Calls: classify directly via CopyNode checks.
+  if (auto *eval = stmt.as<EvaluateNode>()) {
+    if (auto *call = eval->value.as<CallNode>()) {
+      auto tile_op = ParseOperator(GetRef<Call>(call));
+      if (tile_op.defined()) {
+        if (auto *copy = tile_op.as<CopyNode>()) {
+          return ClassifyCopy(copy, target);
+        }
+        // Im2Col lowers to tma_load_im2col on Hopper — treat as TMA
+        // producer so it goes to the producer warp group.
+        if (tile_op.as<Im2ColOpNode>()) {
+          if (TargetIsHopper(target)) {
+            return TileStmtKind::kTmaProducer;
+          }
+        }
+        if (auto gemm = GetGemmInfo(tile_op)) {
+          if (IsTmemBuffer(gemm->accumulator)) {
+            return TileStmtKind::kTcgen05Mma;
+          }
+        }
+        return TileStmtKind::kConsumer; // non-copy tile-op
+      }
+    }
+  }
+  // Explicit cp.async producer-side statements are already low-level builtins.
+  if (ContainsPtxCpAsync(stmt) || IsPtxCommitGroup(stmt) ||
+      IsPtxWaitGroup(stmt)) {
+    return TileStmtKind::kCpAsyncRaw;
+  }
+  // Non-tile-op: check for SIMT global-to-shared copy.
+  if (SimtProducerDetector::Detect(stmt)) {
+    return TileStmtKind::kSimtProducer;
+  }
+  return TileStmtKind::kConsumer;
+}
+
+bool IsProducer(TileStmtKind kind) {
+  return kind == TileStmtKind::kTmaProducer ||
+         kind == TileStmtKind::kCpAsyncProducer ||
+         kind == TileStmtKind::kCpAsyncRaw ||
+         kind == TileStmtKind::kSimtProducer;
+}
+
+bool HasManualWarpSpecialization(const Stmt &stmt) {
+  return ManualWSDetector::HasManualWS(stmt);
+}
+
+Stmt RemapBuffers(Stmt stmt, const BufferRemap &remap) {
+  return BufferRemapper::Rewrite(std::move(stmt), remap);
+}
+
+bool IsTmaCompatibleLayout(const Layout &layout, const Buffer &buffer) {
+  Optional<cute::ComposedLayout> composed =
+      cute::ComposedLayoutFromTileLang(layout);
+  if (!composed.defined())
+    return false;
+  // Recast to byte space (the swizzle atom is defined on byte addresses).
+  cute::ComposedLayout composed_bytes =
+      composed.value().Recast(buffer->dtype.bits(), /*new_bits=*/8);
+  return composed_bytes->swizzle->IsTMACompatible();
+}
+
+void CollectAnnotatedLayouts(const SBlock &block, BufferLayoutMap &layouts) {
+  auto anno = block->annotations.Get("layout_map");
+  if (!anno.has_value())
+    return;
+  auto gmap = anno->as<Map<ObjectRef, ObjectRef>>();
+  if (!gmap.has_value())
+    return;
+  for (const auto &[key, val] : gmap.value()) {
+    Layout layout;
+    if (auto l = val.as<Layout>(); l.has_value())
+      layout = l.value();
+    if (auto buf = key.as<Buffer>(); buf.has_value()) {
+      layouts[buf.value()->data] = {buf.value(), layout};
+    } else if (auto var = key.as<Var>(); var.has_value()) {
+      for (const auto &buf : block->alloc_buffers) {
+        if (buf->data.same_as(var.value())) {
+          layouts[buf->data] = {buf, layout};
+          break;
+        }
+      }
+    }
+  }
+}
+
+} // namespace tl
+} // namespace tvm

--- a/src/cuda/transform/ws_analysis.cc
+++ b/src/cuda/transform/ws_analysis.cc
@@ -207,15 +207,23 @@ static bool IsPtxWaitGroup(const Stmt &stmt) {
 }
 
 bool IsBarrierOrTmaControlCall(const CallNode *call) {
+  // TODO: support warp specialization for cluster kernels and for TMA
+  // gather4 / scatter4 (their raw intrinsics and hand protocols decline).
   return call->op.same_as(mbarrier_wait_parity()) ||
          call->op.same_as(mbarrier_expect_tx()) ||
          call->op.same_as(builtin::ptx_arrive_barrier()) ||
          call->op.same_as(tl::ptx_arrive_cluster_barrier()) ||
          call->op.same_as(builtin::ptx_arrive_barrier_expect_tx()) ||
+         call->op.same_as(tl::named_barrier_arrive()) ||
+         call->op.same_as(tl::ptx_fence_barrier_init()) ||
          call->op.same_as(builtin::ptx_cp_async_barrier()) ||
          call->op.same_as(tl::ptx_cp_async_barrier_noinc()) ||
          call->op.same_as(tma_load()) || call->op.same_as(tma_load_im2col()) ||
+         call->op.same_as(tma_load_multicast()) ||
+         call->op.same_as(tma_load_gather4()) ||
          call->op.same_as(tma_store()) ||
+         call->op.same_as(tma_store_scatter4()) ||
+         call->op.same_as(tma_store_cluster()) ||
          call->op.same_as(tma_store_arrive()) ||
          call->op.same_as(tma_store_wait()) ||
          call->op.same_as(builtin::tvm_storage_sync()) ||

--- a/src/cuda/transform/ws_analysis.h
+++ b/src/cuda/transform/ws_analysis.h
@@ -1,0 +1,90 @@
+/*!
+ * \file ws_analysis.h
+ * \brief Statement analysis shared by the warp-specialization passes.
+ *
+ * Extracted from producer_consumer_ws.cc so automatic schedulers reuse the
+ * same classification the legacy producer/consumer rewriter has been
+ * validated with.
+ */
+#pragma once
+
+#include <tvm/target/target.h>
+#include <tvm/tirx/buffer.h>
+#include <tvm/tirx/stmt.h>
+
+#include <optional>
+#include <unordered_map>
+#include <utility>
+
+#include "layout/layout.h"
+#include "op/copy.h"
+#include "op/operator.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+
+using BufferRemap =
+    std::unordered_map<Buffer, Buffer, ObjectPtrHash, ObjectPtrEqual>;
+using BufferLayoutMap = std::unordered_map<Var, std::pair<Buffer, Layout>,
+                                           ObjectPtrHash, ObjectPtrEqual>;
+
+enum class TileStmtKind {
+  kTmaProducer,     // TMA load (global->shared tile-op copy)
+  kCpAsyncProducer, // tile-op copy selecting cp.async
+  kCpAsyncRaw,      // raw ptx_cp_async / commit_group / wait_group statement
+  kSimtProducer, // Non-tile-op SIMT copy: For loop writing shared from global
+  kTmaStore,     // TMA bulk store (shared->global tile-op copy)
+  kTcgen05Mma,   // tcgen05 GEMM accumulating in tensor memory
+  kConsumer,     // Everything else (compute, wgmma, plain copies)
+};
+
+/// The Evaluate(Call) inside else-less if / attribute / block wrappers, if
+/// the statement has that shape.
+Optional<Call> GetEvaluateCallInSimpleWrapper(const Stmt &stmt);
+
+/// Hand-written synchronization or TMA control: barriers, arrives, waits,
+/// raw TMA instructions, and block-wide syncs. A kernel using these
+/// manages a protocol the schedule cannot see.
+bool IsBarrierOrTmaControlCall(const CallNode *call);
+
+/// Classify a tile-op copy as TMA load producer, cp.async producer, TMA
+/// store, or consumer using coarse pre-layout checks.
+TileStmtKind ClassifyCopy(const CopyNode *copy, Target target);
+
+/// Classify a single statement in a pipeline loop body.
+TileStmtKind ClassifyStmt(const Stmt &stmt, Target target);
+
+struct GemmInfo {
+  Buffer accumulator;
+  int wg_wait;
+};
+
+/// The accumulator and wg_wait of a dense or sparse gemm tile op;
+/// nullopt for any other operator.
+std::optional<GemmInfo> GetGemmInfo(const TileOperator &op);
+
+bool IsProducer(TileStmtKind kind);
+
+/// Both the T.ws() language-level attr ("warp_specialize") and the
+/// compiler-level attr (kWarpSpecializationScope).
+bool HasManualWarpSpecialization(const Stmt &stmt);
+
+/// Check whether a layout annotation on a shared buffer is compatible with
+/// TMA. TMA supports identity (linear) layouts and the three standard
+/// swizzle modes (32B / 64B / 128B). Any other layout (e.g. padded,
+/// Volta-style) cannot be used with TMA.
+bool IsTmaCompatibleLayout(const Layout &layout, const Buffer &buffer);
+
+/// Merge one block's "layout_map" annotation into `layouts`, keyed by the
+/// buffer's data var. Var-keyed entries are resolved against the block's
+/// allocations.
+void CollectAnnotatedLayouts(const SBlock &block, BufferLayoutMap &layouts);
+
+/// Rewrite every use of a remapped buffer (loads, stores, region roots) to
+/// the replacement, including bare uses of the old data vars.
+Stmt RemapBuffers(Stmt stmt, const BufferRemap &remap);
+
+} // namespace tl
+} // namespace tvm

--- a/src/op/utils.h
+++ b/src/op/utils.h
@@ -91,6 +91,13 @@ inline bool IsSharedBuffer(const Buffer &buffer, bool allow_dynamic = true) {
   return buffer.scope() == "shared";
 }
 
+inline bool IsTmemBuffer(const Buffer &buffer) {
+  if (!buffer.defined()) {
+    return false;
+  }
+  return buffer.scope() == "shared.tmem";
+}
+
 inline bool IsGlobalBuffer(const Buffer &buffer) {
   return buffer.defined() && buffer.scope() == "global";
 }

--- a/src/transform/common/warp_specialize.h
+++ b/src/transform/common/warp_specialize.h
@@ -58,6 +58,11 @@ static constexpr const char *kWSScheduleKey = "tl.ws_schedule";
  */
 static constexpr const char *kWSOpIdKey = "tl.ws_op_id";
 
+// Attr wrapper from T.annotate_ws_pipeline_depth: node = buffer var, value =
+// depth of the pipeline the automatic scheduler hosts for it at the
+// enclosing scope. Scheduler-only metadata; the materializer drops it.
+static constexpr const char *kWSPipelineDepthKey = "tl.ws_pipeline_depth";
+
 /*! \brief Scope id of the kernel's implicit root scope (T.WSScope.ROOT). */
 static constexpr const char *kWSRootScopeId = "tl.ws_scope_root";
 
@@ -72,6 +77,8 @@ public:
   /*! \brief setmaxnreg budget; 0 = unset. */
   int64_t max_nreg;
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind =
+      kTVMFFISEqHashKindTreeNode;
   static void RegisterReflection();
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.WSRole", WSRoleNode, ffi::Object);
 };
@@ -94,6 +101,8 @@ public:
   /*! \brief Number of buffer versions. */
   int64_t depth;
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind =
+      kTVMFFISEqHashKindTreeNode;
   static void RegisterReflection();
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.WSPipeline", WSPipelineNode,
                                     ffi::Object);
@@ -110,6 +119,8 @@ public:
 /*! \brief Base class of one step in a role's program. */
 class WSInstrNode : public ffi::Object {
 public:
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind =
+      kTVMFFISEqHashKindTreeNode;
   static void RegisterReflection();
   TVM_FFI_DECLARE_OBJECT_INFO("tl.WSInstr", WSInstrNode, ffi::Object);
 };
@@ -204,6 +215,8 @@ public:
   /*! \brief Role name -> instruction sequence. */
   ffi::Map<ffi::String, ffi::Array<WSInstr>> bodies;
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind =
+      kTVMFFISEqHashKindTreeNode;
   static void RegisterReflection();
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.WSScope", WSScopeNode, ffi::Object);
 };
@@ -225,6 +238,8 @@ public:
   ffi::Array<WSPipeline> pipelines;
   ffi::Array<WSScope> scopes;
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind =
+      kTVMFFISEqHashKindTreeNode;
   static void RegisterReflection();
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.WSSchedule", WSScheduleNode,
                                     ffi::Object);

--- a/testing/python/transform/test_tilelang_transform_auto_schedule.py
+++ b/testing/python/transform/test_tilelang_transform_auto_schedule.py
@@ -1,0 +1,1571 @@
+"""Tests for AutoSchedule's "role_based" scheduler.
+
+The pass consumes plain (schedule-free) kernels, assigns fixed roles from
+lowering eligibility (Load / MMA / Store / Worker), pulls warp-private
+def-use chains into their consumers' roles, derives per-storage pipelines
+with alternating producer/consumer cycles, and emits a typed ``WSSchedule``
+plus ``tl.ws_op_id`` markers. All lowering stays in
+``MaterializeWSSchedule``. Kernels the scheduler declines must come back
+byte-for-byte unchanged.
+"""
+
+import pytest
+
+import tilelang
+import tilelang.testing
+import torch
+from tilelang import language as T
+from tilelang import tvm
+
+_TARGET = tvm.target.Target({"kind": "cuda", "arch": "sm_100a"})
+
+
+def _prepare(func):
+    mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
+    mod = tvm.tirx.transform.BindTarget(_TARGET)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch()(mod)
+    mod = tilelang.transform.InjectAssumes()(mod)
+    return mod
+
+
+def _auto_schedule(mod, scheduler="role_based"):
+    """Apply AutoSchedule with the scheduler opted in via pass config."""
+    with tvm.transform.PassContext(config={"tl.enable_auto_schedule": scheduler}):
+        return tilelang.cuda.transform.AutoSchedule()(mod)
+
+
+def _schedule(func):
+    """Run the pass; returns (scheduled module, root WSSchedule or None)."""
+    scheduled = _auto_schedule(_prepare(func))
+    return scheduled, _root_schedule(scheduled["main"])
+
+
+def _root_schedule(func):
+    result = None
+
+    def visit(node):
+        nonlocal result
+        if isinstance(node, tvm.tirx.SBlock) and node.name_hint == "tilelang_root":
+            result = node.annotations.get("tl.ws_schedule")
+
+    tvm.tirx.stmt_functor.post_order_visit(func.body, visit)
+    return result
+
+
+def _alloc_buffers(mod):
+    """name -> Buffer allocated by the scheduled kernel's root block, for
+    building expected schedules that structurally match the emitted one."""
+    out = {}
+
+    def visit(node):
+        if isinstance(node, tvm.tirx.SBlock):
+            for buffer in node.alloc_buffers:
+                out[str(buffer.name)] = buffer
+
+    tvm.tirx.stmt_functor.post_order_visit(mod["main"].body, visit)
+    return out
+
+
+def _pipelined_load_kernel(num_stages=2):
+    @T.prim_func
+    def kernel(A: T.Tensor((4, 64, 64), T.float16), B: T.Tensor((4, 64, 64), T.float16)):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            for k in T.Pipelined(4, num_stages=num_stages):
+                T.copy(A[k, 0, 0], S)
+                T.copy(S, F)
+                T.copy(F, B[k, 0, 0])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_tma_load_pipeline():
+    """A TMA-eligible global->shared copy becomes the Load role; the shared
+    buffer becomes a pipeline of depth num_stages with one cycle per
+    iteration."""
+    mod, schedule = _schedule(_pipelined_load_kernel())
+    assert schedule is not None
+    bufs = _alloc_buffers(mod)
+    tvm.ir.assert_structural_equal(
+        schedule,
+        T.WSSchedule(
+            num_warps=8,
+            roles=[
+                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
+                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
+            ],
+            pipelines=[T.WSPipeline("S", [bufs["S"]], depth=2)],
+            scopes=[
+                T.WSScope(
+                    "loop_0",
+                    {
+                        "Worker": [
+                            T.WSSync.consumer_wait("S"),
+                            "tl_tileop_copy_1",
+                            T.WSSync.consumer_release("S"),
+                            "tl_tileop_copy_2",
+                        ],
+                        "Load": [
+                            T.WSSync.producer_acquire("S"),
+                            "tl_tileop_copy_0",
+                            T.WSSync.producer_commit("S"),
+                        ],
+                    },
+                ),
+                T.WSScope(T.WSScope.ROOT, {"Worker": ["loop_0"], "Load": ["loop_0"]}),
+            ],
+        ),
+    )
+
+
+@tilelang.testing.requires_cuda
+def test_num_stages_sets_pipeline_depth():
+    mod, schedule = _schedule(_pipelined_load_kernel(num_stages=3))
+    bufs = _alloc_buffers(mod)
+    tvm.ir.assert_structural_equal(schedule.pipelines[0], T.WSPipeline("S", [bufs["S"]], depth=3))
+    assert len(schedule.pipelines) == 1
+
+
+def _two_cycle_kernel():
+    @T.prim_func
+    def kernel(A: T.Tensor((2, 64, 64), T.float16), B: T.Tensor((2, 64, 64), T.float16)):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            F0 = T.alloc_fragment((64, 64), T.float16)
+            F1 = T.alloc_fragment((64, 64), T.float16)
+            T.copy(A[0, 0, 0], S)
+            T.copy(S, F0)
+            T.copy(A[1, 0, 0], S)
+            T.copy(S, F1)
+            T.copy(F0, B[0, 0, 0])
+            T.copy(F1, B[1, 0, 0])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_two_cycles_on_one_buffer_and_root_depth():
+    """Reusing one shared buffer twice yields two bracket pairs — a single
+    bracket around both loads would let the second overwrite unread data —
+    and a root-level handoff gets depth 1."""
+    mod, schedule = _schedule(_two_cycle_kernel())
+    assert schedule is not None
+    bufs = _alloc_buffers(mod)
+    tvm.ir.assert_structural_equal(
+        schedule,
+        T.WSSchedule(
+            num_warps=8,
+            roles=[
+                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
+                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
+            ],
+            pipelines=[T.WSPipeline("S", [bufs["S"]], depth=1)],
+            scopes=[
+                T.WSScope(
+                    T.WSScope.ROOT,
+                    {
+                        "Worker": [
+                            T.WSSync.consumer_wait("S"),
+                            "tl_tileop_copy_1",
+                            T.WSSync.consumer_release("S"),
+                            T.WSSync.consumer_wait("S"),
+                            "tl_tileop_copy_3",
+                            T.WSSync.consumer_release("S"),
+                            "tl_tileop_copy_4",
+                            "tl_tileop_copy_5",
+                        ],
+                        "Load": [
+                            T.WSSync.producer_acquire("S"),
+                            "tl_tileop_copy_0",
+                            T.WSSync.producer_commit("S"),
+                            T.WSSync.producer_acquire("S"),
+                            "tl_tileop_copy_2",
+                            T.WSSync.producer_commit("S"),
+                        ],
+                    },
+                ),
+            ],
+        ),
+    )
+
+
+def _gather_kernel(worker_uses_index):
+    @T.prim_func
+    def kernel(
+        Indices: T.Tensor((4,), T.int32),
+        A: T.Tensor((8, 64, 64), T.float16),
+        B: T.Tensor((8, 64, 64), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            for k in T.Pipelined(4, num_stages=2):
+                idx = Indices[k]
+                T.copy(A[idx, 0, 0], S)
+                T.copy(S, F)
+                if worker_uses_index:
+                    T.copy(F, B[idx, 0, 0])
+                else:
+                    T.copy(F, B[k, 0, 0])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_bind_placed_with_its_single_consumer_role():
+    """A pure Bind read only by the TMA copy moves into the Load role."""
+    _, schedule = _schedule(_gather_kernel(worker_uses_index=False))
+    tvm.ir.assert_structural_equal(
+        schedule.scopes[0],
+        T.WSScope(
+            "loop_0",
+            {
+                "Worker": [
+                    T.WSSync.consumer_wait("S"),
+                    "tl_tileop_copy_1",
+                    T.WSSync.consumer_release("S"),
+                    "tl_tileop_copy_2",
+                ],
+                "Load": [
+                    "idx_0",
+                    T.WSSync.producer_acquire("S"),
+                    "tl_tileop_copy_0",
+                    T.WSSync.producer_commit("S"),
+                ],
+            },
+        ),
+    )
+
+
+@tilelang.testing.requires_cuda
+def test_bind_duplicated_into_two_roles():
+    """A pure global-reading Bind used by two roles is placed in both; the
+    materializer re-emits it per role."""
+    _, schedule = _schedule(_gather_kernel(worker_uses_index=True))
+    tvm.ir.assert_structural_equal(
+        schedule.scopes[0],
+        T.WSScope(
+            "loop_0",
+            {
+                "Worker": [
+                    "idx_0",
+                    T.WSSync.consumer_wait("S"),
+                    "tl_tileop_copy_1",
+                    T.WSSync.consumer_release("S"),
+                    "tl_tileop_copy_2",
+                ],
+                "Load": [
+                    "idx_0",
+                    T.WSSync.producer_acquire("S"),
+                    "tl_tileop_copy_0",
+                    T.WSSync.producer_commit("S"),
+                ],
+            },
+        ),
+    )
+
+
+def _local_chain_kernel():
+    @T.prim_func
+    def kernel(A: T.Tensor((4, 64, 64), T.float16), B: T.Tensor((4, 64, 64), T.float16)):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            tmp = T.alloc_local((1,), T.int32)
+            for k in T.Pipelined(4, num_stages=2):
+                tmp[0] = k * 2 % 4
+                idx = tmp[0]
+                T.copy(A[idx, 0, 0], S)
+                T.copy(S, F)
+                T.copy(F, B[k, 0, 0])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_bind_chain_through_local_buffer_moves_together():
+    """The TMA index Bind and the local store feeding it must land in the
+    Load role together: moving only the Bind would make the TMA warp read
+    another warp's private register."""
+    _, schedule = _schedule(_local_chain_kernel())
+    tvm.ir.assert_structural_equal(
+        schedule.scopes[0],
+        T.WSScope(
+            "loop_0",
+            {
+                "Worker": [
+                    T.WSSync.consumer_wait("S"),
+                    "tl_tileop_copy_1",
+                    T.WSSync.consumer_release("S"),
+                    "tl_tileop_copy_2",
+                ],
+                "Load": [
+                    "tmp_0",
+                    "idx_0",
+                    T.WSSync.producer_acquire("S"),
+                    "tl_tileop_copy_0",
+                    T.WSSync.producer_commit("S"),
+                ],
+            },
+        ),
+    )
+
+
+def _local_accumulator_gemm(threads=128):
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((64, 128), T.float16),
+        B: T.Tensor((128, 64), T.float16),
+        C: T.Tensor((64, 64), T.float16),
+    ):
+        with T.Kernel(1, threads=threads):
+            A_shared = T.alloc_shared((64, 32), T.float16)
+            B_shared = T.alloc_shared((32, 64), T.float16)
+            C_local = T.alloc_fragment((64, 64), T.float32)
+            T.clear(C_local)
+            for k in T.Pipelined(4, num_stages=2):
+                T.copy(A[0, k * 32], A_shared)
+                T.copy(B[k * 32, 0], B_shared)
+                T.gemm(A_shared, B_shared, C_local)
+            T.copy(C_local, C[0, 0])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_worker_gemm_topology_materializes():
+    mod, schedule = _schedule(_local_accumulator_gemm())
+    assert schedule is not None
+    bufs = _alloc_buffers(mod)
+    # One pipeline per storage (merging is a TODO).
+    tvm.ir.assert_structural_equal(
+        schedule,
+        T.WSSchedule(
+            num_warps=8,
+            roles=[
+                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
+                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
+            ],
+            pipelines=[
+                T.WSPipeline("A_shared", [bufs["A_shared"]], depth=2),
+                T.WSPipeline("B_shared", [bufs["B_shared"]], depth=2),
+            ],
+            scopes=[
+                T.WSScope(
+                    "loop_0",
+                    {
+                        "Worker": [
+                            T.WSSync.consumer_wait("A_shared"),
+                            T.WSSync.consumer_wait("B_shared"),
+                            "tl_tileop_gemm_0",
+                            T.WSSync.consumer_release("A_shared"),
+                            T.WSSync.consumer_release("B_shared"),
+                        ],
+                        "Load": [
+                            T.WSSync.producer_acquire("A_shared"),
+                            "tl_tileop_copy_0",
+                            T.WSSync.producer_commit("A_shared"),
+                            T.WSSync.producer_acquire("B_shared"),
+                            "tl_tileop_copy_1",
+                            T.WSSync.producer_commit("B_shared"),
+                        ],
+                    },
+                ),
+                T.WSScope(
+                    T.WSScope.ROOT,
+                    {
+                        "Worker": ["tl_tileop_fill_0", "loop_0", "tl_tileop_copy_2"],
+                        "Load": ["loop_0"],
+                    },
+                ),
+            ],
+        ),
+    )
+
+    script = str(tilelang.cuda.transform.MaterializeWSSchedule()(mod)["main"])
+    assert 'T.launch_thread("threadIdx.x", 256)' in script
+    assert "T.tma_copy" in script
+    assert "ws_schedule" not in script
+
+
+def _tmem_gemm():
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((2, 128, 64), T.float16),
+        B: T.Tensor((2, 128, 64), T.float16),
+        C: T.Tensor((128, 128), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128, 64), T.float16)
+            B_shared = T.alloc_shared((128, 64), T.float16)
+            C_tmem = T.alloc_tmem((128, 128), T.float32)
+            C_frag = T.alloc_fragment((128, 64), T.float32)
+            C_shared = T.alloc_shared((128, 64), T.float16)
+
+            for k in T.Pipelined(2, num_stages=2):
+                T.copy(A[k, 0, 0], A_shared)
+                T.copy(B[k, 0, 0], B_shared)
+                T.gemm(
+                    A_shared,
+                    B_shared,
+                    C_tmem,
+                    transpose_B=True,
+                    clear_accum=k == 0,
+                )
+            for i in T.serial(2):
+                T.copy(C_tmem[:, i * 64 : (i + 1) * 64], C_frag)
+                T.copy(C_frag, C_shared)
+                T.copy(C_shared, C[:, i * 64 : (i + 1) * 64])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_tmem_gemm_four_role_topology():
+    """tcgen05 GEMM -> MMA role, TMA store -> Store role; the accumulator
+    pipeline brackets the k loop at the root with depth 1, and the epilogue
+    staging buffer cycles inside the epilogue loop."""
+    mod, schedule = _schedule(_tmem_gemm())
+    assert schedule is not None
+    bufs = _alloc_buffers(mod)
+    tvm.ir.assert_structural_equal(
+        schedule,
+        T.WSSchedule(
+            num_warps=8,
+            roles=[
+                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
+                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
+                T.WSRole("MMA", warps_lo=5, warps_hi=6, max_nreg=32),
+                T.WSRole("Store", warps_lo=6, warps_hi=7, max_nreg=32),
+            ],
+            pipelines=[
+                T.WSPipeline("A_shared", [bufs["A_shared"]], depth=2),
+                T.WSPipeline("B_shared", [bufs["B_shared"]], depth=2),
+                T.WSPipeline("C_tmem", [bufs["C_tmem"]], depth=1),
+                T.WSPipeline("C_shared", [bufs["C_shared"]], depth=1),
+            ],
+            scopes=[
+                T.WSScope(
+                    "loop_1",
+                    {
+                        "Worker": [
+                            "tl_tileop_copy_2",
+                            T.WSSync.producer_acquire("C_shared"),
+                            "tl_tileop_copy_3",
+                            T.WSSync.producer_commit("C_shared"),
+                        ],
+                        "Store": [
+                            T.WSSync.consumer_wait("C_shared"),
+                            "tl_tileop_copy_4",
+                            T.WSSync.consumer_release("C_shared"),
+                        ],
+                    },
+                ),
+                T.WSScope(
+                    "loop_0",
+                    {
+                        "Load": [
+                            T.WSSync.producer_acquire("A_shared"),
+                            "tl_tileop_copy_0",
+                            T.WSSync.producer_commit("A_shared"),
+                            T.WSSync.producer_acquire("B_shared"),
+                            "tl_tileop_copy_1",
+                            T.WSSync.producer_commit("B_shared"),
+                        ],
+                        "MMA": [
+                            T.WSSync.consumer_wait("A_shared"),
+                            T.WSSync.consumer_wait("B_shared"),
+                            "tl_tileop_gemm_0",
+                            T.WSSync.consumer_release("A_shared"),
+                            T.WSSync.consumer_release("B_shared"),
+                        ],
+                    },
+                ),
+                T.WSScope(
+                    T.WSScope.ROOT,
+                    {
+                        "Worker": [
+                            T.WSSync.consumer_wait("C_tmem"),
+                            "loop_1",
+                            T.WSSync.consumer_release("C_tmem"),
+                        ],
+                        "Load": ["loop_0"],
+                        "MMA": [
+                            T.WSSync.producer_acquire("C_tmem"),
+                            "loop_0",
+                            T.WSSync.producer_commit("C_tmem"),
+                        ],
+                        "Store": ["loop_1"],
+                    },
+                ),
+            ],
+        ),
+    )
+
+    script = str(tilelang.cuda.transform.MaterializeWSSchedule()(mod)["main"])
+    assert "tcgen05_gemm" in script
+    # The Store role reads C_shared through the async proxy; the handoff from
+    # the Worker role's generic-proxy writes needs an explicit fence.
+    assert "fence_proxy_async" in script
+    assert "ws_schedule" not in script
+
+
+def _tmem_gemm_unrolled_epilogue():
+    """_tmem_gemm with the epilogue loop unrolled instead of serial."""
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((2, 128, 64), T.float16),
+        B: T.Tensor((2, 128, 64), T.float16),
+        C: T.Tensor((128, 128), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128, 64), T.float16)
+            B_shared = T.alloc_shared((128, 64), T.float16)
+            C_tmem = T.alloc_tmem((128, 128), T.float32)
+            C_frag = T.alloc_fragment((128, 64), T.float32)
+            C_shared = T.alloc_shared((128, 64), T.float16)
+
+            for k in T.Pipelined(2, num_stages=2):
+                T.copy(A[k, 0, 0], A_shared)
+                T.copy(B[k, 0, 0], B_shared)
+                T.gemm(
+                    A_shared,
+                    B_shared,
+                    C_tmem,
+                    transpose_B=True,
+                    clear_accum=k == 0,
+                )
+            for i in T.unroll(2):
+                T.copy(C_tmem[:, i * 64 : (i + 1) * 64], C_frag)
+                T.copy(C_frag, C_shared)
+                T.copy(C_shared, C[:, i * 64 : (i + 1) * 64])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_unrolled_epilogue_is_scheduled():
+    """Sequential loops are scopes regardless of kind: the unrolled
+    epilogue schedules exactly like the serial one — the TMA store gets
+    the Store role and the staging buffer cycles inside the epilogue
+    scope."""
+    _, schedule = _schedule(_tmem_gemm_unrolled_epilogue())
+    assert schedule is not None
+    # The epilogue scope is the unrolled loop; its schedule matches the
+    # serial one's.
+    tvm.ir.assert_structural_equal(
+        schedule.scopes[0],
+        T.WSScope(
+            "unroll_0",
+            {
+                "Worker": [
+                    "tl_tileop_copy_2",
+                    T.WSSync.producer_acquire("C_shared"),
+                    "tl_tileop_copy_3",
+                    T.WSSync.producer_commit("C_shared"),
+                ],
+                "Store": [
+                    T.WSSync.consumer_wait("C_shared"),
+                    "tl_tileop_copy_4",
+                    T.WSSync.consumer_release("C_shared"),
+                ],
+            },
+        ),
+    )
+    tvm.ir.assert_structural_equal(
+        schedule.scopes[2],
+        T.WSScope(
+            T.WSScope.ROOT,
+            {
+                "Worker": [
+                    T.WSSync.consumer_wait("C_tmem"),
+                    "unroll_0",
+                    T.WSSync.consumer_release("C_tmem"),
+                ],
+                "Load": ["loop_0"],
+                "MMA": [
+                    T.WSSync.producer_acquire("C_tmem"),
+                    "loop_0",
+                    T.WSSync.producer_commit("C_tmem"),
+                ],
+                "Store": ["unroll_0"],
+            },
+        ),
+    )
+
+
+def _guarded_producer_kernel():
+    """The producer write is skipped on the last iteration: under
+    multi-versioning the consumer would see the slot from `depth`
+    iterations ago instead of the previous iteration's value."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((4, 64, 64), T.float16), B: T.Tensor((4, 64, 64), T.float16)):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            for k in T.Pipelined(4, num_stages=2):
+                if k < 3:
+                    T.copy(A[k, 0, 0], S)
+                T.copy(S, F)
+                T.copy(F, B[k, 0, 0])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_guarded_write_into_versioned_pipeline_declines():
+    """A guarded write into a multi-versioned pipeline is declined rather
+    than silently re-versioned; guarded writes to single-buffered
+    pipelines (FA's rescale) keep source semantics and stay schedulable."""
+    prepared = _prepare(_guarded_producer_kernel())
+    scheduled = _auto_schedule(prepared)
+    assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
+
+
+def _rmw_accumulator_kernel():
+    """A flash-attention-shaped accumulator: the Worker rescales C_tmem
+    before the MMA role accumulates onto it, and reads it once more after
+    the loop."""
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((4, 128, 64), T.float16),
+        B: T.Tensor((4, 64, 64), T.float16),
+        Scale: T.Tensor((4,), T.float32),
+        C: T.Tensor((128, 64), T.float32),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128, 64), T.float16)
+            B_shared = T.alloc_shared((64, 64), T.float16)
+            C_tmem = T.alloc_tmem((128, 64), T.float32)
+            C_frag = T.alloc_fragment((128, 64), T.float32)
+
+            for k in T.Pipelined(4, num_stages=2):
+                T.copy(A[k, 0, 0], A_shared)
+                T.copy(B[k, 0, 0], B_shared)
+                if k > 0:
+                    T.copy(C_tmem, C_frag)
+                    for i, j in T.Parallel(128, 64):
+                        C_frag[i, j] *= Scale[k]
+                    T.copy(C_frag, C_tmem)
+                T.gemm(A_shared, B_shared, C_tmem, transpose_B=True, clear_accum=k == 0)
+            T.copy(C_tmem, C_frag)
+            T.copy(C_frag, C)
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_rmw_accumulator_nested_pipelines():
+    """A read-modify-write storage used at two loop depths is bound to two
+    strictly nested pipelines: inside the loop, ownership alternates from
+    the first-touching role (the Worker's rescale precedes the MMA's
+    accumulate) and stays single-buffered despite the 2-stage loop; at the
+    root, the loop projects one MMA-side touch — the MMA producer-brackets
+    the whole loop and the post-loop read is a plain consumer run, with no
+    drain pair anywhere."""
+    mod, schedule = _schedule(_rmw_accumulator_kernel())
+    assert schedule is not None
+    bufs = _alloc_buffers(mod)
+    tvm.ir.assert_structural_equal(
+        schedule,
+        T.WSSchedule(
+            num_warps=8,
+            roles=[
+                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
+                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
+                T.WSRole("MMA", warps_lo=5, warps_hi=6, max_nreg=32),
+            ],
+            pipelines=[
+                T.WSPipeline("A_shared", [bufs["A_shared"]], depth=2),
+                T.WSPipeline("B_shared", [bufs["B_shared"]], depth=2),
+                T.WSPipeline("C_tmem", [bufs["C_tmem"]], depth=1),
+                T.WSPipeline("C_tmem_root", [bufs["C_tmem"]], depth=1),
+            ],
+            scopes=[
+                T.WSScope(
+                    "loop_0",
+                    {
+                        "Worker": [
+                            T.WSSync.producer_acquire("C_tmem"),
+                            "tl_tileop_copy_2",
+                            "parallel_0",
+                            "tl_tileop_copy_3",
+                            T.WSSync.producer_commit("C_tmem"),
+                        ],
+                        "Load": [
+                            T.WSSync.producer_acquire("A_shared"),
+                            "tl_tileop_copy_0",
+                            T.WSSync.producer_commit("A_shared"),
+                            T.WSSync.producer_acquire("B_shared"),
+                            "tl_tileop_copy_1",
+                            T.WSSync.producer_commit("B_shared"),
+                        ],
+                        "MMA": [
+                            T.WSSync.consumer_wait("A_shared"),
+                            T.WSSync.consumer_wait("B_shared"),
+                            T.WSSync.consumer_wait("C_tmem"),
+                            "tl_tileop_gemm_0",
+                            T.WSSync.consumer_release("A_shared"),
+                            T.WSSync.consumer_release("B_shared"),
+                            T.WSSync.consumer_release("C_tmem"),
+                        ],
+                    },
+                ),
+                T.WSScope(
+                    T.WSScope.ROOT,
+                    {
+                        "Worker": [
+                            "loop_0",
+                            T.WSSync.consumer_wait("C_tmem_root"),
+                            "tl_tileop_copy_4",
+                            T.WSSync.consumer_release("C_tmem_root"),
+                            "tl_tileop_copy_5",
+                        ],
+                        "Load": ["loop_0"],
+                        "MMA": [
+                            T.WSSync.producer_acquire("C_tmem_root"),
+                            "loop_0",
+                            T.WSSync.producer_commit("C_tmem_root"),
+                        ],
+                    },
+                ),
+            ],
+        ),
+    )
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+def test_rmw_accumulator_numerical():
+    kernel = tilelang.compile(
+        _rmw_accumulator_kernel(),
+        target="cuda",
+        out_idx=[3],
+        pass_configs={"tl.enable_auto_schedule": "role_based"},
+    )
+    a = torch.randn((4, 128, 64), device="cuda", dtype=torch.float16)
+    b = torch.randn((4, 64, 64), device="cuda", dtype=torch.float16)
+    scale = torch.rand((4,), device="cuda", dtype=torch.float32) + 0.5
+    actual = kernel(a, b, scale)
+    expected = torch.zeros((128, 64), device="cuda", dtype=torch.float32)
+    for k in range(4):
+        if k > 0:
+            expected *= scale[k]
+        expected += a[k].float() @ b[k].float().T
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+
+
+def _post_loop_read_kernel():
+    """The Load fills S inside loop_k; the Worker reads it there AND once
+    more after the loop. The collapsed loop_k also WRITES S, so ownership
+    moves across loop_w iterations: the subtree flips to the Load side of
+    an outer pipeline whose empty side keeps the next wave's fill off S
+    until the post-loop read released it."""
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((2, 4, 64, 64), T.float16),
+        B: T.Tensor((2, 4, 64, 64), T.float16),
+        C: T.Tensor((2, 64, 64), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            G = T.alloc_fragment((64, 64), T.float16)
+            for w in T.Pipelined(2, num_stages=2):
+                for k in T.Pipelined(4, num_stages=2):
+                    T.copy(A[w, k, 0, 0], S)
+                    T.copy(S, F)
+                    T.copy(F, B[w, k, 0, 0])
+                T.copy(S, G)
+                T.copy(G, C[w, 0, 0])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_post_loop_read_forms_outer_pipeline():
+    """Nested bindings from a same-role sibling: inside loop_k the Load
+    hands S to the Worker; at loop_w the subtree hands the whole loop's S
+    to the post-loop read. S carries no loop-carried dependency at either
+    level, so BOTH bindings take their loops' num_stages; the post-loop
+    read resolves the inner binding to its last-completed version."""
+    mod, schedule = _schedule(_post_loop_read_kernel())
+    assert schedule is not None
+    bufs = _alloc_buffers(mod)
+    tvm.ir.assert_structural_equal(
+        schedule,
+        T.WSSchedule(
+            num_warps=8,
+            roles=[
+                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
+                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
+            ],
+            pipelines=[
+                T.WSPipeline("S", [bufs["S"]], depth=2),
+                T.WSPipeline("S_loop_1", [bufs["S"]], depth=2),  # wave ring
+            ],
+            scopes=[
+                T.WSScope(
+                    "loop_0",
+                    {
+                        "Worker": [
+                            T.WSSync.consumer_wait("S"),
+                            "tl_tileop_copy_1",
+                            T.WSSync.consumer_release("S"),
+                            "tl_tileop_copy_2",
+                        ],
+                        "Load": [
+                            T.WSSync.producer_acquire("S"),
+                            "tl_tileop_copy_0",
+                            T.WSSync.producer_commit("S"),
+                        ],
+                    },
+                ),
+                T.WSScope(
+                    "loop_1",
+                    {
+                        "Worker": [
+                            "loop_0",
+                            T.WSSync.consumer_wait("S_loop_1"),
+                            "tl_tileop_copy_3",
+                            T.WSSync.consumer_release("S_loop_1"),
+                            "tl_tileop_copy_4",
+                        ],
+                        "Load": [
+                            T.WSSync.producer_acquire("S_loop_1"),
+                            "loop_0",
+                            T.WSSync.producer_commit("S_loop_1"),
+                        ],
+                    },
+                ),
+                T.WSScope(T.WSScope.ROOT, {"Worker": ["loop_1"], "Load": ["loop_1"]}),
+            ],
+        ),
+    )
+
+
+@tilelang.testing.requires_cuda
+def test_read_before_nested_cycle_declines():
+    """Reading S BEFORE the loop that refills it: the Worker's wait would
+    pair a commit that only happens later in the same wave — the ownership
+    walk declines instead of emitting a deadlocking schedule."""
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((2, 4, 64, 64), T.float16),
+        B: T.Tensor((2, 4, 64, 64), T.float16),
+        C: T.Tensor((2, 64, 64), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            G = T.alloc_fragment((64, 64), T.float16)
+            for w in T.Pipelined(2, num_stages=1):
+                T.copy(S, G)
+                T.copy(G, C[w, 0, 0])
+                for k in T.Pipelined(4, num_stages=1):
+                    T.copy(A[w, k, 0, 0], S)
+                    T.copy(S, F)
+                    T.copy(F, B[w, k, 0, 0])
+
+    prepared = _prepare(kernel)
+    scheduled = _auto_schedule(prepared)
+    assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+def test_post_loop_read_numerical():
+    kernel = tilelang.compile(
+        _post_loop_read_kernel(),
+        target="cuda",
+        out_idx=[1, 2],
+        pass_configs={"tl.enable_auto_schedule": "role_based"},
+    )
+    a = torch.randn((2, 4, 64, 64), device="cuda", dtype=torch.float16)
+    b, c = kernel(a)
+    torch.testing.assert_close(b, a)
+    torch.testing.assert_close(c, a[:, 3])
+
+
+@tilelang.testing.requires_cuda
+def test_pipeline_opt_in_runs_automatic_ws():
+    func = _local_accumulator_gemm().with_attr("global_symbol", "main")
+    mod = tvm.IRModule.from_expr(func)
+    with (
+        _TARGET,
+        tvm.transform.PassContext(config={"tl.enable_auto_schedule": "role_based"}),
+    ):
+        out = tilelang.cuda.pipeline.CUDAPassPipelineBodyPrologue(mod, _TARGET)["main"]
+
+    script = str(out)
+    assert 'T.launch_thread("threadIdx.x", 256)' in script
+    assert "ws_schedule" not in script
+    assert "ws_op_id" not in script
+
+
+@tilelang.testing.requires_cuda
+def test_no_shared_handoff_is_left_unchanged():
+    @T.prim_func
+    def kernel(A: T.Tensor((64, 64), T.float16), B: T.Tensor((64, 64), T.float16)):
+        with T.Kernel(1, threads=128):
+            F = T.alloc_fragment((64, 64), T.float16)
+            T.copy(A, F)
+            T.copy(F, B)
+
+    prepared = _prepare(kernel)
+    scheduled = _auto_schedule(prepared)
+    assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
+
+
+def _persistent_while_kernel():
+    @T.prim_func
+    def kernel(A: T.Tensor((2, 64, 64), T.float16), B: T.Tensor((2, 64, 64), T.float16)):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            wave = T.alloc_local((1,), T.int32)
+            wave[0] = 0
+            while wave[0] < 2:
+                T.copy(A[wave[0], 0, 0], S)
+                T.copy(S, F)
+                T.copy(F, B[wave[0], 0, 0])
+                wave[0] = wave[0] + 1
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_while_scope_is_scheduled():
+    """A while loop is a scope: every role re-evaluates the condition on
+    its own duplicated wave counter, and the shared buffer cycles inside
+    the while body (runtime phase counters in the materializer)."""
+    mod, schedule = _schedule(_persistent_while_kernel())
+    assert schedule is not None
+    bufs = _alloc_buffers(mod)
+    # The wave bump ("wave_1") is duplicated into both roles.
+    tvm.ir.assert_structural_equal(
+        schedule,
+        T.WSSchedule(
+            num_warps=8,
+            roles=[
+                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
+                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
+            ],
+            pipelines=[T.WSPipeline("S", [bufs["S"]], depth=1)],
+            scopes=[
+                T.WSScope(
+                    "while_0",
+                    {
+                        "Worker": [
+                            T.WSSync.consumer_wait("S"),
+                            "tl_tileop_copy_1",
+                            T.WSSync.consumer_release("S"),
+                            "tl_tileop_copy_2",
+                            "wave_1",
+                        ],
+                        "Load": [
+                            T.WSSync.producer_acquire("S"),
+                            "tl_tileop_copy_0",
+                            T.WSSync.producer_commit("S"),
+                            "wave_1",
+                        ],
+                    },
+                ),
+                T.WSScope(
+                    T.WSScope.ROOT,
+                    {"Worker": ["wave_0", "while_0"], "Load": ["wave_0", "while_0"]},
+                ),
+            ],
+        ),
+    )
+
+
+@tilelang.testing.requires_cuda
+def test_while_scope_numerical():
+    kernel = tilelang.compile(
+        _persistent_while_kernel(),
+        target="cuda",
+        out_idx=[1],
+        pass_configs={"tl.enable_auto_schedule": "role_based"},
+    )
+    a = torch.randn((2, 64, 64), device="cuda", dtype=torch.float16)
+    torch.testing.assert_close(kernel(a), a)
+
+
+@tilelang.testing.requires_cuda
+def test_pipelined_load_numerical():
+    kernel = tilelang.compile(
+        _pipelined_load_kernel(),
+        target="cuda",
+        out_idx=[1],
+        pass_configs={"tl.enable_auto_schedule": "role_based"},
+    )
+    a = torch.randn((4, 64, 64), device="cuda", dtype=torch.float16)
+    torch.testing.assert_close(kernel(a), a)
+
+
+@tilelang.testing.requires_cuda
+def test_two_cycles_numerical():
+    kernel = tilelang.compile(
+        _two_cycle_kernel(),
+        target="cuda",
+        out_idx=[1],
+        pass_configs={"tl.enable_auto_schedule": "role_based"},
+    )
+    a = torch.randn((2, 64, 64), device="cuda", dtype=torch.float16)
+    torch.testing.assert_close(kernel(a), a)
+
+
+@tilelang.testing.requires_cuda
+def test_gather_bind_numerical():
+    kernel = tilelang.compile(
+        _gather_kernel(worker_uses_index=True),
+        target="cuda",
+        out_idx=[2],
+        pass_configs={"tl.enable_auto_schedule": "role_based"},
+    )
+    indices = torch.tensor([5, 2, 7, 0], device="cuda", dtype=torch.int32)
+    a = torch.randn((8, 64, 64), device="cuda", dtype=torch.float16)
+    actual = kernel(indices, a)
+    # Rows outside `indices` are never written (the output arrives
+    # uninitialized), so compare the gathered rows only.
+    torch.testing.assert_close(actual[indices.long()], a[indices.long()])
+
+
+@tilelang.testing.requires_cuda
+def test_local_chain_numerical():
+    kernel = tilelang.compile(
+        _local_chain_kernel(),
+        target="cuda",
+        out_idx=[1],
+        pass_configs={"tl.enable_auto_schedule": "role_based"},
+    )
+    a = torch.randn((4, 64, 64), device="cuda", dtype=torch.float16)
+    expected = torch.stack([a[k * 2 % 4] for k in range(4)])
+    torch.testing.assert_close(kernel(a), expected)
+
+
+@tilelang.testing.requires_cuda
+def test_worker_gemm_numerical():
+    kernel = tilelang.compile(
+        _local_accumulator_gemm(),
+        target="cuda",
+        out_idx=[2],
+        pass_configs={"tl.enable_auto_schedule": "role_based"},
+    )
+    a = torch.randn((64, 128), device="cuda", dtype=torch.float16)
+    b = torch.randn((128, 64), device="cuda", dtype=torch.float16)
+    torch.testing.assert_close(kernel(a, b), a @ b, rtol=1e-2, atol=1e-2)
+
+
+def _two_loop_kernel():
+    """The same shared buffer streams through two sequential pipelined
+    loops with different num_stages."""
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((4, 64, 64), T.float16),
+        B: T.Tensor((4, 64, 64), T.float16),
+        C: T.Tensor((4, 64, 64), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            for k in T.Pipelined(4, num_stages=2):
+                T.copy(A[k, 0, 0], S)
+                T.copy(S, F)
+                T.copy(F, B[k, 0, 0])
+            for k in T.Pipelined(4, num_stages=3):
+                T.copy(A[3 - k, 0, 0], S)
+                T.copy(S, F)
+                T.copy(F, C[k, 0, 0])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_storage_cycling_in_sibling_loops_declines():
+    """A pipeline synchronizes exactly one scope, so a buffer streaming
+    through two SIBLING loops would need two pipelines whose barriers
+    nothing chains — the second loop's pre-armed acquire could overwrite
+    data the first loop's consumer still reads. The kernel declines."""
+    prepared = _prepare(_two_loop_kernel())
+    scheduled = _auto_schedule(prepared)
+    assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
+
+
+def _non_tma_layout_kernel():
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((4, 64, 64), T.float16),
+        B: T.Tensor((4, 64, 64), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            S_perm = T.alloc_shared((64, 64), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            F_perm = T.alloc_fragment((64, 64), T.float16)
+            # Additive row rotation is not GF(2)-linear, so the layout is
+            # not TMA-expressible and the copy cannot be a TMA producer.
+            T.annotate_layout({S_perm: T.Layout((64, 64), lambda i, j: [i, (i + j) % 64])})
+            for k in T.Pipelined(4, num_stages=2):
+                T.copy(A[k, 0, 0], S)
+                T.copy(A[k, 0, 0], S_perm)
+                T.copy(S, F)
+                T.copy(S_perm, F_perm)
+                for i, j in T.Parallel(64, 64):
+                    F[i, j] += F_perm[i, j]
+                T.copy(F, B[k, 0, 0])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_non_tma_layout_copy_stays_worker():
+    """A TMA-shaped copy whose destination has a non-TMA-expressible layout
+    must not become a Load: lowering would fall back to a normal copy the
+    Load warp cannot signal as a transaction. It stays a Worker op and its
+    buffer stays out of the pipelines."""
+    mod, schedule = _schedule(_non_tma_layout_kernel())
+    assert schedule is not None
+    bufs = _alloc_buffers(mod)
+    # S_perm stays out of the pipelines; the Worker keeps its copy.
+    tvm.ir.assert_structural_equal(schedule.pipelines[0], T.WSPipeline("S", [bufs["S"]], depth=2))
+    assert len(schedule.pipelines) == 1
+    tvm.ir.assert_structural_equal(
+        schedule.scopes[0],
+        T.WSScope(
+            "loop_0",
+            {
+                "Worker": [
+                    "tl_tileop_copy_1",
+                    T.WSSync.consumer_wait("S"),
+                    "tl_tileop_copy_2",
+                    T.WSSync.consumer_release("S"),
+                    "tl_tileop_copy_3",
+                    "parallel_0",
+                    "tl_tileop_copy_4",
+                ],
+                "Load": [
+                    T.WSSync.producer_acquire("S"),
+                    "tl_tileop_copy_0",
+                    T.WSSync.producer_commit("S"),
+                ],
+            },
+        ),
+    )
+
+
+@tilelang.testing.requires_cuda
+def test_non_tma_layout_numerical():
+    kernel = tilelang.compile(
+        _non_tma_layout_kernel(),
+        target="cuda",
+        out_idx=[1],
+        pass_configs={"tl.enable_auto_schedule": "role_based"},
+    )
+    a = torch.randn((4, 64, 64), device="cuda", dtype=torch.float16)
+    torch.testing.assert_close(kernel(a), a + a)
+
+
+def _cp_async_load_kernel():
+    @T.prim_func
+    def kernel(A: T.Tensor((4, 64, 64), T.float16), B: T.Tensor((4, 64, 64), T.float16)):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            for k in T.Pipelined(4, num_stages=2):
+                T.async_copy(A[k, 0, 0], S)
+                T.copy(S, F)
+                T.copy(F, B[k, 0, 0])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_cp_async_copy_is_a_load_producer():
+    """A cp.async tile-op copy is asynchronous — the mbarrier tracks its
+    completion through the commit entry's deferred cp.async.mbarrier.arrive
+    — so it leaves the workers like a TMA copy."""
+    mod, schedule = _schedule(_cp_async_load_kernel())
+    assert schedule is not None
+    bufs = _alloc_buffers(mod)
+    tvm.ir.assert_structural_equal(schedule.pipelines[0], T.WSPipeline("S", [bufs["S"]], depth=2))
+    tvm.ir.assert_structural_equal(
+        schedule.scopes[0],
+        T.WSScope(
+            "loop_0",
+            {
+                "Worker": [
+                    T.WSSync.consumer_wait("S"),
+                    "tl_tileop_copy_0",
+                    T.WSSync.consumer_release("S"),
+                    "tl_tileop_copy_1",
+                ],
+                "Load": [
+                    T.WSSync.producer_acquire("S"),
+                    "tl_tileop_async_copy_0",
+                    T.WSSync.producer_commit("S"),
+                ],
+            },
+        ),
+    )
+
+    script = str(tilelang.cuda.transform.MaterializeWSSchedule()(mod)["main"])
+    assert "ptx_commit_group" in script
+    assert "ptx_cp_async_barrier_noinc" in script
+
+
+@tilelang.testing.requires_cuda
+def test_cp_async_load_numerical():
+    kernel = tilelang.compile(
+        _cp_async_load_kernel(),
+        target="cuda",
+        out_idx=[1],
+        pass_configs={"tl.enable_auto_schedule": "role_based"},
+    )
+    a = torch.randn((4, 64, 64), device="cuda", dtype=torch.float16)
+    torch.testing.assert_close(kernel(a), a)
+
+
+@tilelang.testing.requires_cuda
+def test_async_wgmma_wait_kernel_is_left_unchanged():
+    """T.wgmma_gemm (wg_wait = -1) returns with MMAs still reading its
+    shared operands; the manual T.wait_wgmma does not touch the buffers, so
+    the scheduler would release them early. Rejected until delayed wgmma
+    waits are supported."""
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((64, 128), T.float16),
+        B: T.Tensor((128, 64), T.float16),
+        C: T.Tensor((64, 64), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((64, 32), T.float16)
+            B_shared = T.alloc_shared((32, 64), T.float16)
+            C_local = T.alloc_fragment((64, 64), T.float32)
+            T.clear(C_local)
+            for k in T.Pipelined(4, num_stages=2):
+                T.copy(A[0, k * 32], A_shared)
+                T.copy(B[k * 32, 0], B_shared)
+                T.wgmma_gemm(A_shared, B_shared, C_local)
+            T.wait_wgmma(0)
+            T.copy(C_local, C[0, 0])
+
+    prepared = _prepare(kernel)
+    scheduled = _auto_schedule(prepared)
+    assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
+
+
+@tilelang.testing.requires_cuda
+def test_raw_cp_async_kernel_is_left_unchanged():
+    """A bare ptx_cp_async may rely on the legacy pass to synthesize its
+    completion protocol; the scheduler backs off rather than emit a read of
+    unlanded data."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((4, 64, 64), T.float16), B: T.Tensor((4, 16), T.float16)):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            B_shared = T.alloc_shared((16,), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            for k in T.Pipelined(4, num_stages=2):
+                T.ptx_cp_async(
+                    T.access_ptr(B_shared[0], "w", 16),
+                    T.access_ptr(B[k, 0], "r", 16),
+                    16,
+                )
+                T.copy(A[k, 0, 0], S)
+                T.copy(S, F)
+                T.copy(F, A[k, 0, 0])
+
+    prepared = _prepare(kernel)
+    scheduled = _auto_schedule(prepared)
+    assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
+
+
+def _pointer_table_kernel():
+    """The TMA source is a make_tensor view over a device pointer table: the
+    handle Bind is scheduled into the Load role and its buffer must follow
+    the SSA-freshened var."""
+
+    @T.prim_func
+    def kernel(src_ptrs: T.Tensor((1,), T.ptr), out: T.Tensor((64, 64), T.float16)):
+        with T.Kernel(1, threads=128):
+            src = T.make_tensor(src_ptrs[0], (64, 64), T.float16)
+            S = T.alloc_shared((64, 64), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            for _k in T.Pipelined(2, num_stages=2):
+                T.copy(src, S)
+                T.copy(S, F)
+                T.copy(F, out)
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_pointer_table_bind_follows_freshened_buffer():
+    mod, schedule = _schedule(_pointer_table_kernel())
+    assert schedule is not None
+    script = str(tilelang.cuda.transform.MaterializeWSSchedule()(mod)["main"])
+    assert "ws_schedule" not in script
+
+    kernel = tilelang.compile(
+        _pointer_table_kernel(),
+        target="cuda",
+        out_idx=[1],
+        pass_configs={"tl.enable_auto_schedule": "role_based"},
+    )
+    src = torch.randn((64, 64), device="cuda", dtype=torch.float16)
+    ptrs = torch.tensor([src.data_ptr()], device="cuda", dtype=torch.int64)
+    torch.testing.assert_close(kernel(ptrs), src)
+
+
+@tilelang.testing.requires_cuda
+def test_unknown_scheduler_rejected():
+    with pytest.raises(Exception, match="unknown auto-schedule scheduler"):
+        _auto_schedule(_prepare(_pipelined_load_kernel()), scheduler="nonexistent")
+
+
+@tilelang.testing.requires_cuda
+def test_unschedulable_constructs_decline():
+    """PreprocessIR checks the schedulability contract — atomics,
+    asynchronous producers nested inside opaque ops, hand-written
+    synchronization — and declines the kernel with a warning, leaving it
+    byte-for-byte unchanged, like a scheduler decline."""
+
+    @T.prim_func
+    def atomic_kernel(A: T.Tensor((64, 64), T.float32), B: T.Tensor((64, 64), T.float32)):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float32)
+            T.copy(A, S)
+            for i, j in T.Parallel(64, 64):
+                T.atomic_add(B[i, j], S[i, j])
+
+    @T.prim_func
+    def hosted_async_kernel(A: T.Tensor((64, 64), T.float16), B: T.Tensor((64, 64), T.float16)):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            with T.ws_op("staged"):  # opaque wrapper hosting an async g2s copy
+                T.copy(A, S)
+                T.copy(S, F)
+            T.copy(F, B)
+
+    @T.prim_func
+    def sync_threads_kernel(A: T.Tensor((64, 64), T.float16), B: T.Tensor((64, 64), T.float16)):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            T.copy(A, S)
+            # A block-wide barrier cannot be duplicated into role branches.
+            T.sync_threads()
+            T.copy(S, B)
+
+    for kernel in (atomic_kernel, hosted_async_kernel, sync_threads_kernel):
+        prepared = _prepare(kernel)
+        scheduled = _auto_schedule(prepared)
+        assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+def test_tmem_gemm_numerical():
+    kernel = tilelang.compile(
+        _tmem_gemm(),
+        target="cuda",
+        out_idx=[2],
+        pass_configs={"tl.enable_auto_schedule": "role_based"},
+    )
+    a = torch.randn((2, 128, 64), device="cuda", dtype=torch.float16)
+    b = torch.randn((2, 128, 64), device="cuda", dtype=torch.float16)
+    actual = kernel(a, b)
+    expected = sum(a[k].float() @ b[k].float().T for k in range(2)).half()
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_cuda
+def test_thread_budget_exceeded_declines():
+    """Issuer warps are appended after the workers: a 1024-thread kernel
+    would exceed the block-size limit, so the scheduler declines instead
+    of emitting an unlaunchable kernel."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((4, 64, 64), T.float16), B: T.Tensor((4, 64, 64), T.float16)):
+        with T.Kernel(1, threads=1024):
+            S = T.alloc_shared((64, 64), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            for k in T.Pipelined(4, num_stages=2):
+                T.copy(A[k, 0, 0], S)
+                T.copy(S, F)
+                T.copy(F, B[k, 0, 0])
+
+    prepared = _prepare(kernel)
+    scheduled = _auto_schedule(prepared)
+    assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
+
+
+def _waved_rmw_accumulator_kernel(depth=None, inner_depth=None):
+    """The RMW accumulator inside a wave loop: each wave clears C_tmem
+    (clear_accum at k == 0) and reads it once after its k loop. The
+    per-wave clear is exactly the recurrence reset that
+    T.annotate_ws_pipeline_depth asserts."""
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((2, 4, 128, 64), T.float16),
+        B: T.Tensor((2, 4, 64, 64), T.float16),
+        Scale: T.Tensor((4,), T.float32),
+        C: T.Tensor((2, 128, 64), T.float32),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128, 64), T.float16)
+            B_shared = T.alloc_shared((64, 64), T.float16)
+            C_tmem = T.alloc_tmem((128, 64), T.float32)
+            C_frag = T.alloc_fragment((128, 64), T.float32)
+            for w in T.Pipelined(2, num_stages=1):
+                if depth is not None:
+                    T.annotate_ws_pipeline_depth({C_tmem: depth})
+                for k in T.Pipelined(4, num_stages=2):
+                    if inner_depth is not None:
+                        T.annotate_ws_pipeline_depth({C_tmem: inner_depth})
+                    T.copy(A[w, k, 0, 0], A_shared)
+                    T.copy(B[w, k, 0, 0], B_shared)
+                    if k > 0:
+                        T.copy(C_tmem, C_frag)
+                        for i, j in T.Parallel(128, 64):
+                            C_frag[i, j] *= Scale[k]
+                        T.copy(C_frag, C_tmem)
+                    T.gemm(A_shared, B_shared, C_tmem, transpose_B=True, clear_accum=k == 0)
+                T.copy(C_tmem, C_frag)
+                T.copy(C_frag, C[w, 0, 0])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_annotated_ws_pipeline_depth_overrides_num_stages():
+    """T.annotate_ws_pipeline_depth overrides the depth the enclosing
+    scope's num_stages would give its pipeline."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((4, 64, 64), T.float16), B: T.Tensor((4, 64, 64), T.float16)):
+        with T.Kernel(1, threads=128):
+            S = T.alloc_shared((64, 64), T.float16)
+            F = T.alloc_fragment((64, 64), T.float16)
+            for k in T.Pipelined(4, num_stages=2):
+                T.annotate_ws_pipeline_depth({S: 3})
+                T.copy(A[k, 0, 0], S)
+                T.copy(S, F)
+                T.copy(F, B[k, 0, 0])
+
+    mod, schedule = _schedule(kernel)
+    assert schedule is not None
+    bufs = _alloc_buffers(mod)
+    tvm.ir.assert_structural_equal(schedule.pipelines[0], T.WSPipeline("S", [bufs["S"]], depth=3))
+    assert len(schedule.pipelines) == 1
+
+
+@tilelang.testing.requires_cuda
+def test_annotated_ws_pipeline_depth_ring_accumulator():
+    """Without the annotation the accumulator's wave-scope binding is
+    pinned single-buffered (the scheduler cannot prove the per-wave
+    clear); annotating the wave scope asserts it, giving a ring — and
+    the guarded rescale inside the INNER binding must not veto it (a
+    skipped write cycles the inner slot, not the ring's)."""
+    mod, schedule = _schedule(_waved_rmw_accumulator_kernel())
+    assert schedule is not None
+    bufs = _alloc_buffers(mod)
+    # Inner alternation and outer binding both pinned single-buffered.
+    tvm.ir.assert_structural_equal(schedule.pipelines[2], T.WSPipeline("C_tmem", [bufs["C_tmem"]], depth=1))
+    tvm.ir.assert_structural_equal(schedule.pipelines[3], T.WSPipeline("C_tmem_loop_1", [bufs["C_tmem"]], depth=1))
+
+    mod, schedule = _schedule(_waved_rmw_accumulator_kernel(depth=2))
+    assert schedule is not None
+    bufs = _alloc_buffers(mod)
+    # The inner binding stays pinned; the annotation gives the wave ring.
+    tvm.ir.assert_structural_equal(schedule.pipelines[2], T.WSPipeline("C_tmem", [bufs["C_tmem"]], depth=1))
+    tvm.ir.assert_structural_equal(schedule.pipelines[3], T.WSPipeline("C_tmem_loop_1", [bufs["C_tmem"]], depth=2))
+
+
+@tilelang.testing.requires_cuda
+def test_annotated_ws_pipeline_depth_on_inner_binding_declines():
+    """The waved accumulator's inner binding has a GUARDED writer (the
+    rescale): versioning it would expose a stale slot, so the annotated
+    depth declines."""
+    prepared = _prepare(_waved_rmw_accumulator_kernel(inner_depth=2))
+    scheduled = _auto_schedule(prepared)
+    assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+def test_annotated_ws_pipeline_depth_ring_numerical():
+    kernel = tilelang.compile(
+        _waved_rmw_accumulator_kernel(depth=2),
+        target="cuda",
+        out_idx=[3],
+        pass_configs={"tl.enable_auto_schedule": "role_based"},
+    )
+    a = torch.randn((2, 4, 128, 64), device="cuda", dtype=torch.float16)
+    b = torch.randn((2, 4, 64, 64), device="cuda", dtype=torch.float16)
+    scale = torch.rand((4,), device="cuda", dtype=torch.float32) + 0.5
+    actual = kernel(a, b, scale)
+    expected = torch.zeros((2, 128, 64), device="cuda", dtype=torch.float32)
+    for w in range(2):
+        for k in range(4):
+            if k > 0:
+                expected[w] *= scale[k]
+            expected[w] += a[w, k].float() @ b[w, k].float().T
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_cuda
+def test_seamless_sibling_bindings_rejected_by_materializer():
+    """Two sibling loops hand the accumulator back and forth seamlessly
+    (MMA->Worker in the first, Worker->MMA in the second), so no transfer
+    is needed at the wave level — but the loops' pipelines would then be
+    sibling bindings of one storage, whose barriers cannot chain. The
+    kernel declines."""
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((2, 128, 64), T.float16),
+        B: T.Tensor((2, 64, 64), T.float16),
+        C: T.Tensor((2, 128, 64), T.float32),
+    ):
+        with T.Kernel(1, threads=128):
+            A1_shared = T.alloc_shared((128, 64), T.float16)
+            B1_shared = T.alloc_shared((64, 64), T.float16)
+            A2_shared = T.alloc_shared((128, 64), T.float16)
+            B2_shared = T.alloc_shared((64, 64), T.float16)
+            C_tmem = T.alloc_tmem((128, 64), T.float32)
+            C_frag = T.alloc_fragment((128, 64), T.float32)
+            for w in T.serial(2):
+                for _k1 in T.Pipelined(2, num_stages=2):
+                    T.copy(A[0, 0, 0], A1_shared)
+                    T.copy(B[0, 0, 0], B1_shared)
+                    T.gemm(A1_shared, B1_shared, C_tmem, transpose_B=True, clear_accum=True)
+                    T.copy(C_tmem, C_frag)
+                    T.copy(C_frag, C[w, 0, 0])
+                for _k2 in T.Pipelined(2, num_stages=2):
+                    T.copy(A[1, 0, 0], A2_shared)
+                    T.copy(B[1, 0, 0], B2_shared)
+                    T.copy(C_frag, C_tmem)
+                    T.gemm(A2_shared, B2_shared, C_tmem, transpose_B=True, clear_accum=False)
+
+    mod, schedule = _schedule(kernel)
+    assert schedule is not None
+    with pytest.raises(Exception, match="not strictly nested"):
+        tilelang.cuda.transform.MaterializeWSSchedule()(mod)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_auto_schedule.py
+++ b/testing/python/transform/test_tilelang_transform_auto_schedule.py
@@ -93,8 +93,8 @@ def test_tma_load_pipeline():
         T.WSSchedule(
             num_warps=8,
             roles=[
-                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
-                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
+                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=104),
+                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=24),
             ],
             pipelines=[T.WSPipeline("S", [bufs["S"]], depth=2)],
             scopes=[
@@ -158,8 +158,8 @@ def test_two_cycles_on_one_buffer_and_root_depth():
         T.WSSchedule(
             num_warps=8,
             roles=[
-                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
-                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
+                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=104),
+                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=24),
             ],
             pipelines=[T.WSPipeline("S", [bufs["S"]], depth=1)],
             scopes=[
@@ -345,8 +345,8 @@ def test_worker_gemm_topology_materializes():
         T.WSSchedule(
             num_warps=8,
             roles=[
-                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
-                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
+                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=104),
+                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=24),
             ],
             pipelines=[
                 T.WSPipeline("A_shared", [bufs["A_shared"]], depth=2),
@@ -435,10 +435,10 @@ def test_tmem_gemm_four_role_topology():
         T.WSSchedule(
             num_warps=8,
             roles=[
-                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
-                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
-                T.WSRole("MMA", warps_lo=5, warps_hi=6, max_nreg=32),
-                T.WSRole("Store", warps_lo=6, warps_hi=7, max_nreg=32),
+                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=232),
+                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=24),
+                T.WSRole("MMA", warps_lo=5, warps_hi=6, max_nreg=24),
+                T.WSRole("Store", warps_lo=6, warps_hi=7, max_nreg=24),
             ],
             pipelines=[
                 T.WSPipeline("A_shared", [bufs["A_shared"]], depth=2),
@@ -676,9 +676,9 @@ def test_rmw_accumulator_nested_pipelines():
         T.WSSchedule(
             num_warps=8,
             roles=[
-                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
-                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
-                T.WSRole("MMA", warps_lo=5, warps_hi=6, max_nreg=32),
+                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=104),
+                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=24),
+                T.WSRole("MMA", warps_lo=5, warps_hi=6, max_nreg=24),
             ],
             pipelines=[
                 T.WSPipeline("A_shared", [bufs["A_shared"]], depth=2),
@@ -803,8 +803,8 @@ def test_post_loop_read_forms_outer_pipeline():
         T.WSSchedule(
             num_warps=8,
             roles=[
-                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
-                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
+                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=104),
+                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=24),
             ],
             pipelines=[
                 T.WSPipeline("S", [bufs["S"]], depth=2),
@@ -955,8 +955,8 @@ def test_while_scope_is_scheduled():
         T.WSSchedule(
             num_warps=8,
             roles=[
-                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
-                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
+                T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=104),
+                T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=24),
             ],
             pipelines=[T.WSPipeline("S", [bufs["S"]], depth=1)],
             scopes=[

--- a/testing/python/transform/test_tilelang_transform_materialize_ws_schedule.py
+++ b/testing/python/transform/test_tilelang_transform_materialize_ws_schedule.py
@@ -124,6 +124,9 @@ def test_basic_two_role_transform():
     assert "if tx < 32:" in script
     assert "T.set_max_nreg(40, 0)" in script
     assert "T.set_max_nreg(224, 1)" in script
+    # The roles carry their own setmaxnreg: marked custom WS so the late
+    # reg-alloc pass stays out.
+    assert 'T.attr(0, "kCustomWarpSpecialization", 1)' in script
     # The schedule annotation is consumed.
     assert "ws_schedule" not in script
     # Every scheduling marker is stripped.
@@ -2780,8 +2783,7 @@ def test_idle_warps_adopt_warpgroup_nreg():
 
     func = _materialize(kernel)
     script = str(func)
-    # Producer branch + idle warps 1..3 of warpgroup 0: both request 80.
-    assert script.count("T.set_max_nreg(80, 0)") == 2
+    assert script.count("T.set_max_nreg(80, 1)") == 2
     assert script.count("T.set_max_nreg(40, 0)") == 1  # consumer warpgroup
 
 

--- a/testing/python/transform/test_tilelang_transform_materialize_ws_schedule.py
+++ b/testing/python/transform/test_tilelang_transform_materialize_ws_schedule.py
@@ -180,9 +180,9 @@ def test_buffer_multi_versioning():
 def test_barrier_counts_tma_and_threads():
     func = _materialize(_smem_pipeline_kernel())
     script = str(func)
-    # Producer side: the TMA data rides the tx-count; the per-thread
-    # arrive of the producer warp (32 threads) closes the arrival count.
-    assert "buf_full: [32, 32]" in script
+    # Producer side: the TMA data rides the tx-count and one elected
+    # arrive fused into the copy closes the arrival count.
+    assert "buf_full: [1, 1]" in script
     # Consumer side: synchronous fragment reads -> all 128 consumer threads.
     assert "buf_empty: [128, 128]" in script
 
@@ -192,11 +192,13 @@ def test_tma_copy_conversion_carries_barrier():
     func = _materialize(_smem_pipeline_kernel())
     script = str(func)
     # The producer copy is converted to tma_copy with the full barrier
-    # attached; the commit is a plain per-thread arrive.
+    # attached; as the last copy of a pure-TMA commit cycle it also
+    # carries the cycle's single elected arrive, so the commit entry
+    # emits no arrive of its own.
     assert "T.tma_copy(" in script
     assert "barrier=buf_full" in script
-    assert "emit_arrive" not in script
-    assert "T.ptx_arrive_barrier(buf_full" in script
+    assert "emit_arrive=1" in script
+    assert "T.ptx_arrive_barrier(buf_full" not in script
 
 
 @tilelang.testing.requires_cuda
@@ -596,6 +598,7 @@ def test_empty_defs_op_duplicated_across_roles():
         with T.Kernel(1, threads=128) as _:
             A_shared = T.alloc_shared((64, 64), T.float16)
             A_frag = T.alloc_fragment((64, 64), T.float16)
+            probe = T.alloc_fragment((64,), T.float16)
 
             T.annotate_ws_schedule(
                 T.WSSchedule(
@@ -634,12 +637,12 @@ def test_empty_defs_op_duplicated_across_roles():
                 )
             )
 
-            T.fill(A_frag, 0, annotations={T.WSID: "init_frag"})
+            T.fill(probe, 0, annotations={T.WSID: "init_frag"})
             for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
                 T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
                 T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
-                for r, c in T.Parallel(64, 64, annotations={T.WSID: "step_frag"}):
-                    A_frag[r, c] = A_frag[r, c] + T.float16(1.0)
+                for r in T.Parallel(64, annotations={T.WSID: "step_frag"}):
+                    probe[r] = probe[r] + T.float16(1.0)
             T.copy(A_frag, B[0, 0], annotations={T.WSID: "copy_out"})
 
     func = _materialize(kernel)
@@ -647,7 +650,7 @@ def test_empty_defs_op_duplicated_across_roles():
     # Both roles run their own copy: once in the producer branch, once in
     # the consumer branch — at the root and inside the loop scope alike.
     assert script.count("T.fill(") == 2
-    assert script.count("A_frag[r, c] + T.float16(1.0)") == 2
+    assert script.count("probe[r] + T.float16(1.0)") == 2
     # Scheduling metadata is fully consumed.
     assert "ws_op_id" not in script
 
@@ -1096,6 +1099,361 @@ def test_unannotated_global_store_rejected():
         _materialize(_smem_pipeline_kernel(kernel_edit="unannotated_global_store"))
 
 
+def _bind_guard_kernel(bind_in_consumer):
+    """Producer binds a scalar read from global memory; the consumer guards
+    its pipeline read with that scalar."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            consumer_body = [
+                T.WSSync.consumer_wait("buf"),
+                "copy_frag",
+                T.WSSync.consumer_release("buf"),
+                "copy_out",
+            ]
+            if bind_in_consumer:
+                consumer_body.insert(0, "bind_lim")
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    "bind_lim",
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": consumer_body,
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                with T.ws_op("bind_lim"):
+                    lim = A[i, 0]
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                if lim > T.float16(0):
+                    T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_var_use_requires_defining_op_in_role():
+    """A guard using a var whose defining Bind op runs only in the other
+    role would reference an undefined variable in the emitted branch."""
+    with pytest.raises(Exception, match="does not run earlier in that role"):
+        _materialize(_bind_guard_kernel(bind_in_consumer=False))
+    # Placing the Bind in both roles (it has no pipeline operands) is legal.
+    script = str(_materialize(_bind_guard_kernel(bind_in_consumer=True)))
+    assert script.count("lim") >= 2
+
+
+@tilelang.testing.requires_cuda
+def test_bind_under_stage_shift_freshens_per_slice():
+    """A Bind op inside a stage-shifted scope is emitted once per unrolled
+    prologue/epilogue step and once in the steady-state loop; every emitted
+    copy must define a fresh variable (SSA)."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((32, 64), T.float16)
+            C_shared = T.alloc_shared((32, 64), T.float16)
+            A_frag = T.alloc_fragment((32, 64), T.float16)
+            C_frag = T.alloc_fragment((32, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[
+                        T.WSPipeline("a", [A_shared], depth=2),
+                        T.WSPipeline("c", [C_shared], depth=2),
+                    ],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    "bind_v",
+                                    T.WSSync.producer_acquire("a", stage=0),
+                                    "copy_a",
+                                    T.WSSync.producer_commit("a", stage=0),
+                                    T.WSSync.producer_acquire("c", stage=1),
+                                    "copy_c",
+                                    T.WSSync.producer_commit("c", stage=1),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("a", stage=0),
+                                    "read_a",
+                                    T.WSSync.consumer_release("a", stage=0),
+                                    T.WSSync.consumer_wait("c", stage=0),
+                                    "read_c",
+                                    T.WSSync.consumer_release("c", stage=0),
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                with T.ws_op("bind_v"):
+                    v = A[i, 0]
+                if v > T.float16(0):
+                    T.copy(A[i * 32, 0], A_shared, annotations={T.WSID: "copy_a"})
+                T.copy(A[i * 32, 0], C_shared, annotations={T.WSID: "copy_c"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "read_a"})
+                T.copy(C_shared, C_frag, annotations={T.WSID: "read_c"})
+
+    func = _materialize(kernel)
+    assert tvm.tirx.analysis.verify_ssa(func)
+    script = str(func)
+    # Prologue and steady state each bind their own copy of `v`.
+    assert len(set(re.findall(r"v_ws\d+", script))) >= 2
+
+
+@tilelang.testing.requires_cuda
+def test_var_def_use_stage_mismatch_rejected():
+    """Under a stage shift, a definition and its use at different deltas
+    would be split apart by the unrolled prologue/epilogue steps."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((32, 64), T.float16)
+            C_shared = T.alloc_shared((32, 64), T.float16)
+            A_frag = T.alloc_fragment((32, 64), T.float16)
+            C_frag = T.alloc_fragment((32, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[
+                        T.WSPipeline("a", [A_shared], depth=2),
+                        T.WSPipeline("c", [C_shared], depth=2),
+                    ],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    "bind_v",
+                                    T.WSSync.producer_acquire("a", stage=0),
+                                    "copy_a",
+                                    T.WSSync.producer_commit("a", stage=0),
+                                    T.WSSync.producer_acquire("c", stage=1),
+                                    "copy_c",
+                                    T.WSSync.producer_commit("c", stage=1),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("a", stage=0),
+                                    "read_a",
+                                    T.WSSync.consumer_release("a", stage=0),
+                                    T.WSSync.consumer_wait("c", stage=0),
+                                    "read_c",
+                                    T.WSSync.consumer_release("c", stage=0),
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                with T.ws_op("bind_v"):
+                    v = A[i, 0]
+                T.copy(A[i * 32, 0], A_shared, annotations={T.WSID: "copy_a"})
+                if v > T.float16(0):
+                    T.copy(A[i * 32, 0], C_shared, annotations={T.WSID: "copy_c"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "read_a"})
+                T.copy(C_shared, C_frag, annotations={T.WSID: "read_c"})
+
+    with pytest.raises(Exception, match="at a different stage"):
+        _materialize(kernel)
+
+
+def _alias_pipeline_kernel(use_view):
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((4, 64), T.float16),
+        B: T.Tensor((4, 64), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            shared = T.alloc_shared((64,), T.float16)
+            alias = T.view(shared, (8, 8)) if use_view else T.reshape(shared, (8, 8))
+            fragment = T.alloc_fragment((8, 8), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Load", warps_lo=4, warps_hi=5, max_nreg=32),
+                        T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=0),
+                    ],
+                    pipelines=[T.WSPipeline("shared_pipe", [shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop",
+                            {
+                                "Load": [
+                                    T.WSSync.producer_acquire("shared_pipe"),
+                                    "load",
+                                    T.WSSync.producer_commit("shared_pipe"),
+                                ],
+                                "Worker": [
+                                    T.WSSync.consumer_wait("shared_pipe", stage=1),
+                                    "consume_alias",
+                                    T.WSSync.consumer_release("shared_pipe", stage=1),
+                                    "store",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Load": ["loop"], "Worker": ["loop"]}),
+                    ],
+                )
+            )
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop"}):
+                T.copy(A[i, 0], shared, annotations={T.WSID: "load"})
+                T.copy(alias, fragment, annotations={T.WSID: "consume_alias"})
+                T.copy(fragment, B[i, 0], annotations={T.WSID: "store"})
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_versions_reshape_and_view_aliases_by_storage():
+    """T.view / T.reshape aliases share their allocation's storage, so they
+    join its pipeline and index the same acquired version."""
+    for use_view in (False, True):
+        script = str(_materialize(_alias_pipeline_kernel(use_view)))
+        assert "ws_schedule" not in script
+        assert "shared_pipe_full" in script
+        assert "shared = T.sblock_alloc_buffer((2, 64)" in script
+
+
+@tilelang.testing.requires_cuda
+def test_duplicated_op_global_write_rejected():
+    """A multi-role op runs once per role; a non-local write would repeat
+    the side effect."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                    "mark_global",
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                    "mark_global",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+                with T.ws_op("mark_global"):
+                    B[0, 0] = T.float16(1)
+
+    with pytest.raises(Exception, match="every role would repeat the write"):
+        _materialize(kernel)
+
+
+@tilelang.testing.requires_cuda
+def test_async_copy_in_consumer_role_rejected():
+    """A TMA copy writing a pipeline buffer must run in the role that
+    commits the pipeline's full side, or its transaction bytes are never
+    accounted."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "fill_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_in",
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.fill(A_shared, T.float16(0), annotations={T.WSID: "fill_in"})
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    with pytest.raises(Exception, match="never observes it finishing"):
+        _materialize(kernel)
+
+
 @tilelang.testing.requires_cuda
 def test_kernel_metadata_attrs_preserved():
     """Kernel-level metadata AttrStmts (T.use_swizzle,
@@ -1439,19 +1797,23 @@ def _scope_kind_kernel(loop_ctor):
 
 
 @tilelang.testing.requires_cuda
-def test_serial_scope_loop_and_unrolled_rejected():
-    """Any serial loop can be a schedule scope (T.Pipelined is a serial
-    loop whose num_stages this pass consumes); T.unroll / T.Parallel loops
-    cannot."""
+def test_sequential_scope_loop_kinds():
+    """Any sequential loop can be a schedule scope (T.Pipelined is a serial
+    loop whose num_stages this pass consumes; a T.unroll scope keeps its
+    unroll kind); T.Parallel loops cannot."""
     # A plain T.serial scope materializes like a T.Pipelined one.
-    func = _materialize(_scope_kind_kernel(T.serial))
-    script = str(func)
+    script = str(_materialize(_scope_kind_kernel(T.serial)))
     assert "T.mbarrier_wait_parity(" in script
     assert '"num_stages"' not in script
 
-    # T.unroll cannot be a scope.
-    with pytest.raises(Exception, match="must be a serial loop"):
-        _materialize(_scope_kind_kernel(T.unroll))
+    # A T.unroll scope materializes the same, keeping the unroll kind.
+    script = str(_materialize(_scope_kind_kernel(T.unroll)))
+    assert "T.mbarrier_wait_parity(" in script
+    assert "T.unroll(4)" in script
+
+    # A T.Parallel loop cannot be a scope.
+    with pytest.raises(Exception, match="must be a sequential loop"):
+        _materialize(_scope_kind_kernel(T.Parallel))
 
 
 @tilelang.testing.requires_cuda
@@ -1632,9 +1994,70 @@ def test_tcgen05_async_arrive_count():
 
 
 @tilelang.testing.requires_cuda
-def test_runtime_phase_counter_for_multi_depth_spans():
-    """A pipeline synchronized at two loop depths by one role needs a
-    runtime phase counter instead of the linearized iteration."""
+def test_runtime_phase_counter_for_multi_cycle_body():
+    """A pipeline cycled twice per iteration of its scope needs a runtime
+    phase counter instead of the linearized iteration."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in2",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag2",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out2",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+
+            for i in T.Pipelined(2, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 128, 0], A_shared, annotations={T.WSID: "copy_in"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(A_frag, B[i * 128, 0], annotations={T.WSID: "copy_out"})
+                T.copy(A[i * 128 + 64, 0], A_shared, annotations={T.WSID: "copy_in2"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag2"})
+                T.copy(A_frag, B[i * 128 + 64, 0], annotations={T.WSID: "copy_out2"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    # Both roles track their buf phase with a local counter.
+    assert "buf_phase" in script
+
+
+@tilelang.testing.requires_cuda
+def test_pipeline_synced_in_two_scopes_rejected():
+    """A pipeline synchronizes exactly one scope; syncing buf at the root
+    AND inside loop_k must be split into two (nested) pipelines."""
 
     @T.prim_func
     def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
@@ -1670,8 +2093,6 @@ def test_runtime_phase_counter_for_multi_depth_spans():
                             T.WSScope.ROOT,
                             {
                                 "Producer": [
-                                    # An extra root-level cycle: the producer
-                                    # now syncs buf at two loop depths.
                                     T.WSSync.producer_acquire("buf"),
                                     "copy_head",
                                     T.WSSync.producer_commit("buf"),
@@ -1698,10 +2119,382 @@ def test_runtime_phase_counter_for_multi_depth_spans():
                 T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
                 T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
 
-    func = _materialize(kernel)
+    with pytest.raises(Exception, match="synchronizes exactly one scope"):
+        _materialize(kernel)
+
+
+def _nested_pipeline_kernel(accum_brackets_loop=True):
+    """An rmw-shaped nested binding: inside loop_k the Rescale role writes
+    A_shared and the Accum role read-modify-writes it (pipeline `buf`); at
+    the root, Accum producer-brackets the whole loop and Rescale reads the
+    final value (pipeline `buf_outer`)."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            B_frag = T.alloc_fragment((64, 64), T.float16)
+
+            accum_root = (
+                [
+                    T.WSSync.producer_acquire("buf_outer"),
+                    "loop_k",
+                    T.WSSync.producer_commit("buf_outer"),
+                ]
+                if accum_brackets_loop
+                # The bracket misses the loop: Accum's writes inside loop_k
+                # would not publish through the outer commit.
+                else [
+                    "loop_k",
+                    T.WSSync.producer_acquire("buf_outer"),
+                    T.WSSync.producer_commit("buf_outer"),
+                ]
+            )
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Rescale", warps_lo=0, warps_hi=4, max_nreg=224),
+                        T.WSRole("Accum", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[
+                        T.WSPipeline("buf", [A_shared], depth=1),
+                        T.WSPipeline("buf_outer", [A_shared], depth=1),
+                    ],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Rescale": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "produce",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Accum": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "acc_load",
+                                    "acc_store",
+                                    T.WSSync.consumer_release("buf"),
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {
+                                "Rescale": [
+                                    "loop_k",
+                                    T.WSSync.consumer_wait("buf_outer"),
+                                    "read_back",
+                                    T.WSSync.consumer_release("buf_outer"),
+                                    "store_out",
+                                ],
+                                "Accum": accum_root,
+                            },
+                        ),
+                    ],
+                )
+            )
+
+            for i in T.serial(4, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "produce"})
+                T.copy(A_shared, B_frag, annotations={T.WSID: "acc_load"})
+                T.copy(B_frag, A_shared, annotations={T.WSID: "acc_store"})
+            T.copy(A_shared, A_frag, annotations={T.WSID: "read_back"})
+            T.copy(A_frag, B[0, 0], annotations={T.WSID: "store_out"})
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_nested_pipelines_on_one_storage():
+    """A buffer bound to two pipelines in strictly nested scopes
+    materializes: each pipeline gets its own barrier pair, and every
+    access resolves against the innermost binding whose scope contains
+    it."""
+    func = _materialize(_nested_pipeline_kernel())
     script = str(func)
-    # Both roles track their buf phase with a local counter.
-    assert "buf_phase" in script
+    assert "buf_full" in script and "buf_empty" in script
+    assert "buf_outer_full" in script and "buf_outer_empty" in script
+
+
+@tilelang.testing.requires_cuda
+def test_nested_pipeline_producer_must_bracket_scope():
+    """The outer pipeline's producer must hold its span across the nested
+    scope: its writes inside publish through the outer commit."""
+    with pytest.raises(Exception, match="enclosing pipeline"):
+        _materialize(_nested_pipeline_kernel(accum_brackets_loop=False))
+
+
+@tilelang.testing.requires_cuda
+def test_sibling_pipelines_on_one_storage_rejected():
+    """Two pipelines on one buffer whose scopes are siblings are rejected:
+    nothing chains their barriers, so the second loop's pre-armed acquire
+    could overwrite data the first loop's consumer still reads."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[
+                        T.WSPipeline("buf_a", [A_shared], depth=2),
+                        T.WSPipeline("buf_b", [A_shared], depth=2),
+                    ],
+                    scopes=[
+                        T.WSScope(
+                            "loop_a",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf_a"),
+                                    "copy_in_a",
+                                    T.WSSync.producer_commit("buf_a"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf_a"),
+                                    "copy_frag_a",
+                                    T.WSSync.consumer_release("buf_a"),
+                                    "copy_out_a",
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            "loop_b",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf_b"),
+                                    "copy_in_b",
+                                    T.WSSync.producer_commit("buf_b"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf_b"),
+                                    "copy_frag_b",
+                                    T.WSSync.consumer_release("buf_b"),
+                                    "copy_out_b",
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {
+                                "Producer": ["loop_a", "loop_b"],
+                                "Consumer": ["loop_a", "loop_b"],
+                            },
+                        ),
+                    ],
+                )
+            )
+
+            for i in T.serial(2, annotations={T.WSID: "loop_a"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in_a"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag_a"})
+                T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out_a"})
+            for i in T.serial(2, annotations={T.WSID: "loop_b"}):
+                T.copy(A[128 + i * 64, 0], A_shared, annotations={T.WSID: "copy_in_b"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag_b"})
+                T.copy(A_frag, B[128 + i * 64, 0], annotations={T.WSID: "copy_out_b"})
+
+    with pytest.raises(Exception, match="strictly nested"):
+        _materialize(kernel)
+
+
+def _nested_ring_kernel(rescale_syncs_before_loop=False):
+    """The rmw shape under an outer FOR loop with a depth-2 outer pipeline:
+    O-style storage double-buffers across outer iterations (versions
+    1 x 2). Rescale's in-loop produce holds only the inner span and derives
+    the outer slot from its own phase (the linearized outer iteration)."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((512, 64), T.float16), B: T.Tensor((128, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            B_frag = T.alloc_fragment((64, 64), T.float16)
+
+            rescale_wave = (
+                # The syncs run before the loop reference: Rescale's phase
+                # then names the NEXT cycle when produce runs — rejected.
+                [
+                    T.WSSync.consumer_wait("buf_outer"),
+                    "read_back",
+                    T.WSSync.consumer_release("buf_outer"),
+                    "loop_k",
+                    "store_out",
+                ]
+                if rescale_syncs_before_loop
+                else [
+                    "loop_k",
+                    T.WSSync.consumer_wait("buf_outer"),
+                    "read_back",
+                    T.WSSync.consumer_release("buf_outer"),
+                    "store_out",
+                ]
+            )
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Rescale", warps_lo=0, warps_hi=4, max_nreg=224),
+                        T.WSRole("Accum", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[
+                        T.WSPipeline("buf", [A_shared], depth=1),
+                        T.WSPipeline("buf_outer", [A_shared], depth=2),
+                    ],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Rescale": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "produce",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Accum": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "acc_load",
+                                    "acc_store",
+                                    T.WSSync.consumer_release("buf"),
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            "loop_w",
+                            {
+                                "Rescale": rescale_wave,
+                                "Accum": [
+                                    T.WSSync.producer_acquire("buf_outer"),
+                                    "loop_k",
+                                    T.WSSync.producer_commit("buf_outer"),
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Rescale": ["loop_w"], "Accum": ["loop_w"]}),
+                    ],
+                )
+            )
+
+            for w in T.serial(2, annotations={T.WSID: "loop_w"}):
+                for i in T.serial(4, annotations={T.WSID: "loop_k"}):
+                    T.copy(A[(w * 4 + i) * 64, 0], A_shared, annotations={T.WSID: "produce"})
+                    T.copy(A_shared, B_frag, annotations={T.WSID: "acc_load"})
+                    T.copy(B_frag, A_shared, annotations={T.WSID: "acc_store"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "read_back"})
+                T.copy(A_frag, B[w * 64, 0], annotations={T.WSID: "store_out"})
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_nested_pipeline_outer_ring():
+    """A depth-2 outer binding over a depth-1 inner one gives the buffer
+    two slots cycling with the outer loop; every access resolves the outer
+    slot — from its span, or (the joint-role produce) from the role's own
+    phase."""
+    func = _materialize(_nested_ring_kernel())
+    script = str(func)
+    assert "buf_outer_full" in script and "buf_outer_empty" in script
+    # One version dimension per binding, outermost first: the outer
+    # ring's 2 slots and the inner binding's pinned 1.
+    assert "(2, 1, 64, 64)" in script
+
+
+@tilelang.testing.requires_cuda
+def test_nested_pipeline_access_after_sync_rejected():
+    """Once the role's sync entries of the outer pipeline have run, its
+    phase names the next cycle, so a later unheld access can no longer
+    derive the in-production slot."""
+    with pytest.raises(Exception, match="after this role's sync"):
+        _materialize(_nested_ring_kernel(rescale_syncs_before_loop=True))
+
+
+def _observer_producer_kernel():
+    """Nested bindings where the outer producer never writes the storage:
+    the Load role TMA-fills A_shared inside loop_k, the Worker observes it
+    through the inner handshake and hands the whole loop's result to the
+    Out role. The collapsed scope use is what the Worker's outer commit
+    publishes."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((64, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Load", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Out", warps_lo=1, warps_hi=2, max_nreg=40),
+                        T.WSRole("Worker", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[
+                        T.WSPipeline("buf", [A_shared], depth=1),
+                        T.WSPipeline("buf_outer", [A_shared], depth=1),
+                    ],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Load": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Worker": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {
+                                "Load": ["loop_k"],
+                                "Worker": [
+                                    T.WSSync.producer_acquire("buf_outer"),
+                                    "loop_k",
+                                    T.WSSync.producer_commit("buf_outer"),
+                                ],
+                                "Out": [
+                                    T.WSSync.consumer_wait("buf_outer"),
+                                    "copy_out",
+                                    T.WSSync.consumer_release("buf_outer"),
+                                ],
+                            },
+                        ),
+                    ],
+                )
+            )
+
+            for i in T.serial(4, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+            T.copy(A_shared, B[0, 0], annotations={T.WSID: "copy_out"})
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_scope_use_publishes_observed_writes():
+    """The Worker writes nothing, yet its commit validly publishes the
+    scope's TMA-filled data — its thread observed every inner handoff
+    before leaving the loop, so a plain per-thread arrive suffices (the
+    collapsed scope use is synchronous)."""
+    func = _materialize(_observer_producer_kernel())
+    script = str(func)
+    # Full side: the Worker's 128 per-thread arrives; empty side: Out's 32.
+    assert "buf_outer_full: [128]" in script
+    assert "buf_outer_empty: [32]" in script
 
 
 @tilelang.testing.requires_cuda
@@ -1795,10 +2588,10 @@ def test_guard_read_outside_span_rejected():
 
 
 @tilelang.testing.requires_cuda
-def test_one_sided_scope_cycles_rejected():
-    """A pipeline cycling on one side only inside a loop scope (its
-    counterpart cycles in the root here) diverges with the loop extent;
-    every pipeline must cycle both sides equally often per iteration."""
+def test_unbalanced_scope_cycles_rejected():
+    """A pipeline cycling twice on the producer side but once on the
+    consumer side per iteration diverges with the loop extent; every
+    pipeline must cycle both sides equally often within its scope."""
 
     @T.prim_func
     def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
@@ -1822,13 +2615,10 @@ def test_one_sided_scope_cycles_rejected():
                                     T.WSSync.producer_acquire("buf"),
                                     "copy_in",
                                     T.WSSync.producer_commit("buf"),
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in2",
+                                    T.WSSync.producer_commit("buf"),
                                 ],
-                            },
-                        ),
-                        T.WSScope(
-                            T.WSScope.ROOT,
-                            {
-                                "Producer": ["loop_k"],
                                 "Consumer": [
                                     T.WSSync.consumer_wait("buf"),
                                     "copy_frag",
@@ -1837,14 +2627,16 @@ def test_one_sided_scope_cycles_rejected():
                                 ],
                             },
                         ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
                     ],
                 )
             )
 
             for _i in T.serial(4, annotations={T.WSID: "loop_k"}):
                 T.copy(A[0, 0], A_shared, annotations={T.WSID: "copy_in"})
-            T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
-            T.copy(A_frag, B[0, 0], annotations={T.WSID: "copy_out"})
+                T.copy(A[64, 0], A_shared, annotations={T.WSID: "copy_in2"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(A_frag, B[0, 0], annotations={T.WSID: "copy_out"})
 
     with pytest.raises(Exception, match="parity diverges"):
         _materialize(kernel)
@@ -2069,6 +2861,254 @@ def test_negative_warp_range_rejected():
             T.copy(A, B, annotations={T.WSID: "cp"})
 
     with pytest.raises(Exception, match="negative warp range"):
+        _materialize(kernel)
+
+
+@tilelang.testing.requires_cuda
+def test_capacity_deadlock_rejected():
+    """Two roles produce into sibling scopes in opposite orders: each
+    fills its pipeline's depth and blocks on an acquire that only the
+    other's never-reached consumer scope would release. Surfaces only
+    when loops are modeled past two iterations."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            S1 = T.alloc_shared((64, 64), T.float16)
+            S2 = T.alloc_shared((64, 64), T.float16)
+            F1 = T.alloc_fragment((64, 64), T.float16)
+            F2 = T.alloc_fragment((64, 64), T.float16)
+
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[
+                        T.WSPipeline("s1", [S1], depth=2),
+                        T.WSPipeline("s2", [S2], depth=2),
+                    ],
+                    scopes=[
+                        T.WSScope(
+                            "loop_a",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("s1"),
+                                    "copy_in1",
+                                    T.WSSync.producer_commit("s1"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("s1"),
+                                    "copy_frag1",
+                                    T.WSSync.consumer_release("s1"),
+                                    "copy_out1",
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            "loop_b",
+                            {
+                                "Consumer": [
+                                    T.WSSync.producer_acquire("s2"),
+                                    "copy_in2",
+                                    T.WSSync.producer_commit("s2"),
+                                ],
+                                "Producer": [
+                                    T.WSSync.consumer_wait("s2"),
+                                    "copy_frag2",
+                                    T.WSSync.consumer_release("s2"),
+                                    "copy_out2",
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {
+                                "Producer": ["loop_a", "loop_b"],
+                                "Consumer": ["loop_b", "loop_a"],
+                            },
+                        ),
+                    ],
+                )
+            )
+
+            for _i in T.serial(4, annotations={T.WSID: "loop_a"}):
+                T.copy(A[0, 0], S1, annotations={T.WSID: "copy_in1"})
+                T.copy(S1, F1, annotations={T.WSID: "copy_frag1"})
+                T.copy(F1, B[0, 0], annotations={T.WSID: "copy_out1"})
+            for _i in T.serial(4, annotations={T.WSID: "loop_b"}):
+                T.copy(A[64, 0], S2, annotations={T.WSID: "copy_in2"})
+                T.copy(S2, F2, annotations={T.WSID: "copy_frag2"})
+                T.copy(F2, B[64, 0], annotations={T.WSID: "copy_out2"})
+
+    with pytest.raises(Exception, match="deadlocks"):
+        _materialize(kernel)
+
+
+@tilelang.testing.requires_cuda
+def test_guarded_scope_syncs_use_phase_counter():
+    """A guard-skipped iteration produces no cycle but would still
+    advance a linearized phase; sync entries inside a guarded scope must
+    fall back to runtime phase counters."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(2, threads=128) as bx:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+
+            if bx == 0:
+                for i in T.serial(4, annotations={T.WSID: "loop_k"}):
+                    T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                    T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                    T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    assert "buf_phase" in script
+
+
+@tilelang.testing.requires_cuda
+def test_pipeline_on_private_storage_rejected():
+    """Each role has its own physical instance of fragment storage, so a
+    pipeline over it could never hand a value across roles."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_frag], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {"Producer": ["cp_in"], "Consumer": ["cp_out"]},
+                        ),
+                    ],
+                )
+            )
+            T.copy(A[0, 0], A_frag, annotations={T.WSID: "cp_in"})
+            T.copy(A_frag, B[0, 0], annotations={T.WSID: "cp_out"})
+
+    with pytest.raises(Exception, match="must live in shared or tensor memory"):
+        _materialize(kernel)
+
+
+@tilelang.testing.requires_cuda
+def test_duplicate_pipeline_name_rejected():
+    """Sync entries reference pipelines by name; two pipelines sharing a
+    name would bind both sync streams to the first."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            S1 = T.alloc_shared((64, 64), T.float16)
+            S2 = T.alloc_shared((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[
+                        T.WSPipeline("buf", [S1], depth=2),
+                        T.WSPipeline("buf", [S2], depth=2),
+                    ],
+                    scopes=[
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["cp"], "Consumer": []}),
+                    ],
+                )
+            )
+            T.copy(A[0, 0], B[0, 0], annotations={T.WSID: "cp"})
+
+    with pytest.raises(Exception, match="duplicate pipeline name"):
+        _materialize(kernel)
+
+
+@tilelang.testing.requires_cuda
+def test_scope_body_role_never_entering_rejected():
+    """A role's body in a scope its parent never enters for that role
+    would plan barrier arrivals that are never emitted."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": []}),
+                    ],
+                )
+            )
+
+            for i in T.serial(4, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    with pytest.raises(Exception, match="never enters it from the parent scope"):
         _materialize(kernel)
 
 

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -100,9 +100,11 @@ def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     # @CUDA-specific
     # Tile-level warp specialization: runs before layout inference so that
     # producer/consumer split happens at the high-level tile-op IR.
+    # AutoSchedule: derive a WSSchedule for kernels without one, using the scheduler named by tl.enable_auto_schedule (opt-in; no-op when unset).
     # MaterializeWSSchedule: Materialize a user-provided warp-specialization schedule (T.annotate_ws_schedule).
     # ProducerConsumerWarpSpecialized: The pass classifies copy ops as TMA/cp.async/sync inline. Shared buffers are multi-versioned internally only for functions where the WS transformation actually applies.
     if allow_warp_specialized(target=target):
+        mod = tilelang.cuda.transform.AutoSchedule()(mod)
         mod = tilelang.cuda.transform.MaterializeWSSchedule()(mod)
         mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
 

--- a/tilelang/cuda/transform/__init__.py
+++ b/tilelang/cuda/transform/__init__.py
@@ -3,6 +3,24 @@
 from .. import _ffi_api
 
 
+def AutoSchedule():
+    """Derive a warp-specialization schedule with the scheduler named by
+    the ``tl.enable_auto_schedule`` pass config (currently
+    ``"role_based"``); a no-op when the config is unset.
+
+    Eligible kernels gain stable ``tl.ws_op_id`` markers and a typed
+    ``WSSchedule`` block annotation — the same surface a hand-written
+    schedule uses — which :func:`MaterializeWSSchedule` then lowers.
+    Kernels the scheduler declines are left unchanged.
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.AutoSchedule()  # type: ignore
+
+
 def AnnotateDeviceBoundTmaCopies():
     """Mark tile copies whose TensorMap base is defined in the device body.
 
@@ -160,6 +178,7 @@ def PersistThreadblock():
 
 __all__ = [
     "AnnotateDeviceBoundTmaCopies",
+    "AutoSchedule",
     "AnnotateWarpGroupRegAlloc",
     "FuseMBarrierArriveExpectTx",
     "InjectFenceProxy",

--- a/tilelang/language/annotations.py
+++ b/tilelang/language/annotations.py
@@ -6,7 +6,7 @@ from tilelang.layout import Fragment, Layout, PartialFragment
 from tilelang.utils.language import is_fragment, is_reducer
 from tvm.tirx.script.parser import attr
 from tvm.tirx.script.builder.ir import sblock_attr
-from tvm.tirx import FloatImm, tvm_tuple
+from tvm.tirx import FloatImm, IntImm, tvm_tuple
 
 __all__ = [
     "WSID",
@@ -16,6 +16,7 @@ __all__ = [
     "annotate_l2_hit_ratio",
     "annotate_restrict_buffers",
     "annotate_min_blocks_per_sm",
+    "annotate_ws_pipeline_depth",
     "annotate_ws_schedule",
     "ws_op",
 ]
@@ -132,17 +133,32 @@ def annotate_restrict_buffers(*buffers):
     return sblock_attr({"tl.non_restrict_params": data_vars})
 
 
+def annotate_ws_pipeline_depth(depth_map: dict):
+    """Declare the depth of the pipelines the automatic scheduler hosts at
+    the ENCLOSING scope for the given buffers, asserting each recurrence
+    resets per version — otherwise the depth derives from the loop's
+    ``num_stages``, and accumulators pin single-buffered.
+
+    ``depth_map`` maps each buffer to its pipeline depth at this scope.
+    """
+    _map = {}
+    for buffer, depth in depth_map.items():
+        assert isinstance(depth, int) and depth >= 1, f"pipeline depth must be a positive int, got {depth!r}"
+        _map[buffer.data] = IntImm("int32", depth)
+    return attr(_map, "tl.ws_pipeline_depth", 0)
+
+
 def annotate_ws_schedule(schedule):
     """Attach a warp-specialization schedule to the kernel.
 
-    ``schedule`` is a typed :class:`~tilelang.language.ws_schedule.WSSchedule`
+    ``schedule`` is a typed :class:`~tilelang.language.warp_specialize.WSSchedule`
     object describing how to transform the straight-line kernel into a
     warp-specialized one: warp roles, pipelines (full/empty barrier pairs
     protecting multi-versioned buffers), and per-role instruction sequences
     per loop scope. It is materialized by the ``MaterializeWSSchedule`` pass;
     see ``examples/aws/gemm.py`` for a complete example.
     """
-    from tilelang.language.ws_schedule import WSSchedule
+    from tilelang.language.warp_specialize import WSSchedule
 
     assert isinstance(schedule, WSSchedule), f"annotate_ws_schedule expects a T.WSSchedule object, got {type(schedule)}"
     return sblock_attr({"tl.ws_schedule": schedule})

--- a/tilelang/language/common.py
+++ b/tilelang/language/common.py
@@ -144,11 +144,12 @@ from .annotations import (  # noqa: F401
     annotate_layout,
     annotate_safe_value,
     annotate_restrict_buffers,
+    annotate_ws_pipeline_depth,
     annotate_ws_schedule,
     ws_op,
 )
 
-from .ws_schedule import (  # noqa: F401
+from .warp_specialize import (  # noqa: F401
     WSRole,
     WSPipeline,
     WSInstr,
@@ -228,6 +229,7 @@ _LOCAL_EXPORTS = (
     "annotate_layout",
     "annotate_restrict_buffers",
     "annotate_safe_value",
+    "annotate_ws_pipeline_depth",
     "annotate_ws_schedule",
     "ws_op",
     "any_of",

--- a/tilelang/language/warp_specialize.py
+++ b/tilelang/language/warp_specialize.py
@@ -71,8 +71,10 @@ class WSPipeline(Node):
 
     The producer waits for the empty barrier and signals the full barrier;
     the consumer waits for the full barrier and signals the empty barrier.
-    ``depth`` is the number of buffer versions; multiple buffers can share
-    one pipeline.
+    A pipeline synchronizes exactly one scope, between exactly two roles.
+    Multiple buffers can share one pipeline; conversely, a buffer may be
+    bound to several pipelines whose scopes are strictly nested — its
+    version count is then the product of their depths (outer-major slots).
 
     Parameters
     ----------
@@ -81,7 +83,7 @@ class WSPipeline(Node):
     buffers : list[tirx.Buffer]
         The on-chip buffers this pipeline protects (and multi-versions).
     depth : int
-        The number of versions of each buffer.
+        The number of versions this pipeline contributes to each buffer.
     """
 
     def __init__(self, name: str, buffers: list[tirx.Buffer], depth: int):

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -73,6 +73,10 @@ class PassConfigKey(str, Enum):
     TL_DISABLE_WARP_SPECIALIZED = "tl.disable_warp_specialized"
     """Disable warp specialization optimization. Default: False"""
 
+    TL_ENABLE_AUTO_SCHEDULE = "tl.enable_auto_schedule"
+    """Name of the automatic warp-specialization scheduler to run (e.g.
+    "role_based"). Default: unset (disabled)."""
+
     TL_ENABLE_FAST_MATH = "tl.enable_fast_math"
     """
         Enable fast math optimization. Default: False


### PR DESCRIPTION
This PR adds the role-based automatic warp specialization scheduler. Heuristically there are 4 roles: TMA Load, MMA, TMA Store, and Worker. Tile ops are assigned to these roles based on their characteristics.

Now this scheduler is opt-in. Decorate your kernel with `@tilelang.jit(pass_configs={tilelang.PassConfigKey.TL_ENABLE_AUTO_SCHEDULE: "role_based"})` to enable it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added opt-in CUDA role-based automatic warp specialization through `tl.enable_auto_schedule`.
- Added and integrated the `tl.cuda.transform.AutoSchedule` pass before `MaterializeWSSchedule`.
- Added role classification for TMA Load, MMA, TMA Store, and Worker operations.
- Added dependency analysis, buffer-access detection, pipeline construction, barrier metadata, and unsupported-kernel validation.
- Added shared warp-specialization analysis and buffer-type helpers.
- Added pipeline-depth annotations through `annotate_ws_pipeline_depth`.
- Added `gemm_manual` and expanded FlashAttention examples with manual and auto-scheduled variants.
- Added extensive CUDA tests for scheduling, pipelines, synchronization, validation, materialization, and numerical correctness.

## C++ style / lint notes

- The PR changes C++ source and TileLang-owned headers covered by `docs/developer_guide/cpp_style.md`.
- The C++ API style audit and its warning-only CI step are relevant.
- TLCPP003 and TLCPP004 findings are advisory unless they indicate a clear API, FFI, or maintainability risk.
- Build correctness and test failures remain separate from warning-only style findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->