### PR TITLE
[BugFix] Scalarize Select in automatic vectorization

### DIFF
--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -530,6 +530,13 @@ private:
     return arith::IRMutatorWithAnalyzer::VisitStmt_(node);
   }
 
+  PrimExpr VisitExpr_(const SelectNode *node) final {
+    // Select stays an expression-level ternary. Constrain its vector width
+    // using the same condition-uniformity rule as IfThenElse.
+    CheckConditionVectorized(node->condition);
+    return arith::IRMutatorWithAnalyzer::VisitExpr_(node);
+  }
+
   static std::optional<int> GetAccessPtrElementBits(const PrimExpr &expr) {
     const auto *ptr_call = expr.as<CallNode>();
     if (ptr_call == nullptr) {

--- a/testing/python/language/test_tilelang_language_select.py
+++ b/testing/python/language/test_tilelang_language_select.py
@@ -85,8 +85,14 @@ def get_parallel_select_kernel():
     return main
 
 
-def test_parallel_select_vectorized_condition():
+def test_parallel_select_uniform_condition():
     kernel = get_parallel_select_kernel()
+    source = kernel.get_kernel_source()
+
+    assert "if (" not in source
+    assert ") ? " in source
+    assert "*(float4*)" in source or "load_global_256" in source
+
     A = torch.randn((1024,), dtype=torch.float32, device="cuda")
     B = torch.empty_like(A)
 
@@ -94,6 +100,37 @@ def test_parallel_select_vectorized_condition():
 
     expected = torch.zeros_like(A)
     expected[:512] = A[:512]
+    torch.testing.assert_close(B, expected)
+
+
+@tilelang.jit
+def get_parallel_data_dependent_select_kernel():
+    @T.prim_func
+    def main(
+        A: T.Tensor[(256,), T.float32],
+        B: T.Tensor[(256,), T.float32],
+    ):
+        with T.Kernel(1, threads=32):
+            for i in T.Parallel(256):
+                B[i] = T.Select(A[i] > T.float32(0), A[i], T.float32(0))
+
+    return main
+
+
+def test_parallel_data_dependent_select_disables_auto_vectorization():
+    kernel = get_parallel_data_dependent_select_kernel()
+    source = kernel.get_kernel_source()
+
+    assert "if (" not in source
+    assert ") ? " in source
+    assert "*(float4*)" not in source
+    assert "load_global_256" not in source
+
+    A = torch.randn((256,), dtype=torch.float32, device="cuda")
+    B = torch.empty_like(A)
+    kernel(A, B)
+
+    expected = torch.where(A > 0, A, torch.zeros_like(A))
     torch.testing.assert_close(B, expected)
 
 


### PR DESCRIPTION
Now `T.select` vectorization is disabled to align with `T.if_then_else`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Disabled automatic vectorization of `T.select`.
- Kept explicit `T.vectorized` loops unchanged.
- Added coverage for data-dependent parallel selects.
- Verified scalar code generation and correctness against `torch.where`.

## C++ style / lint notes

- The change touches C++ code but does not alter rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains advisory.
- No correctness or build issues were identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->