### PR TITLE
[Layout][Config] Add environment override for layout cost model

### DIFF
--- a/tilelang/autotuner/grouped_compile.py
+++ b/tilelang/autotuner/grouped_compile.py
@@ -20,6 +20,7 @@ from tilelang.jit.adapter import TVMFFIKernelAdapter
 from tilelang.jit.abi import prepare_tvm_ffi_callee_allocated_outputs
 from tilelang.jit.kernel import JITKernel
 from tilelang.transform import PassConfigKey
+from tilelang.transform.pass_config import normalize_pass_configs
 from tilelang.instrumentation import compile_pass_instrumentation, create_pass_instruments
 from tilelang.tools.pass_timing import create_pass_timing_tool
 
@@ -43,7 +44,7 @@ def compile_grouped_unit_tvm_ffi(
     timing_tool = create_pass_timing_tool(compile_args.pass_configs)
     tools = [timing_tool] if timing_tool is not None else []
     with compile_pass_instrumentation(name="grouped-tvm-ffi", tools=tools):
-        pass_configs = dict(compile_args.pass_configs) if compile_args.pass_configs else {}
+        pass_configs = normalize_pass_configs(compile_args.pass_configs)
         base_pass_instruments = []
         if pass_configs.get(PassConfigKey.TL_ENABLE_DUMP_IR):
             dump_ir_path = pass_configs.get(PassConfigKey.TL_DUMP_IR_DIR, "./dump_ir")

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -78,13 +78,18 @@ class CompileArgs:
 
     def __hash__(self):
         """Return a stable hash for cache key construction."""
+        from tilelang.transform.pass_config import normalize_pass_configs
+
+        # Resolve env-var-derived pass-config defaults so a changed environment
+        # does not silently reuse tuning results produced under another one.
+        pass_configs = normalize_pass_configs(self.pass_configs)
         data = {
             "out_idx": self.out_idx,
             "execution_backend": self.execution_backend,
             "target": str(self.target),
             "target_host": str(self.target_host) if self.target_host else None,
             "verbose": self.verbose,
-            "pass_configs": json.dumps(self.pass_configs, sort_keys=True) if self.pass_configs else None,
+            "pass_configs": json.dumps(pass_configs, sort_keys=True) if pass_configs else None,
         }
         hash_obj = hashlib.sha256(json.dumps(data, sort_keys=True).encode("utf-8"))
         return int.from_bytes(hash_obj.digest(), byteorder="big")

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -27,6 +27,7 @@ from tilelang import env
 from tilelang.jit import JITKernel
 from tilelang.jit.adapter.base import CachedTextSource
 from tilelang.jit.diagnostics import jit_phase
+from tilelang.transform.pass_config import normalize_pass_configs
 from tilelang.contrib.hip_resource_info import dump_to_file, load_from_file
 from tilelang import __version__
 
@@ -324,7 +325,14 @@ class KernelCache:
             Default execution backend. Defaults to "auto".
         TILELANG_VERBOSE : str
             Set to "1", "true", "yes", or "on" to enable verbose compilation by default.
+        TILELANG_LAYOUT_COST_MODEL : str
+            Default value for the `tl.layout_cost_model` pass config when it is
+            not set explicitly in `pass_configs`. Unset keeps the built-in default.
         """
+
+        # Resolve env-var-derived pass-config defaults up front so they are
+        # reflected in the cache key.
+        pass_configs = normalize_pass_configs(pass_configs)
 
         if backend_context is None:
             if target is None:

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -399,6 +399,9 @@ class Environment:
     TILELANG_DEFAULT_TARGET = EnvVar("TILELANG_DEFAULT_TARGET", "auto")
     TILELANG_DEFAULT_EXECUTION_BACKEND = EnvVar("TILELANG_EXECUTION_BACKEND", "auto")
     TILELANG_DEFAULT_VERBOSE = EnvVar("TILELANG_VERBOSE", "0")
+    TILELANG_LAYOUT_COST_MODEL = EnvVar(
+        "TILELANG_LAYOUT_COST_MODEL", None
+    )  # default for the `tl.layout_cost_model` pass config; unset keeps the built-in default
 
     # TVM integration
     SKIP_LOADING_TILELANG_SO = EnvVar("SKIP_LOADING_TILELANG_SO", "0")
@@ -511,6 +514,16 @@ class Environment:
     def get_default_verbose(self) -> bool:
         """Get default verbose flag from environment."""
         return self.TILELANG_DEFAULT_VERBOSE.lower() in ("1", "true", "yes", "on")
+
+    def get_default_layout_cost_model(self) -> str | None:
+        """Default for the `tl.layout_cost_model` pass config, or None when
+        unset (the compiler then falls back to its built-in default). An
+        explicit `pass_configs` entry always takes precedence over this."""
+        value = self.TILELANG_LAYOUT_COST_MODEL
+        if value is None:
+            return None
+        value = str(value).strip()
+        return value or None
 
     def is_running_autodd(self) -> bool:
         """Return True if we are running under `python -m tilelang.autodd`."""

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -117,7 +117,9 @@ class PassConfigKey(str, Enum):
     "io-aware" scores estimated global-memory access cost (vector width /
     warp coalescing of every fragment<->global copy, weighted by bytes
     moved) with register count as the tiebreak; "register-count" is the
-    total-register-slots-only ordering. Default: 'register-count'"""
+    total-register-slots-only ordering. When unset, the
+    ``TILELANG_LAYOUT_COST_MODEL`` environment variable supplies the
+    default. Default: 'register-count'"""
 
     TL_REDUCER_FORCE_BASELINE = "tl.reducer_force_baseline"
     """Force the canonical FullParticipant baseline for every reducer epoch,
@@ -342,14 +344,14 @@ _DEPRECATED_PASS_CONFIG_MESSAGES = {
 
 
 def normalize_pass_configs(pass_configs: dict[str | PassConfigKey, Any] | None) -> dict[str, Any]:
-    """Canonicalize known pass-config keys and emit compatibility warnings."""
-    if pass_configs is None:
-        return {}
+    """Canonicalize known pass-config keys, apply environment-variable
+    defaults, and emit compatibility warnings."""
+    from tilelang.env import env
 
     normalized: dict[str, Any] = {}
     warned_keys: set[str] = set()
 
-    for key, value in pass_configs.items():
+    for key, value in (pass_configs or {}).items():
         normalized_key = key.value if isinstance(key, PassConfigKey) else key
 
         normalized[normalized_key] = value
@@ -357,5 +359,10 @@ def normalize_pass_configs(pass_configs: dict[str | PassConfigKey, Any] | None) 
         if normalized_key in _DEPRECATED_PASS_CONFIG_MESSAGES and normalized_key not in warned_keys:
             warnings.warn(_DEPRECATED_PASS_CONFIG_MESSAGES[normalized_key], DeprecationWarning, stacklevel=3)
             warned_keys.add(normalized_key)
+
+    # Environment-derived defaults; an explicit pass_configs entry wins.
+    layout_cost_model = env.get_default_layout_cost_model()
+    if layout_cost_model is not None:
+        normalized.setdefault(PassConfigKey.TL_LAYOUT_COST_MODEL.value, layout_cost_model)
 
     return normalized


### PR DESCRIPTION
## Summary

- Add `TILELANG_LAYOUT_COST_MODEL` as a process-level default for `tl.layout_cost_model`.
- Keep explicit pass configs authoritative while preventing cache reuse across environment-selected models.

## Changes

- Expose and parse the environment setting through the central environment configuration.
- Apply normalized defaults consistently in grouped TVM FFI compilation.
- Normalize configs before autotuner and kernel cache key construction so cached artifacts stay aligned with the selected layout policy.

## Validation

- `./format.sh`
- `python -m pytest testing/python/components/test_tilelang_env.py testing/python/autotune/test_autotune_cache_key.py -x`
- Manual Python assertions for unset and blank handling, explicit pass-config precedence, and environment-sensitive autotuner hashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `TILELANG_LAYOUT_COST_MODEL` as the process-level default for `tl.layout_cost_model`.
- Trimmed environment values and ignored unset or blank values.
- Preserved explicit pass configuration precedence.
- Applied normalized pass configurations during grouped compilation, autotuner hashing, kernel cache key generation, and kernel compilation.
- Prevented cache reuse across different layout cost model policies.

## Validation

- Ran formatting and targeted tests.
- Manually checked unset and blank environment values.
- Verified explicit configuration precedence.
- Verified environment-sensitive autotuner hashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->