### PR TITLE
[BugFix][Layout] Fix parallel layout undercoverage

### DIFF
--- a/maint/layout_inference/cases/fragment_mixed_extents.py
+++ b/maint/layout_inference/cases/fragment_mixed_extents.py
@@ -3,28 +3,92 @@
 import tilelang.language as T
 
 
-def _mixed_extents(small_extent, full_extent, threads):
+def _mixed_extent_read(small_extent, full_extent, threads):
     @T.prim_func
     def main(C: T.Tensor((full_extent,), T.float32)):
         with T.Kernel(1, threads=threads):
-            fragment = T.alloc_fragment((full_extent,), T.float32)
-            T.clear(fragment)
+            frag = T.alloc_fragment((full_extent,), T.float32)
+            T.clear(frag)
             for i in T.Parallel(small_extent):
-                fragment[i] = 5.0
+                frag[i] = 5.0
             for i in T.Parallel(full_extent):
-                C[i] = fragment[i] + 1.0
+                C[i] = frag[i] + 1.0
+
+    return main
+
+
+def _mixed_extent_write(small_extent, full_extent, threads):
+    @T.prim_func
+    def main(C: T.Tensor((full_extent,), T.float32)):
+        with T.Kernel(1, threads=threads):
+            frag = T.alloc_fragment((full_extent,), T.float32)
+            T.clear(frag)
+            for i in T.Parallel(small_extent):
+                frag[i] = 7.0
+            for i in T.Parallel(full_extent):
+                frag[i] = 5.0
+            for i in T.Parallel(full_extent):
+                C[i] = frag[i]
+
+    return main
+
+
+def _equal_extents(full_extent, threads):
+    @T.prim_func
+    def main(C: T.Tensor((full_extent,), T.float32)):
+        with T.Kernel(1, threads=threads):
+            frag = T.alloc_fragment((full_extent,), T.float32)
+            T.clear(frag)
+            for i in T.Parallel(full_extent):
+                frag[i] = 5.0
+            for i in T.Parallel(full_extent):
+                C[i] = frag[i] + 1.0
+
+    return main
+
+
+def _independent_fragments(small_extent, full_extent, threads):
+    @T.prim_func
+    def main(C: T.Tensor((small_extent + full_extent,), T.float32)):
+        with T.Kernel(1, threads=threads):
+            small_frag = T.alloc_fragment((small_extent,), T.float32)
+            full_frag = T.alloc_fragment((full_extent,), T.float32)
+            T.clear(small_frag)
+            T.clear(full_frag)
+            for i in T.Parallel(small_extent):
+                small_frag[i] = 7.0
+            for i in T.Parallel(full_extent):
+                full_frag[i] = 5.0
+            for i in T.Parallel(small_extent):
+                C[i] = small_frag[i]
+            for i in T.Parallel(full_extent):
+                C[small_extent + i] = full_frag[i]
 
     return main
 
 
 VARIANTS = {
-    "issue2957_100_to_256_t128": lambda: _mixed_extents(100, 256, 128),
+    "issue2957_100_to_256_t128": lambda: _mixed_extent_read(100, 256, 128),
+    "issue2957_write_100_to_256_t128": lambda: _mixed_extent_write(100, 256, 128),
+    "equal_extents_256_t128": lambda: _equal_extents(256, 128),
+    "independent_fragments_100_and_256_t128": lambda: _independent_fragments(100, 256, 128),
+}
+
+EXPECTED_BUFFER_SHAPES = {
+    "issue2957_100_to_256_t128": {"frag": [256]},
+    "issue2957_write_100_to_256_t128": {"frag": [256]},
+    "equal_extents_256_t128": {"frag": [256]},
+    "independent_fragments_100_and_256_t128": {
+        "small_frag": [100],
+        "full_frag": [256],
+    },
 }
 
 
 def check(variant, model, result):
-    del variant, model
-    assert result["buffers"]["fragment"]["input_shape"] == [256]
+    del model
+    buffer_shapes = {name: layout["input_shape"] for name, layout in result["buffers"].items()}
+    assert buffer_shapes == EXPECTED_BUFFER_SHAPES[variant]
     for key, layout in result["loops"].items():
         extent = int(key.split("[")[1].split("]")[0])
         assert layout["input_shape"][0] >= extent

--- a/maint/layout_inference/cases/fragment_mixed_extents.py
+++ b/maint/layout_inference/cases/fragment_mixed_extents.py
@@ -1,0 +1,30 @@
+"""Ensure a shared fragment layout covers the largest parallel-loop extent."""
+
+import tilelang.language as T
+
+
+def _mixed_extents(small_extent, full_extent, threads):
+    @T.prim_func
+    def main(C: T.Tensor((full_extent,), T.float32)):
+        with T.Kernel(1, threads=threads):
+            fragment = T.alloc_fragment((full_extent,), T.float32)
+            T.clear(fragment)
+            for i in T.Parallel(small_extent):
+                fragment[i] = 5.0
+            for i in T.Parallel(full_extent):
+                C[i] = fragment[i] + 1.0
+
+    return main
+
+
+VARIANTS = {
+    "issue2957_100_to_256_t128": lambda: _mixed_extents(100, 256, 128),
+}
+
+
+def check(variant, model, result):
+    del variant, model
+    assert result["buffers"]["fragment"]["input_shape"] == [256]
+    for key, layout in result["loops"].items():
+        extent = int(key.split("[")[1].split("]")[0])
+        assert layout["input_shape"][0] >= extent

--- a/maint/layout_inference/expected/fragment_mixed_extents.json
+++ b/maint/layout_inference/expected/fragment_mixed_extents.json
@@ -1,0 +1,130 @@
+{
+  "issue2957_100_to_256_t128": {
+    "io-aware": {
+      "buffers": {
+        "fragment": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      },
+      "loops": {
+        "i[100]": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "i[256]": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      }
+    },
+    "register-count": {
+      "buffers": {
+        "fragment": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      },
+      "loops": {
+        "i[100]": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "i[256]": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      }
+    }
+  }
+}

--- a/maint/layout_inference/expected/fragment_mixed_extents.json
+++ b/maint/layout_inference/expected/fragment_mixed_extents.json
@@ -1,8 +1,378 @@
 {
+  "equal_extents_256_t128": {
+    "io-aware": {
+      "buffers": {
+        "frag": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      },
+      "loops": {
+        "i[256]": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "i[256]#2": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      }
+    },
+    "register-count": {
+      "buffers": {
+        "frag": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      },
+      "loops": {
+        "i[256]": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "i[256]#2": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      }
+    }
+  },
+  "independent_fragments_100_and_256_t128": {
+    "io-aware": {
+      "buffers": {
+        "full_frag": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "small_frag": {
+          "forward_index": [
+            "0"
+          ],
+          "forward_thread": "_i",
+          "input_shape": [
+            100
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            1
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 100
+        }
+      },
+      "loops": {
+        "i[100]": {
+          "forward_index": [
+            "0"
+          ],
+          "forward_thread": "_i",
+          "input_shape": [
+            100
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            1
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 100
+        },
+        "i[100]#2": {
+          "forward_index": [
+            "0"
+          ],
+          "forward_thread": "_i",
+          "input_shape": [
+            100
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            1
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 100
+        },
+        "i[256]": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "i[256]#2": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      }
+    },
+    "register-count": {
+      "buffers": {
+        "full_frag": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "small_frag": {
+          "forward_index": [
+            "0"
+          ],
+          "forward_thread": "_i",
+          "input_shape": [
+            100
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            1
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 100
+        }
+      },
+      "loops": {
+        "i[100]": {
+          "forward_index": [
+            "0"
+          ],
+          "forward_thread": "_i",
+          "input_shape": [
+            100
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            1
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 100
+        },
+        "i[100]#2": {
+          "forward_index": [
+            "0"
+          ],
+          "forward_thread": "_i",
+          "input_shape": [
+            100
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            1
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 100
+        },
+        "i[256]": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "i[256]#2": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      }
+    }
+  },
   "issue2957_100_to_256_t128": {
     "io-aware": {
       "buffers": {
-        "fragment": {
+        "frag": {
           "forward_index": [
             "_i % 2"
           ],
@@ -65,7 +435,7 @@
     },
     "register-count": {
       "buffers": {
-        "fragment": {
+        "frag": {
           "forward_index": [
             "_i % 2"
           ],
@@ -106,6 +476,172 @@
           "threads": 128
         },
         "i[256]": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      }
+    }
+  },
+  "issue2957_write_100_to_256_t128": {
+    "io-aware": {
+      "buffers": {
+        "frag": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      },
+      "loops": {
+        "i[100]": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "i[256]": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "i[256]#2": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      }
+    },
+    "register-count": {
+      "buffers": {
+        "frag": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      },
+      "loops": {
+        "i[100]": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "i[256]": {
+          "forward_index": [
+            "_i % 2"
+          ],
+          "forward_thread": "_i // 2",
+          "input_shape": [
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            2
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "i[256]#2": {
           "forward_index": [
             "_i % 2"
           ],

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -512,21 +512,7 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &layout_args,
     return {};
   }
 
-  // A layout may over-cover a loop and guard its padded points, but it must
-  // never under-cover valid iterations.
-  ICHECK_EQ(loop_layout_->InputShape().size(), loop_vars_.size());
-  Stmt loop = root_;
-  for (size_t i = 0; i < loop_vars_.size(); ++i) {
-    For for_node = loop.as<For>().value();
-    if (analyzer_.CanProve(loop_layout_->InputShape()[i] < for_node->extent)) {
-      std::ostringstream oss;
-      oss << "Inferred T.Parallel layout under-covers axis " << i
-          << ": layout extent " << loop_layout_->InputShape()[i]
-          << " is smaller than loop extent " << for_node->extent;
-      throw LayoutConflictException(oss.str());
-    }
-    loop = for_node->body;
-  }
+  ValidateCandidateCoversLoop(loop_layout_, /*throw_on_error=*/true);
 
   // Non-fragment SIMT loops may deliberately over-cover a ragged iteration
   // space; PartitionLoop emits guards for the padded points. Fragment/reducer
@@ -684,6 +670,39 @@ Fragment ParallelOpNode::CompleteBufferFragment(const Buffer &buffer) const {
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() { ParallelOpNode::RegisterReflection(); }
+
+bool ParallelOpNode::ValidateCandidateCoversLoop(const Fragment &candidate,
+                                                 bool throw_on_error) const {
+  if (!candidate.defined() ||
+      candidate->InputShape().size() != loop_vars_.size()) {
+    if (throw_on_error) {
+      std::ostringstream oss;
+      oss << "T.Parallel layout rank mismatch: layout rank "
+          << (candidate.defined() ? candidate->InputShape().size() : 0)
+          << ", loop rank " << loop_vars_.size();
+      throw LayoutConflictException(oss.str());
+    }
+    return false;
+  }
+
+  // Over-coverage is safe because loop partitioning guards padded points.
+  // Require proof of coverage so symbolic relations cannot hide undercoverage.
+  for (size_t i = 0; i < loop_vars_.size(); ++i) {
+    const PrimExpr &layout_extent = candidate->InputShape()[i];
+    const PrimExpr &loop_extent = loop_vars_[i]->dom->extent;
+    if (!analyzer_.CanProve(layout_extent >= loop_extent)) {
+      if (throw_on_error) {
+        std::ostringstream oss;
+        oss << "T.Parallel layout does not provably cover axis " << i
+            << ": layout extent " << layout_extent << ", loop extent "
+            << loop_extent;
+        throw LayoutConflictException(oss.str());
+      }
+      return false;
+    }
+  }
+  return true;
+}
 
 bool ParallelOpNode::ValidateCandidateAgainstFragments(
     const Fragment &candidate, const LayoutInferArgs &layout_args,
@@ -925,8 +944,10 @@ ParallelOpNode::ChooseBestCandidate(const Fragment &candidate_from_buffer,
   };
 
   bool buf_ok =
+      ValidateCandidateCoversLoop(candidate_from_buffer) &&
       ValidateCandidateAgainstFragments(candidate_from_buffer, layout_args);
   bool plan_ok =
+      ValidateCandidateCoversLoop(candidate_from_plan) &&
       ValidateCandidateAgainstFragments(candidate_from_plan, layout_args);
 
   if (buf_ok && !plan_ok) {

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -512,6 +512,22 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &layout_args,
     return {};
   }
 
+  // A layout may over-cover a loop and guard its padded points, but it must
+  // never under-cover valid iterations.
+  ICHECK_EQ(loop_layout_->InputShape().size(), loop_vars_.size());
+  Stmt loop = root_;
+  for (size_t i = 0; i < loop_vars_.size(); ++i) {
+    For for_node = loop.as<For>().value();
+    if (analyzer_.CanProve(loop_layout_->InputShape()[i] < for_node->extent)) {
+      std::ostringstream oss;
+      oss << "Inferred T.Parallel layout under-covers axis " << i
+          << ": layout extent " << loop_layout_->InputShape()[i]
+          << " is smaller than loop extent " << for_node->extent;
+      throw LayoutConflictException(oss.str());
+    }
+    loop = for_node->body;
+  }
+
   // Non-fragment SIMT loops may deliberately over-cover a ragged iteration
   // space; PartitionLoop emits guards for the padded points. Fragment/reducer
   // loops stay strict because padding would change per-thread ownership.

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -145,6 +145,10 @@ private:
   // Check if a buffer is completely replicated (all threads hold same data).
   bool IsBufferCompletelyReplicated(const Buffer &buffer,
                                     const LayoutMap &layout_map) const;
+  // Return true only when every candidate axis is proven to cover the
+  // corresponding parallel loop axis. Optionally throw a detailed conflict.
+  bool ValidateCandidateCoversLoop(const Fragment &candidate,
+                                   bool throw_on_error = false) const;
   // Validate a candidate loop layout against all source fragments in
   // T.layout_map. Returns true if compatible with all fragments; otherwise
   // false. When throw_on_error is true, throws LayoutConflictException with

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -175,8 +175,26 @@ def test_parallel_fragment_layout_covers_mixed_loop_extents(cost_model):
     post_order_visit(mod["main"].body, collect_layouts)
     assert fragment_shapes
     assert all(shape == [256] for shape in fragment_shapes)
-    assert loop_shapes
+    assert {extent for extent, _ in loop_shapes} == {100, 256}
     assert all(shape[0] >= extent for extent, shape in loop_shapes)
+
+
+def test_parallel_layout_rejects_unproven_symbolic_coverage():
+    n = T.dynamic("n")
+    loop_layout = T.Fragment((128,), forward_fn=lambda i: (i, 0))
+
+    @T.prim_func
+    def main(C: T.Tensor((n,), T.float32)):
+        with T.Kernel(1, threads=128):
+            for i in T.Parallel(n, loop_layout=loop_layout):
+                C[i] = 0.0
+
+    target = auto_target
+    with pytest.raises(tvm.TVMError, match="does not provably cover"), target:
+        mod = tvm.IRModule({"main": main})
+        mod = tvm.tirx.transform.BindTarget(target)(mod)
+        mod = tl.transform.MaterializeKernelLaunch()(mod)
+        tl.transform.LayoutInference()(mod)
 
 
 def test_static_ragged_copy_minimizes_full_thread_padding():

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -146,12 +146,12 @@ def test_parallel_fragment_layout_covers_mixed_loop_extents(cost_model):
     @T.prim_func
     def main(C: T.Tensor((256,), T.float32)):
         with T.Kernel(1, threads=128):
-            fragment = T.alloc_fragment((256,), T.float32)
-            T.clear(fragment)
+            frag = T.alloc_fragment((256,), T.float32)
+            T.clear(frag)
             for i in T.Parallel(100):
-                fragment[i] = 5.0
+                frag[i] = 5.0
             for i in T.Parallel(256):
-                C[i] = fragment[i] + 1.0
+                C[i] = frag[i] + 1.0
 
     target = auto_target
     with target, tvm.transform.PassContext(config={"tl.layout_cost_model": cost_model}):
@@ -166,7 +166,7 @@ def test_parallel_fragment_layout_covers_mixed_loop_extents(cost_model):
     def collect_layouts(node):
         if isinstance(node, tvm.tirx.SBlock) and "layout_map" in node.annotations:
             for buffer, layout in node.annotations["layout_map"].items():
-                if buffer.name == "fragment":
+                if buffer.name == "frag":
                     fragment_shapes.append([int(value) for value in layout.get_input_shape()])
         if isinstance(node, tvm.tirx.For) and "parallel_loop_layout" in node.annotations:
             layout = node.annotations["parallel_loop_layout"]

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -7,6 +7,7 @@ import tilelang.language as T
 import tilelang.testing
 import pytest
 import torch
+from tvm.tirx.stmt_functor import post_order_visit
 
 auto_target = tvm.target.Target(determine_target("auto"))
 
@@ -138,6 +139,44 @@ def test_register_count_is_default_layout_cost_model():
 
     tvm.ir.assert_structural_equal(default, register_count)
     assert not tvm.ir.structural_equal(default, io_aware)
+
+
+@pytest.mark.parametrize("cost_model", ["register-count", "io-aware"])
+def test_parallel_fragment_layout_covers_mixed_loop_extents(cost_model):
+    @T.prim_func
+    def main(C: T.Tensor((256,), T.float32)):
+        with T.Kernel(1, threads=128):
+            fragment = T.alloc_fragment((256,), T.float32)
+            T.clear(fragment)
+            for i in T.Parallel(100):
+                fragment[i] = 5.0
+            for i in T.Parallel(256):
+                C[i] = fragment[i] + 1.0
+
+    target = auto_target
+    with target, tvm.transform.PassContext(config={"tl.layout_cost_model": cost_model}):
+        mod = tvm.IRModule({"main": main})
+        mod = tvm.tirx.transform.BindTarget(target)(mod)
+        mod = tl.transform.MaterializeKernelLaunch()(mod)
+        mod = tl.transform.LayoutInference()(mod)
+
+    fragment_shapes = []
+    loop_shapes = []
+
+    def collect_layouts(node):
+        if isinstance(node, tvm.tirx.SBlock) and "layout_map" in node.annotations:
+            for buffer, layout in node.annotations["layout_map"].items():
+                if buffer.name == "fragment":
+                    fragment_shapes.append([int(value) for value in layout.get_input_shape()])
+        if isinstance(node, tvm.tirx.For) and "parallel_loop_layout" in node.annotations:
+            layout = node.annotations["parallel_loop_layout"]
+            loop_shapes.append((int(node.extent), [int(value) for value in layout.get_input_shape()]))
+
+    post_order_visit(mod["main"].body, collect_layouts)
+    assert fragment_shapes
+    assert all(shape == [256] for shape in fragment_shapes)
+    assert loop_shapes
+    assert all(shape[0] >= extent for extent, shape in loop_shapes)
 
 
 def test_static_ragged_copy_minimizes_full_thread_padding():


### PR DESCRIPTION
Fixes a wrong-code issue where `T.Parallel` loops with different extents sharing the same fragment could be silently truncated to the smallest extent.

This change rejects inferred loop layouts whose input shape is smaller than the loop extent, allowing free-mode inference to select a layout that covers all valid iterations.

Regression coverage is added for both `register-count` and `io-aware` cost models.


Fixes #2957