### PR TITLE
[BugFix][Transform] Avoid int32 overflow in vector analysis

### DIFF
--- a/src/transform/common/int64_promoter.h
+++ b/src/transform/common/int64_promoter.h
@@ -24,10 +24,11 @@ public:
   using Parent = tirx::IndexDataTypeRewriter;
 
   PrimExpr VisitExpr_(const tirx::VarNode *op) final {
-    if (op->dtype.is_int() && op->dtype.bits() < 64) {
-      return tvm::cast(DataType::Int(64), ffi::GetRef<tirx::Var>(op));
+    PrimExpr var = Parent::VisitExpr_(op);
+    if (var.dtype().is_int() && var.dtype().bits() < 64) {
+      return tvm::cast(DataType::Int(64), var);
     }
-    return ffi::GetRef<PrimExpr>(op);
+    return var;
   }
 
   PrimExpr VisitExpr_(const tirx::IntImmNode *op) final {

--- a/src/transform/common/loop_vectorization_utils.h
+++ b/src/transform/common/loop_vectorization_utils.h
@@ -507,8 +507,7 @@ public:
     Array<PrimExpr> indices = op->indices.Map(fmutate);
 
     if (!indices.same_as(op->indices)) {
-      auto writer = load.CopyOnWrite();
-      writer->indices = indices;
+      return BufferLoad(op->buffer, indices, op->predicate, op->span);
     }
 
     return std::move(load);

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -49,6 +49,13 @@ namespace tl {
 using namespace tirx;
 using namespace ffi;
 
+namespace {
+
+PrimExpr SimplifyExprForAnalyzer(const PrimExpr &expr, int scale,
+                                 arith::Analyzer *analyzer);
+
+} // namespace
+
 /*!
  * \brief Check if buffer strides represent a contiguous (row-major) layout.
  * \param buffer The buffer to check.
@@ -733,8 +740,12 @@ private:
     if (!inner_for_) {
       return;
     }
-    PrimExpr condition = analyzer_->Simplify(cond);
     int condition_vector_size = loop_extent_vector_size_;
+    PrimExpr condition = cond;
+    if (condition_vector_size > 1) {
+      condition =
+          SimplifyExprForAnalyzer(cond, condition_vector_size, analyzer_);
+    }
     while (condition_vector_size > 1 &&
            !IsExprInvariantInVectorBoundary(condition, inner_for_->loop_var,
                                             condition_vector_size, analyzer_)) {
@@ -808,7 +819,10 @@ private:
     // of the whole loop body. To avoid planning a vector size that will be
     // immediately scalarized (and to keep semantics sane for side-effectful
     // calls), require the offset to be invariant within the vector boundary.
-    PrimExpr offset_s = analyzer_->Simplify(offset);
+    PrimExpr offset_s = offset;
+    if (access_vec_size > 1) {
+      offset_s = SimplifyExprForAnalyzer(offset, access_vec_size, analyzer_);
+    }
     while (access_vec_size > 1 &&
            !IndicesCanVectorize(offset_s, inner_for_->loop_var,
                                 inner_for_->extent, access_vec_size,
@@ -1109,6 +1123,11 @@ PrimExpr PrepareExprForAnalyzer(const PrimExpr &expr, int scale,
   return promoter(expr);
 }
 
+PrimExpr SimplifyExprForAnalyzer(const PrimExpr &expr, int scale,
+                                 arith::Analyzer *analyzer) {
+  return analyzer->Simplify(PrepareExprForAnalyzer(expr, scale, analyzer));
+}
+
 } // namespace
 
 bool CanProveIndependent(const PrimExpr &expr, Var var,
@@ -1120,10 +1139,12 @@ bool CanProveIndependent(const PrimExpr &expr, Var var,
     return true;
   }
   // 2. if \forall v_1, v_2, f(v_1) == f(v_2), f is independent with v
-  PrimExpr analysis_expr = PrepareExprForAnalyzer(expr, 1, analyzer);
   Var var_1("_t", var.dtype());
-  PrimExpr expr_1 = Substitute(analysis_expr, {{var, var_1}});
-  if (analyzer->CanProveEqual(analysis_expr, expr_1)) {
+  PrimExpr expr_1 = Substitute(expr, {{var, var_1}});
+  PrimExpr equality = PrepareExprForAnalyzer(expr == expr_1, 1, analyzer);
+  const auto *equality_node = equality.as<EQNode>();
+  ICHECK(equality_node);
+  if (analyzer->CanProveEqual(equality_node->a, equality_node->b)) {
     return true;
   }
   return false;

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -29,6 +29,7 @@
 #include "arith/int_operator.h"
 #include "arith/ir_visitor_with_analyzer.h"
 #include "backend/common/target_utils.h"
+#include "common/int64_promoter.h"
 #include "common/loop_vectorization_utils.h"
 #include "support/check.h"
 #include <iostream>
@@ -1065,6 +1066,51 @@ int GetVectorizeSize(const For &loop, arith::Analyzer *analyzer,
   return VectorizePlanner(analyzer, layout_map).Plan(loop);
 }
 
+namespace {
+
+// Canonical simplification may multiply an integer subexpression's coefficient
+// by the candidate vector width before it constructs an IntImm. Widen the
+// analysis copy if any such scaled bound can exceed the source dtype. Inspect
+// subexpressions as well as the root so boolean conditions and cancelling
+// affine terms cannot hide a risky integer coefficient.
+bool ScaledIntSubexprMayOverflow(const PrimExpr &expr, int scale,
+                                 arith::Analyzer *analyzer) {
+  ICHECK_GE(scale, 1);
+  bool may_overflow = false;
+  PostOrderVisit(expr, [&](const ObjectRef &obj) {
+    if (may_overflow) {
+      return;
+    }
+    Optional<PrimExpr> opt_subexpr = obj.as<PrimExpr>();
+    if (!opt_subexpr.defined()) {
+      return;
+    }
+    PrimExpr subexpr = opt_subexpr.value();
+    DataType dtype = subexpr.dtype();
+    if (!dtype.is_int() || dtype.bits() >= 64 || dtype.lanes() != 1) {
+      return;
+    }
+
+    arith::ConstIntBound bound = analyzer->const_int_bound(subexpr);
+    const int64_t type_max = (1LL << (dtype.bits() - 1)) - 1;
+    const int64_t type_min = -(1LL << (dtype.bits() - 1));
+    may_overflow = bound->max_value > type_max / scale ||
+                   bound->min_value < type_min / scale;
+  });
+  return may_overflow;
+}
+
+PrimExpr PrepareExprForAnalyzer(const PrimExpr &expr, int scale,
+                                arith::Analyzer *analyzer) {
+  if (!ScaledIntSubexprMayOverflow(expr, scale, analyzer)) {
+    return expr;
+  }
+  Int64Promoter promoter;
+  return promoter(expr);
+}
+
+} // namespace
+
 bool CanProveIndependent(const PrimExpr &expr, Var var,
                          arith::Analyzer *analyzer) {
   // 1. if var doesn't exist, it is independent
@@ -1074,9 +1120,10 @@ bool CanProveIndependent(const PrimExpr &expr, Var var,
     return true;
   }
   // 2. if \forall v_1, v_2, f(v_1) == f(v_2), f is independent with v
+  PrimExpr analysis_expr = PrepareExprForAnalyzer(expr, 1, analyzer);
   Var var_1("_t", var.dtype());
-  auto expr_1 = Substitute(expr, {{var, var_1}});
-  if (analyzer->CanProveEqual(expr, expr_1)) {
+  PrimExpr expr_1 = Substitute(analysis_expr, {{var, var_1}});
+  if (analyzer->CanProveEqual(analysis_expr, expr_1)) {
     return true;
   }
   return false;
@@ -1095,10 +1142,12 @@ bool IsExprInvariantInVectorBoundary(const PrimExpr &expr, Var var,
   //     A[i] = B[i] * C[i//4]
   // if vecsize=4, f(i)=i//4 depends only on i//4
   // Therefore A[i] = B[i] * C[i//4] can be vectorized with vecsize=4
+  PrimExpr analysis_expr =
+      PrepareExprForAnalyzer(expr, target_vectorized_size, analyzer);
   PrimExpr var_aligned =
       floordiv(var, target_vectorized_size) * target_vectorized_size;
-  PrimExpr expr_aligned = Substitute(expr, {{var, var_aligned}});
-  if (analyzer->CanProveEqual(expr, expr_aligned)) {
+  PrimExpr expr_aligned = Substitute(analysis_expr, {{var, var_aligned}});
+  if (analyzer->CanProveEqual(analysis_expr, expr_aligned)) {
     return true;
   }
   return false;
@@ -1120,38 +1169,44 @@ bool IndicesCanVectorize(const PrimExpr &expr, Var var,
   if (target_vectorized_size == 1)
     return true;
 
+  PrimExpr analysis_expr =
+      PrepareExprForAnalyzer(expr, target_vectorized_size, analyzer);
+
   // Extent must be divisible
   PrimExpr target_size_for_iter =
       make_const(iter_var_size.dtype(), target_vectorized_size);
   PrimExpr target_size_for_expr =
-      make_const(expr.dtype(), target_vectorized_size);
+      make_const(analysis_expr.dtype(), target_vectorized_size);
   PrimExpr target_size_for_var =
       make_const(var.dtype(), target_vectorized_size);
-  PrimExpr zero = make_const(var.dtype(), 0);
+  PrimExpr zero_var = make_const(var.dtype(), 0);
+  PrimExpr zero_expr = make_const(analysis_expr.dtype(), 0);
 
   if (!analyzer->CanProveEqual(FloorMod(iter_var_size, target_size_for_iter),
                                0))
     return false;
 
-  if (IsExprInvariantInVectorBoundary(expr, var, target_vectorized_size,
-                                      analyzer)) {
+  if (IsExprInvariantInVectorBoundary(analysis_expr, var,
+                                      target_vectorized_size, analyzer)) {
     return true;
   }
 
-  auto simplified_expr = analyzer->Simplify(Substitute(expr, {{var, zero}}));
+  PrimExpr simplified_expr =
+      analyzer->Simplify(Substitute(analysis_expr, {{var, zero_var}}));
   // The base offset must be divisible
   if (!analyzer->CanProveEqual(FloorMod(simplified_expr, target_size_for_expr),
-                               zero)) {
+                               zero_expr)) {
     return false;
   }
 
   // Bind thread range
   Var v0("v0", var.dtype()), v1("v1", var.dtype());
-  analyzer->Bind(v0, Range(zero, target_size_for_var));
-  analyzer->Bind(v1, Range(zero, analyzer->Simplify(FloorDiv(
-                                     iter_var_size, target_size_for_iter))));
+  analyzer->Bind(v0, Range(zero_var, target_size_for_var));
+  analyzer->Bind(
+      v1, Range(zero_var, analyzer->Simplify(
+                              FloorDiv(iter_var_size, target_size_for_iter))));
   PrimExpr expr_transformed = analyzer->Simplify(
-      Substitute(expr, {{var, v0 + v1 * target_size_for_var}}));
+      Substitute(analysis_expr, {{var, v0 + v1 * target_size_for_var}}));
   Vectorizer vectorizer(v0, target_size_for_var);
   PrimExpr expr_vectorized = vectorizer.VisitExpr(expr_transformed);
 

--- a/testing/python/transform/test_tilelang_transform_loop_vectorize.py
+++ b/testing/python/transform/test_tilelang_transform_loop_vectorize.py
@@ -76,9 +76,9 @@ def test_large_int32_affine_index_does_not_abort_layout_inference(access_kind):
     _run_layout_inference(main)
 
 
-def test_large_int32_affine_index_with_bounded_residual_does_not_abort():
+@pytest.mark.parametrize("extent", [4, 8])
+def test_large_int32_affine_index_with_bounded_residual_does_not_abort(extent):
     """The final index fits int32 even though canonical coefficients do not."""
-    extent = 8
     group_size = 4
     stride = 600_000_000
 
@@ -92,6 +92,90 @@ def test_large_int32_affine_index_with_bounded_residual_does_not_abort():
                 output[i] = A[(i - (i // group_size) * group_size) * stride]
 
     _run_layout_inference(main)
+
+
+def test_large_int32_bounded_residual_condition_does_not_abort():
+    """Conditions must be widened before their first canonical simplification."""
+    extent = 8
+    group_size = 4
+    stride = 600_000_000
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((extent,), T.float32),
+        output: T.Tensor((extent,), T.float32),
+    ):
+        with T.Kernel(1, threads=extent):
+            for i in T.Parallel(extent):
+                if (i - (i // group_size) * group_size) * stride != 0:
+                    output[i] = A[i]
+
+    _run_layout_inference(main)
+
+
+def test_large_int32_bounded_residual_access_ptr_does_not_abort():
+    """tvm_access_ptr offsets must be widened before simplification."""
+    extent = 8
+    group_size = 4
+    stride = 600_000_000
+
+    @T.prim_func
+    def main(A: T.Tensor((2_000_000_000,), T.float32)):
+        with T.Kernel(1, threads=extent):
+            for i in T.Parallel(extent):
+                T.evaluate(
+                    T.call_intrin(
+                        "float32",
+                        tvm.tirx.op.Op.get("tl.atomic_add_elem_op"),
+                        T.tvm_access_ptr(
+                            T.type_annotation("float32"),
+                            A.data,
+                            (i - (i // group_size) * group_size) * stride,
+                            1,
+                            3,
+                        ),
+                        T.float32(1),
+                        T.int32(0),
+                    )
+                )
+
+    _run_layout_inference(main)
+
+
+def test_overflow_promotion_preserves_let_var_binding():
+    """Promoted Let bodies must reference the rewritten binder."""
+    extent = 4
+    stride = 600_000_000
+    loop_var = tvm.tirx.Var("i", "int32")
+    let_var = tvm.tirx.Var("offset", "int32")
+    input_buffer = tvm.tirx.decl_buffer((2_000_000_000,), "float32", name="A")
+    output_buffer = tvm.tirx.decl_buffer((extent,), "float32", name="output")
+    scaled_offset = loop_var * stride
+    index = tvm.tirx.Let(let_var, scaled_offset, let_var - scaled_offset)
+    body = tvm.tirx.BufferStore(
+        output_buffer,
+        tvm.tirx.BufferLoad(input_buffer, [index]),
+        [loop_var],
+    )
+    loop = tvm.tirx.For(
+        loop_var,
+        0,
+        extent,
+        tvm.tirx.ForKind.VECTORIZED,
+        body,
+    )
+    func = tvm.tirx.PrimFunc(
+        [input_buffer.data, output_buffer.data],
+        loop,
+        buffer_map={
+            input_buffer.data: input_buffer,
+            output_buffer.data: output_buffer,
+        },
+    )
+
+    transformed = _run_vectorized_loop_legalizer(func)
+
+    assert _vectorized_extents(transformed["main"]) == [extent]
 
 
 def test_large_int32_affine_index_under_int64_cast_does_not_abort():

--- a/testing/python/transform/test_tilelang_transform_loop_vectorize.py
+++ b/testing/python/transform/test_tilelang_transform_loop_vectorize.py
@@ -171,3 +171,22 @@ def test_large_coefficient_boundary_invariant_index_remains_vectorizable():
     transformed = _run_vectorized_loop_legalizer(main)
 
     assert _vectorized_extents(transformed["main"]) == [vector_size]
+
+
+def test_overflow_promotion_preserves_atomic_vector_lanes():
+    """Widening a dynamic row offset must not break x4 atomic lanes."""
+    extent = 128
+    lanes = 4
+    row_size = 576
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((512, row_size), T.float32),
+        indices: T.Tensor((extent,), T.int32),
+        values: T.Tensor((extent, lanes), T.float32),
+    ):
+        with T.Kernel(1, threads=extent):
+            for i in T.Parallel(extent):
+                T.atomic_addx4(A[indices[i], i * lanes], values[i, 0])
+
+    _run_layout_inference(main)

--- a/testing/python/transform/test_tilelang_transform_loop_vectorize.py
+++ b/testing/python/transform/test_tilelang_transform_loop_vectorize.py
@@ -1,0 +1,173 @@
+import pytest
+
+import tilelang as tl
+import tilelang.language as T
+from tilelang import tvm
+from tvm.tirx.stmt_functor import post_order_visit
+
+
+_TARGET = tvm.target.Target({"kind": "cuda", "arch": "sm_80"})
+
+
+def _run_layout_inference(func):
+    mod = tvm.IRModule({"main": func})
+    with _TARGET:
+        mod = tvm.tirx.transform.BindTarget(_TARGET)(mod)
+        mod = tl.transform.MaterializeKernelLaunch()(mod)
+        return tl.transform.LayoutInference()(mod)
+
+
+def _run_vectorized_loop_legalizer(func):
+    mod = tvm.IRModule({"main": func})
+    with _TARGET:
+        return tl.transform.LegalizeVectorizedLoop()(mod)
+
+
+def _vectorized_extents(func):
+    extents = []
+
+    def collect(node):
+        if isinstance(node, tvm.tirx.For) and node.kind == tvm.tirx.ForKind.VECTORIZED:
+            extents.append(int(node.extent))
+
+    post_order_visit(func.body, collect)
+    return extents
+
+
+@pytest.mark.parametrize("access_kind", ["load", "store", "implicit-row-stride"])
+def test_large_int32_affine_index_does_not_abort_layout_inference(access_kind):
+    """Regression for issue #3027's host-side vectorization analysis ICE."""
+    extent = 4
+    stride = 600_000_000
+
+    if access_kind == "load":
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((2_000_000_000,), T.float32),
+            output: T.Tensor((extent,), T.float32),
+        ):
+            with T.Kernel(1, threads=extent):
+                for i in T.Parallel(extent):
+                    output[i] = A[i * stride]
+
+    elif access_kind == "store":
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((extent,), T.float32),
+            output: T.Tensor((2_000_000_000,), T.float32),
+        ):
+            with T.Kernel(1, threads=extent):
+                for i in T.Parallel(extent):
+                    output[i * stride] = A[i]
+
+    else:
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((extent, stride), T.float32),
+            output: T.Tensor((extent,), T.float32),
+        ):
+            with T.Kernel(1, threads=extent):
+                for i in T.Parallel(extent):
+                    output[i] = A[i, 0]
+
+    _run_layout_inference(main)
+
+
+def test_large_int32_affine_index_with_bounded_residual_does_not_abort():
+    """The final index fits int32 even though canonical coefficients do not."""
+    extent = 8
+    group_size = 4
+    stride = 600_000_000
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((2_000_000_000,), T.float32),
+        output: T.Tensor((extent,), T.float32),
+    ):
+        with T.Kernel(1, threads=extent):
+            for i in T.Parallel(extent):
+                output[i] = A[(i - (i // group_size) * group_size) * stride]
+
+    _run_layout_inference(main)
+
+
+def test_large_int32_affine_index_under_int64_cast_does_not_abort():
+    """A wide cast must preserve the narrow arithmetic it encloses."""
+    extent = 8
+    group_size = 4
+    stride = 600_000_000
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((2_000_000_000,), T.float32),
+        output: T.Tensor((extent,), T.float32),
+    ):
+        with T.Kernel(1, threads=extent):
+            for i in T.Parallel(extent):
+                idx = T.cast(
+                    (i - (i // group_size) * group_size) * stride,
+                    "int64",
+                )
+                output[i] = A[idx]
+
+    load_indices = []
+    bindings = []
+
+    def collect(node):
+        if isinstance(node, tvm.tirx.BufferLoad) and node.buffer.name == "A":
+            load_indices.append(node.indices[0])
+        elif isinstance(node, tvm.tirx.Bind):
+            bindings.append((node.var, node.value))
+
+    post_order_visit(main.body, collect)
+    assert len(load_indices) == 1
+    assert isinstance(load_indices[0], tvm.tirx.Var)
+    cast_values = [value for var, value in bindings if var.same_as(load_indices[0])]
+    assert len(cast_values) == 1
+    assert isinstance(cast_values[0], tvm.tirx.Cast)
+    assert str(cast_values[0].dtype) == "int64"
+    assert str(cast_values[0].value.dtype) == "int32"
+
+    _run_layout_inference(main)
+
+
+def test_large_offset_unit_stride_remains_vectorizable():
+    """Analysis-only int64 promotion must preserve unit-stride Ramp detection."""
+    extent = 4
+    offset = 600_000_000
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((2_000_000_000,), T.float32),
+        output: T.Tensor((extent,), T.float32),
+    ):
+        with T.Kernel(1, threads=extent):
+            for i in T.vectorized(extent):
+                output[i] = A[offset + i]
+
+    transformed = _run_vectorized_loop_legalizer(main)
+
+    assert _vectorized_extents(transformed["main"]) == [extent]
+
+
+def test_large_coefficient_boundary_invariant_index_remains_vectorizable():
+    """A large coefficient must not turn a successful proof into scalarization."""
+    extent = 8
+    stride = 600_000_000
+    vector_size = 4
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((2_000_000_000,), T.float32),
+        output: T.Tensor((extent,), T.float32),
+    ):
+        with T.Kernel(1, threads=extent):
+            for i in T.vectorized(extent):
+                output[i] = A[(i // vector_size) * stride]
+
+    transformed = _run_vectorized_loop_legalizer(main)
+
+    assert _vectorized_extents(transformed["main"]) == [vector_size]


### PR DESCRIPTION
  ## Motivation

  Fixes #3027.

  TileLang's vectorization analysis may abort while simplifying a valid int32
  index expression. The failure occurs when the canonical simplifier scales an
  internal coefficient and attempts to materialize the result as an int32
  `IntImm`.

  For example:

  ```python
  A[(i - (i // 4) * 4) * 600_000_000]
  ```

  For `i` in `[0, 8)`, this expression only evaluates to:

  ```text
  0, 600M, 1.2B, 1.8B
  ```

  All of these indices fit within int32. During vector-boundary analysis,
  however, the canonical simplifier may internally construct:

  ```text
  4 * 600_000_000 = 2_400_000_000
  ```

  This exceeds the int32 `IntImm` range and aborts compilation inside
  `SplitExprNode::NormalizeWithScale`:

  ```text
  Literal value 2400000000 exceeds maximum of int32
  ```

  The overflowing value is an analyzer intermediate, not an index evaluated by
  the generated kernel.

  ## Root cause

  `IsExprInvariantInVectorBoundary` substitutes an aligned loop variable and
  passes the original int32 expression to `Analyzer::CanProveEqual`.

  Canonical simplification represents affine coefficients internally as int64,
  but eventually materializes a scaled coefficient using the expression's
  original dtype. A large int32 coefficient multiplied by the candidate vector
  width can therefore exceed the int32 `IntImm` range.

  The same problem can also occur in `CanProveIndependent`. Although that check
  does not apply an additional vector-boundary substitution, the input expression
  may already contain a large internal coefficient such as
  `4 * 600_000_000`.

  ## Changes

  This PR reuses the existing `Int64Promoter` to widen risky expressions for
  vectorization analysis only.

  Before invoking the analyzer, it:

  1. visits signed integer scalar subexpressions;
  2. obtains their constant integer bounds;
  3. checks whether scaling those bounds by the analysis scale may exceed the
     source dtype;
  4. promotes a temporary analysis copy to int64 only when needed.

  The prepared analysis expression is used by:

  - `CanProveIndependent`;
  - `IsExprInvariantInVectorBoundary`;
  - `IndicesCanVectorize`.

  The check visits integer subexpressions rather than only examining the root
  expression. This also covers:

  - integer arithmetic inside boolean conditions;
  - cancelling or bounded affine expressions whose intermediate coefficients are
    larger than their final value range;
  - expressions that already contain an overflowing internal coefficient before
    vector-boundary scaling.

  ## Semantics and scope

  The promoted expression is temporary and is not written back to the
  `PrimFunc`.

  Therefore, this change does not alter:

  - BufferLoad or BufferStore index dtypes;
  - the generated kernel's index dtype;
  - `NarrowDataType(32)` behavior;
  - runtime address arithmetic for existing valid int32 kernels.

  The int64 expression is only used by the analyzer and vectorization planner to
  produce an invariance or vector-width decision.

  Expressions whose scaled bounds fit their existing dtype continue through the
  original analysis path without promotion.

  This PR does not change the vectorization policy for strided gathers. A
  large-stride gather that is not vectorizable still falls back to scalar access;
  it simply no longer aborts during analysis.

  ## Tests

  Added host-side transform tests covering:

  - the original large-stride load;
  - the corresponding large-stride store;
  - an implicit large 2-D row stride;
  - a bounded residual expression that reproduces the failure on current `main`;
  - preservation of unit-stride `Ramp` vectorization after analysis-only
    promotion;
  - preservation of a successful large-coefficient boundary-invariance proof.

  The bounded-residual regression fails before this change with:

  ```text
  Literal value 2400000000 exceeds maximum of int32
  ```

  and passes after the change.

  ### Host-side validation

  ```bash
  python -m pytest \
    testing/python/transform/test_tilelang_transform_loop_vectorize.py \
    testing/python/transform/test_tilelang_transform_legalize_vectorized_loop.py \
    -q
  ```

  Result:

  ```text
  7 passed
  ```

  Formatting and static checks:

  ```bash
  python -m pre_commit run --files \
    src/transform/loop_vectorize.cc \
    testing/python/transform/test_tilelang_transform_loop_vectorize.py
  ```

  Result:

  ```text
  All checks passed
  ```

  ### CUDA validation

  CUDA compilation and runtime validation passed.

  The following cases compile and produce the expected results:

  - the original issue #3027 large-stride gather;
  - the large-stride store variant;
  - the bounded-residual regression;
  - existing vectorized index and boundary-invariant index cases.

  The bounded-residual kernel accesses the expected index sequence:

  ```text
  0, 600M, 1.2B, 1.8B, 0, 600M, 1.2B, 1.8B
  ```

  Checklist:

  - [x] Host-side regression tests
  - [x] Existing vectorized-loop legalization test
  - [x] Formatting and static checks
  - [x] CUDA compilation validation
  - [x] CUDA runtime correctness validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevents int32 overflow during TileLang vectorization analysis.
- Uses `Int64Promoter` for temporary int64 analysis in independence, boundary-invariance, and index-vectorization checks.
- Preserves original `PrimFunc` expressions, index dtypes, runtime address arithmetic, and `NarrowDataType(32)` behavior.
- Adds CUDA tests for large-stride loads, stores, implicit row strides, bounded residuals, large offsets, and boundary-invariant indices.

## Validation

- Host-side tests passed.
- Formatting checks passed.
- CUDA compilation passed.
- CUDA runtime validation passed.

## C++ style / lint notes

- The PR changes C++ implementation code but does not touch rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains advisory.
- No correctness or build issues are reported. TLCPP003/TLCPP004 findings should not block merge unless they identify a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->