### PR TITLE
[Build] Support Cython 3.3 with the Python 3.9 limited API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ requires = [
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
-wheel.py-api = "cp38"
+wheel.py-api = "cp39"
 cmake.version = ">=3.26.1"
 build-dir = "build"
 


### PR DESCRIPTION
## Summary

- Raise the abi3 floor from CPython 3.8 to CPython 3.9.
- Keep editable and wheel builds compatible with Cython 3.3, which requires a Python limited API version of 3.9 or newer.

## Changes

- Set `tool.scikit-build.wheel.py-api` to `cp39`.
- Preserve the existing supported interpreter range because the package already requires Python 3.10 or newer.

## Validation

- `./format.sh`
- `git diff HEAD^ HEAD --check`
- Parsed `pyproject.toml` with `tomllib` and asserted `wheel.py-api = cp39`.

## Notes

- A full native rebuild was not run locally; CI will exercise the isolated wheel build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Raise the stable ABI floor from `cp38` to `cp39`.
- Preserve support for Python 3.10 and newer.
- Support editable and wheel builds with Cython 3.3.

## Validation

- Ran `./format.sh`.
- Ran `git diff HEAD^ HEAD --check`.
- Confirmed `wheel.py-api = "cp39"` with `tomllib`.
- CI will validate the isolated wheel build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->