### PR TITLE
[Runtime][Cache] Remove separate cache temporary directory

### DIFF
--- a/docs/programming_guides/autotuning.md
+++ b/docs/programming_guides/autotuning.md
@@ -209,7 +209,6 @@ Disk cache contents (per key)
 
 Control via env vars (tilelang.env)
 - `TILELANG_CACHE_DIR` (default `~/.tilelang/cache`)
-- `TILELANG_TMP_DIR` (default `$TILELANG_CACHE_DIR/tmp`)
 - Disable all kernel caches: `TILELANG_DISABLE_CACHE=1`
 - Disable autotune disk cache only: `TILELANG_AUTO_TUNING_DISABLE_CACHE=1`
 

--- a/testing/python/autotune/test_tilelang_autotune_atomic_save.py
+++ b/testing/python/autotune/test_tilelang_autotune_atomic_save.py
@@ -1,4 +1,5 @@
 import errno
+import os
 
 import pytest
 
@@ -44,11 +45,8 @@ def _fake_func():
 @pytest.fixture
 def cache_dirs(tmp_path, monkeypatch):
     cache_dir = tmp_path / "cache"
-    tmp_dir = tmp_path / "tmp"
     cache_dir.mkdir()
-    tmp_dir.mkdir()
     monkeypatch.setattr(env, "TILELANG_CACHE_DIR", str(cache_dir))
-    monkeypatch.setattr(env, "TILELANG_TMP_DIR", str(tmp_dir))
     return cache_dir
 
 
@@ -69,6 +67,27 @@ def _make_result(tmp_path, execution_backend: str = "cython"):
         func=_fake_func,
         kernel=_FakeKernel(str(lib_path), execution_backend=execution_backend),
     )
+
+
+def test_autotune_safe_write_stages_next_to_destination(tmp_path, monkeypatch):
+    destination = tmp_path / "value.json"
+    real_replace = autotune_param.os.replace
+    replace_calls = []
+
+    def reject_cross_directory_replace(source, target):
+        if os.path.dirname(source) != os.path.dirname(target):
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        replace_calls.append((source, target))
+        real_replace(source, target)
+
+    monkeypatch.setattr(autotune_param.os, "replace", reject_cross_directory_replace)
+
+    AutotuneResult._safe_write_file(str(destination), "w", lambda file: file.write("cached"))
+
+    assert destination.read_text() == "cached"
+    assert len(replace_calls) == 1
+    assert os.path.dirname(replace_calls[0][0]) == str(destination.parent)
+    assert not [path for path in tmp_path.iterdir() if path.name.startswith(".")]
 
 
 def test_autotune_save_rewrites_incomplete_cache_dir(cache_dirs, tmp_path):

--- a/testing/python/autotune/test_tilelang_autotune_atomic_save.py
+++ b/testing/python/autotune/test_tilelang_autotune_atomic_save.py
@@ -1,5 +1,4 @@
 import errno
-import os
 
 import pytest
 
@@ -67,27 +66,6 @@ def _make_result(tmp_path, execution_backend: str = "cython"):
         func=_fake_func,
         kernel=_FakeKernel(str(lib_path), execution_backend=execution_backend),
     )
-
-
-def test_autotune_safe_write_stages_next_to_destination(tmp_path, monkeypatch):
-    destination = tmp_path / "value.json"
-    real_replace = autotune_param.os.replace
-    replace_calls = []
-
-    def reject_cross_directory_replace(source, target):
-        if os.path.dirname(source) != os.path.dirname(target):
-            raise OSError(errno.EXDEV, "Invalid cross-device link")
-        replace_calls.append((source, target))
-        real_replace(source, target)
-
-    monkeypatch.setattr(autotune_param.os, "replace", reject_cross_directory_replace)
-
-    AutotuneResult._safe_write_file(str(destination), "w", lambda file: file.write("cached"))
-
-    assert destination.read_text() == "cached"
-    assert len(replace_calls) == 1
-    assert os.path.dirname(replace_calls[0][0]) == str(destination.parent)
-    assert not [path for path in tmp_path.iterdir() if path.name.startswith(".")]
 
 
 def test_autotune_save_rewrites_incomplete_cache_dir(cache_dirs, tmp_path):

--- a/testing/python/autotune/test_tilelang_autotune_cutedsl_cache.py
+++ b/testing/python/autotune/test_tilelang_autotune_cutedsl_cache.py
@@ -11,52 +11,45 @@ from tilelang.env import env
 
 def test_cutedsl_save_creates_kernel_py(tmp_path):
     """_save_kernel_to_disk should write kernel.py (not kernel_lib.so) for CuTeDSL."""
-    original_tmp_dir = env.TILELANG_TMP_DIR
-    env.TILELANG_TMP_DIR = str(tmp_path / "tmp")
-    os.makedirs(env.TILELANG_TMP_DIR, exist_ok=True)
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "kernel.py").write_text("# cutedsl kernel\n")
+    (src_dir / "kernel.cubin").write_bytes(b"fake_cubin")
 
-    try:
-        src_dir = tmp_path / "src"
-        src_dir.mkdir()
-        (src_dir / "kernel.py").write_text("# cutedsl kernel\n")
-        (src_dir / "kernel.cubin").write_bytes(b"fake_cubin")
+    class FakeLibGen:
+        """Minimal CuTeDSL library generator stub for cache-save tests."""
 
-        class FakeLibGen:
-            """Minimal CuTeDSL library generator stub for cache-save tests."""
+        launcher_libpath = None
 
-            launcher_libpath = None
+    class FakeAdapter:
+        """Minimal CuTeDSL adapter stub exposing source accessors."""
 
-        class FakeAdapter:
-            """Minimal CuTeDSL adapter stub exposing source accessors."""
+        libpath = str(src_dir / "kernel.py")
+        lib_generator = FakeLibGen()
 
-            libpath = str(src_dir / "kernel.py")
-            lib_generator = FakeLibGen()
+        def get_kernel_source(self, kernel_only=True):
+            """Return a fake device source."""
+            return "# device src"
 
-            def get_kernel_source(self, kernel_only=True):
-                """Return a fake device source."""
-                return "# device src"
+        def get_host_source(self):
+            """Return a fake host wrapper source."""
+            return "# host src"
 
-            def get_host_source(self):
-                """Return a fake host wrapper source."""
-                return "# host src"
+    class FakeKernel:
+        """Minimal JITKernel stub for CuTeDSL autotune cache saving."""
 
-        class FakeKernel:
-            """Minimal JITKernel stub for CuTeDSL autotune cache saving."""
+        execution_backend = "cutedsl"
+        adapter = FakeAdapter()
+        kernel_source = "# src"
+        params = []
 
-            execution_backend = "cutedsl"
-            adapter = FakeAdapter()
-            kernel_source = "# src"
-            params = []
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    AutotuneResult()._save_kernel_to_disk(cache, FakeKernel())
 
-        cache = tmp_path / "cache"
-        cache.mkdir()
-        AutotuneResult()._save_kernel_to_disk(cache, FakeKernel())
-
-        assert (cache / "kernel.py").exists()
-        assert not (cache / "kernel_lib.so").exists()
-        assert (cache / "kernel.cubin").exists()
-    finally:
-        env.TILELANG_TMP_DIR = original_tmp_dir
+    assert (cache / "kernel.py").exists()
+    assert not (cache / "kernel_lib.so").exists()
+    assert (cache / "kernel.cubin").exists()
 
 
 def _is_cutedsl_available():
@@ -100,11 +93,9 @@ def test_cutedsl_autotune_cache_roundtrip(tmp_path):
     import torch
     from tilelang.autotuner import AutoTuner
 
-    original_cache_dir, original_tmp_dir = env.TILELANG_CACHE_DIR, env.TILELANG_TMP_DIR
+    original_cache_dir = env.TILELANG_CACHE_DIR
     env.TILELANG_CACHE_DIR = str(tmp_path / "cache")
-    env.TILELANG_TMP_DIR = str(tmp_path / "tmp")
     os.makedirs(env.TILELANG_CACHE_DIR, exist_ok=True)
-    os.makedirs(env.TILELANG_TMP_DIR, exist_ok=True)
     original_cache_enabled = env.is_cache_enabled()
     tilelang.enable_cache()
     AutoTuner._memory_cache.clear()
@@ -125,7 +116,6 @@ def test_cutedsl_autotune_cache_roundtrip(tmp_path):
         torch.testing.assert_close(vec_add(N)(a, b), ref, atol=1e-5, rtol=1e-5)
     finally:
         env.TILELANG_CACHE_DIR = original_cache_dir
-        env.TILELANG_TMP_DIR = original_tmp_dir
         if not original_cache_enabled:
             tilelang.disable_cache()
         AutoTuner._memory_cache.clear()

--- a/testing/python/cache/test_tilelang_cuda_binary_cache.py
+++ b/testing/python/cache/test_tilelang_cuda_binary_cache.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import cloudpickle
-import errno
 import os
 
 import tilelang
-import tilelang.cache.cuda_binary_cache as cuda_binary_cache_mod
 import tilelang.cache.kernel_cache as kernel_cache_mod
 from tilelang.backend import create_backend_context
 from tilelang.cache.cuda_binary_cache import CUDABinaryCache
@@ -72,28 +70,6 @@ def test_cuda_binary_cache_hit_skips_nvcc_compile(monkeypatch, tmp_path):
     assert compile_calls[0][3] != compile_calls[1][3]
     cache_files = list((tmp_path / "cache").glob("*/cuda-binaries/*.cubin"))
     assert len(cache_files) == 2
-
-
-def test_cuda_binary_cache_stages_next_to_destination(monkeypatch, tmp_path):
-    _set_cache_dirs(monkeypatch, tmp_path)
-    real_replace = os.replace
-    replace_calls = []
-
-    def reject_cross_directory_replace(source, destination):
-        if os.path.dirname(source) != os.path.dirname(destination):
-            raise OSError(errno.EXDEV, "Invalid cross-device link")
-        replace_calls.append((source, destination))
-        real_replace(source, destination)
-
-    monkeypatch.setattr(cuda_binary_cache_mod.os, "replace", reject_cross_directory_replace)
-
-    CUDABinaryCache.save("same-filesystem", "cubin", b"fake-cubin")
-
-    cache_path = CUDABinaryCache.get_path("same-filesystem", "cubin")
-    assert CUDABinaryCache.load("same-filesystem", "cubin") == b"fake-cubin"
-    assert len(replace_calls) == 1
-    assert os.path.dirname(replace_calls[0][0]) == os.path.dirname(cache_path)
-    assert not [name for name in os.listdir(os.path.dirname(cache_path)) if name.startswith(".")]
 
 
 def test_disk_cache_load_failure_is_cache_miss(monkeypatch, tmp_path):

--- a/testing/python/cache/test_tilelang_cuda_binary_cache.py
+++ b/testing/python/cache/test_tilelang_cuda_binary_cache.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import cloudpickle
+import errno
 import os
 
 import tilelang
+import tilelang.cache.cuda_binary_cache as cuda_binary_cache_mod
 import tilelang.cache.kernel_cache as kernel_cache_mod
 from tilelang.backend import create_backend_context
 from tilelang.cache.cuda_binary_cache import CUDABinaryCache
@@ -73,6 +75,28 @@ def test_cuda_binary_cache_hit_skips_nvcc_compile(monkeypatch, tmp_path):
     assert compile_calls[0][3] != compile_calls[1][3]
     cache_files = list((tmp_path / "cache").glob("*/cuda-binaries/*.cubin"))
     assert len(cache_files) == 2
+
+
+def test_cuda_binary_cache_stages_next_to_destination(monkeypatch, tmp_path):
+    _set_cache_dirs(monkeypatch, tmp_path)
+    real_replace = os.replace
+    replace_calls = []
+
+    def reject_cross_directory_replace(source, destination):
+        if os.path.dirname(source) != os.path.dirname(destination):
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        replace_calls.append((source, destination))
+        real_replace(source, destination)
+
+    monkeypatch.setattr(cuda_binary_cache_mod.os, "replace", reject_cross_directory_replace)
+
+    CUDABinaryCache.save("same-filesystem", "cubin", b"fake-cubin")
+
+    cache_path = CUDABinaryCache.get_path("same-filesystem", "cubin")
+    assert CUDABinaryCache.load("same-filesystem", "cubin") == b"fake-cubin"
+    assert len(replace_calls) == 1
+    assert os.path.dirname(replace_calls[0][0]) == os.path.dirname(cache_path)
+    assert not os.listdir(tmp_path / "tmp")
 
 
 def test_disk_cache_load_failure_is_cache_miss(monkeypatch, tmp_path):

--- a/testing/python/cache/test_tilelang_cuda_binary_cache.py
+++ b/testing/python/cache/test_tilelang_cuda_binary_cache.py
@@ -16,11 +16,8 @@ from tvm.target import Target
 
 def _set_cache_dirs(monkeypatch, tmp_path):
     cache_dir = tmp_path / "cache"
-    tmp_dir = tmp_path / "tmp"
     cache_dir.mkdir()
-    tmp_dir.mkdir()
     monkeypatch.setattr(env, "TILELANG_CACHE_DIR", str(cache_dir))
-    monkeypatch.setattr(env, "TILELANG_TMP_DIR", str(tmp_dir))
     monkeypatch.setattr(env, "TILELANG_DISABLE_CACHE", "0")
     tilelang.enable_cache()
     KernelCache._get_cache_namespace.cache_clear()
@@ -96,7 +93,7 @@ def test_cuda_binary_cache_stages_next_to_destination(monkeypatch, tmp_path):
     assert CUDABinaryCache.load("same-filesystem", "cubin") == b"fake-cubin"
     assert len(replace_calls) == 1
     assert os.path.dirname(replace_calls[0][0]) == os.path.dirname(cache_path)
-    assert not os.listdir(tmp_path / "tmp")
+    assert not [name for name in os.listdir(os.path.dirname(cache_path)) if name.startswith(".")]
 
 
 def test_disk_cache_load_failure_is_cache_miss(monkeypatch, tmp_path):

--- a/testing/python/cache/test_tilelang_kernel_cache.py
+++ b/testing/python/cache/test_tilelang_kernel_cache.py
@@ -80,7 +80,6 @@ def setup_module_env():
     """Setup and restore module-level environment and cache state."""
     # Save original env values
     original_cache_dir = env.TILELANG_CACHE_DIR
-    original_tmp_dir = env.TILELANG_TMP_DIR
 
     # Enable cache once for entire module
     tilelang.enable_cache()
@@ -89,7 +88,6 @@ def setup_module_env():
 
     # Restore env at module end
     env.TILELANG_CACHE_DIR = original_cache_dir
-    env.TILELANG_TMP_DIR = original_tmp_dir
 
     # Restore default postproc callbacks
     tvm_ffi.register_global_func("tilelang_callback_cuda_postproc", f=lambda code, _: code, override=True)
@@ -100,15 +98,10 @@ def setup_module_env():
 def clean_cache_env(tmp_path, request):
     """Provide isolated cache environment for each test.
 
-    Creates isolated cache/tmp directories to ensure:
+    Creates an isolated cache directory to ensure:
     - No interference from previous test runs
     - No interference between parallel tests
     - Clean slate for testing cache miss/hit behavior
-    - No "Invalid cross-device link" errors (os.replace requires same filesystem)
-
-    Technical notes:
-    - TILELANG_TMP_DIR MUST be on same filesystem as TILELANG_CACHE_DIR because
-      cache implementation uses os.replace() for atomic writes
     - Env restoration is handled by setup_module_env at module scope
     """
     # This fixture should ONLY be used with @pytest.mark.parametrize("backend", ...)
@@ -118,12 +111,8 @@ def clean_cache_env(tmp_path, request):
     cache_dir = tmp_path / "tilelang_cache"
     cache_dir.mkdir()
 
-    tmp_dir = tmp_path / "tilelang_tmp"
-    tmp_dir.mkdir()
-
-    # Patch env variables to point to isolated directories
+    # Patch the cache root to point to an isolated directory.
     env.TILELANG_CACHE_DIR = str(cache_dir)
-    env.TILELANG_TMP_DIR = str(tmp_dir)
 
     # Clear memory caches to force disk I/O
     _dispatch_map[backend]._memory_cache.clear()

--- a/testing/python/cache/test_tilelang_kernel_cache_atomic_save.py
+++ b/testing/python/cache/test_tilelang_kernel_cache_atomic_save.py
@@ -33,11 +33,8 @@ class _FakeKernel:
 @pytest.fixture
 def cache_dirs(tmp_path, monkeypatch):
     cache_dir = tmp_path / "cache"
-    tmp_dir = tmp_path / "tmp"
     cache_dir.mkdir()
-    tmp_dir.mkdir()
     monkeypatch.setattr(env, "TILELANG_CACHE_DIR", str(cache_dir))
-    monkeypatch.setattr(env, "TILELANG_TMP_DIR", str(tmp_dir))
     return cache_dir
 
 
@@ -344,24 +341,52 @@ def test_nvrtc_kernel_cache_rewrites_dir_missing_launcher(cache_dirs, tmp_path):
     assert not (cache_path / "legacy.txt").exists()
 
 
-def test_safe_write_executable_uses_explicit_export_kwargs(cache_dirs, tmp_path):
+def test_safe_write_file_stages_next_to_destination(tmp_path, monkeypatch):
+    destination = tmp_path / "value.json"
+    real_replace = kernel_cache_mod.os.replace
+    replace_calls = []
+
+    def reject_cross_directory_replace(source, target):
+        if Path(source).parent != Path(target).parent:
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        replace_calls.append((source, target))
+        real_replace(source, target)
+
+    monkeypatch.setattr(kernel_cache_mod.os, "replace", reject_cross_directory_replace)
+
+    KernelCache._safe_write_file(str(destination), "w", lambda file: file.write("cached"))
+
+    assert destination.read_text() == "cached"
+    assert len(replace_calls) == 1
+    assert Path(replace_calls[0][0]).parent == destination.parent
+    assert not [path for path in tmp_path.iterdir() if path.name.startswith(".")]
+
+
+def test_safe_write_executable_uses_sibling_and_explicit_export_kwargs(cache_dirs, tmp_path):
     captured = []
+    export_paths = []
 
     class FakeExecutable:
         def export_library(self, path, **kwargs):
             captured.append(dict(kwargs))
+            export_paths.append(Path(path))
             with open(path, "wb") as f:
                 f.write(b"fake-so")
 
     export_kwargs = {"options": ["-Wl,-dead_strip"], "custom": "keep"}
+    destination = tmp_path / "explicit.so"
 
     KernelCache._safe_write_executable(
         FakeExecutable(),
-        str(tmp_path / "explicit.so"),
+        str(destination),
         export_kwargs=export_kwargs,
     )
 
     assert captured == [export_kwargs]
+    assert export_paths[0].parent == destination.parent
+    assert export_paths[0].suffix == destination.suffix
+    assert destination.read_bytes() == b"fake-so"
+    assert not export_paths[0].exists()
 
 
 def test_tvm_ffi_kernel_cache_selects_export_kwargs_from_host_target(cache_dirs, tmp_path, monkeypatch):

--- a/testing/python/cache/test_tilelang_kernel_cache_atomic_save.py
+++ b/testing/python/cache/test_tilelang_kernel_cache_atomic_save.py
@@ -341,52 +341,24 @@ def test_nvrtc_kernel_cache_rewrites_dir_missing_launcher(cache_dirs, tmp_path):
     assert not (cache_path / "legacy.txt").exists()
 
 
-def test_safe_write_file_stages_next_to_destination(tmp_path, monkeypatch):
-    destination = tmp_path / "value.json"
-    real_replace = kernel_cache_mod.os.replace
-    replace_calls = []
-
-    def reject_cross_directory_replace(source, target):
-        if Path(source).parent != Path(target).parent:
-            raise OSError(errno.EXDEV, "Invalid cross-device link")
-        replace_calls.append((source, target))
-        real_replace(source, target)
-
-    monkeypatch.setattr(kernel_cache_mod.os, "replace", reject_cross_directory_replace)
-
-    KernelCache._safe_write_file(str(destination), "w", lambda file: file.write("cached"))
-
-    assert destination.read_text() == "cached"
-    assert len(replace_calls) == 1
-    assert Path(replace_calls[0][0]).parent == destination.parent
-    assert not [path for path in tmp_path.iterdir() if path.name.startswith(".")]
-
-
-def test_safe_write_executable_uses_sibling_and_explicit_export_kwargs(cache_dirs, tmp_path):
+def test_safe_write_executable_uses_explicit_export_kwargs(cache_dirs, tmp_path):
     captured = []
-    export_paths = []
 
     class FakeExecutable:
         def export_library(self, path, **kwargs):
             captured.append(dict(kwargs))
-            export_paths.append(Path(path))
             with open(path, "wb") as f:
                 f.write(b"fake-so")
 
     export_kwargs = {"options": ["-Wl,-dead_strip"], "custom": "keep"}
-    destination = tmp_path / "explicit.so"
 
     KernelCache._safe_write_executable(
         FakeExecutable(),
-        str(destination),
+        str(tmp_path / "explicit.so"),
         export_kwargs=export_kwargs,
     )
 
     assert captured == [export_kwargs]
-    assert export_paths[0].parent == destination.parent
-    assert export_paths[0].suffix == destination.suffix
-    assert destination.read_bytes() == b"fake-so"
-    assert not export_paths[0].exists()
 
 
 def test_tvm_ffi_kernel_cache_selects_export_kwargs_from_host_target(cache_dirs, tmp_path, monkeypatch):

--- a/testing/python/components/test_tilelang_env.py
+++ b/testing/python/components/test_tilelang_env.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 import tilelang
@@ -33,35 +31,6 @@ def test_env_var(monkeypatch):
         assert tilelang.env.TILELANG_PRINT_ON_COMPILATION == "1"
     finally:
         _restore_forced_value("TILELANG_PRINT_ON_COMPILATION", original_forced_value)
-
-
-def test_tilelang_tmp_dir_default_tracks_cache_dir(monkeypatch, tmp_path):
-    original_cache_forced_value = _env_var_descriptor("TILELANG_CACHE_DIR")._forced_value
-    original_tmp_forced_value = _env_var_descriptor("TILELANG_TMP_DIR")._forced_value
-    _restore_forced_value("TILELANG_CACHE_DIR", None)
-    _restore_forced_value("TILELANG_TMP_DIR", None)
-
-    try:
-        monkeypatch.delenv("TILELANG_CACHE_DIR", raising=False)
-        monkeypatch.delenv("TILELANG_TMP_DIR", raising=False)
-
-        monkeypatch.setenv("TILELANG_CACHE_DIR", str(tmp_path / "env_cache_a"))
-        assert os.path.join(str(tmp_path / "env_cache_a"), "tmp") == tilelang.env.TILELANG_TMP_DIR
-
-        monkeypatch.setenv("TILELANG_CACHE_DIR", str(tmp_path / "env_cache_b"))
-        assert os.path.join(str(tmp_path / "env_cache_b"), "tmp") == tilelang.env.TILELANG_TMP_DIR
-
-        tilelang.env.TILELANG_CACHE_DIR = str(tmp_path / "cache_a")
-        assert os.path.join(str(tmp_path / "cache_a"), "tmp") == tilelang.env.TILELANG_TMP_DIR
-
-        tilelang.env.TILELANG_CACHE_DIR = str(tmp_path / "cache_b")
-        assert os.path.join(str(tmp_path / "cache_b"), "tmp") == tilelang.env.TILELANG_TMP_DIR
-
-        monkeypatch.setenv("TILELANG_TMP_DIR", str(tmp_path / "explicit_tmp"))
-        assert str(tmp_path / "explicit_tmp") == tilelang.env.TILELANG_TMP_DIR
-    finally:
-        _restore_forced_value("TILELANG_CACHE_DIR", original_cache_forced_value)
-        _restore_forced_value("TILELANG_TMP_DIR", original_tmp_forced_value)
 
 
 @pytest.mark.parametrize(

--- a/testing/python/jit/test_tilelang_jit_diagnostics.py
+++ b/testing/python/jit/test_tilelang_jit_diagnostics.py
@@ -267,11 +267,8 @@ def test_kernel_cache_miss_compile_logs_context(monkeypatch, tmp_path, caplog, c
     from tilelang.env import env
 
     cache_dir = tmp_path / "cache"
-    tmp_dir = tmp_path / "tmp"
     cache_dir.mkdir()
-    tmp_dir.mkdir()
     monkeypatch.setattr(env, "TILELANG_CACHE_DIR", str(cache_dir))
-    monkeypatch.setattr(env, "TILELANG_TMP_DIR", str(tmp_dir))
     monkeypatch.setenv("TILELANG_JIT_DIAGNOSTICS", "1")
 
     class _FakeKernel:

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import tilelang
 from tilelang import tvm as tvm
 from tvm.tirx import PrimFunc
@@ -22,7 +23,6 @@ from tilelang import logger
 import json
 import hashlib
 import uuid
-from tilelang import env
 from tvm.runtime import Executable
 
 if TYPE_CHECKING:
@@ -181,23 +181,28 @@ class AutotuneResult:
     @staticmethod
     def _safe_write_file(path: str, mode: str, operation: Callable[[Any], None]):
         """Atomically write one cache file through a temporary sibling file."""
-        # Random a temporary file within the same FS as the cache directory
-        tmp_dir = env.TILELANG_TMP_DIR
-        os.makedirs(tmp_dir, exist_ok=True)
-        temp_path = os.path.join(tmp_dir, f"{os.getpid()}_{uuid.uuid4()}")
-        with open(temp_path, mode) as temp_file:
-            operation(temp_file)
-        # Use atomic POSIX replace, so other processes cannot see a partial write
-        os.replace(temp_path, path)
+        directory, filename = os.path.split(path)
+        temp_path = os.path.join(directory, f".{filename}.{os.getpid()}_{uuid.uuid4().hex}.tmp")
+        try:
+            with open(temp_path, mode) as temp_file:
+                operation(temp_file)
+            os.replace(temp_path, path)
+        finally:
+            with contextlib.suppress(OSError):
+                os.remove(temp_path)
 
     @staticmethod
     def _safe_write_executable(executable: Executable, path: str):
         """Atomically export one runtime executable to disk."""
-        tmp_dir = env.TILELANG_TMP_DIR
-        os.makedirs(tmp_dir, exist_ok=True)
-        temp_path = os.path.join(tmp_dir, f"{os.getpid()}_{uuid.uuid4()}.so")
-        executable.export_library(temp_path)
-        os.replace(temp_path, path)
+        directory, filename = os.path.split(path)
+        stem, suffix = os.path.splitext(filename)
+        temp_path = os.path.join(directory, f".{stem}.{os.getpid()}_{uuid.uuid4().hex}.tmp{suffix}")
+        try:
+            executable.export_library(temp_path)
+            os.replace(temp_path, path)
+        finally:
+            with contextlib.suppress(OSError):
+                os.remove(temp_path)
 
     def _save_kernel_to_disk(self, cache_path: Path, kernel: JITKernel, verbose: bool = False):
         """

--- a/tilelang/cache/cuda_binary_cache.py
+++ b/tilelang/cache/cuda_binary_cache.py
@@ -143,9 +143,8 @@ class CUDABinaryCache:
         os.makedirs(cache_root, exist_ok=True)
         path = cls.get_path(key, compile_format)
         # Atomic replacement requires the temporary file and destination to be
-        # on the same filesystem. Keep the temporary file next to the cache
-        # entry instead of relying on TILELANG_TMP_DIR, which may be mounted
-        # elsewhere.
+        # on the same filesystem, so keep the temporary file next to the cache
+        # entry.
         temp_path = os.path.join(cache_root, f".{os.getpid()}_{uuid.uuid4()}.{compile_format}.tmp")
         try:
             with open(temp_path, "wb") as f:

--- a/tilelang/cache/cuda_binary_cache.py
+++ b/tilelang/cache/cuda_binary_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import json
 import os
@@ -137,12 +138,19 @@ class CUDABinaryCache:
     def save(cls, key: str, compile_format: str, data: bytes) -> None:
         if not env.is_cache_enabled():
             return
-        os.makedirs(env.TILELANG_CACHE_DIR, exist_ok=True)
-        os.makedirs(env.TILELANG_TMP_DIR, exist_ok=True)
-        os.makedirs(cls._get_cache_root(), exist_ok=True)
 
+        cache_root = cls._get_cache_root()
+        os.makedirs(cache_root, exist_ok=True)
         path = cls.get_path(key, compile_format)
-        temp_path = os.path.join(env.TILELANG_TMP_DIR, f"{os.getpid()}_{uuid.uuid4()}.{compile_format}")
-        with open(temp_path, "wb") as f:
-            f.write(data)
-        os.replace(temp_path, path)
+        # Atomic replacement requires the temporary file and destination to be
+        # on the same filesystem. Keep the temporary file next to the cache
+        # entry instead of relying on TILELANG_TMP_DIR, which may be mounted
+        # elsewhere.
+        temp_path = os.path.join(cache_root, f".{os.getpid()}_{uuid.uuid4()}.{compile_format}.tmp")
+        try:
+            with open(temp_path, "wb") as f:
+                f.write(data)
+            os.replace(temp_path, path)
+        finally:
+            with contextlib.suppress(OSError):
+                os.remove(temp_path)

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import json
 import logging
@@ -193,7 +194,6 @@ class KernelCache:
     @staticmethod
     def _create_dirs():
         os.makedirs(env.TILELANG_CACHE_DIR, exist_ok=True)
-        os.makedirs(env.TILELANG_TMP_DIR, exist_ok=True)
         os.makedirs(KernelCache._get_namespace_root(), exist_ok=True)
         os.makedirs(KernelCache._get_cache_root(), exist_ok=True)
         os.makedirs(KernelCache._get_staging_root(), exist_ok=True)
@@ -493,19 +493,29 @@ class KernelCache:
 
     @staticmethod
     def _safe_write_file(path: str, mode: str, operation: Callable):
-        # Random a temporary file within the same FS as the cache directory
-        temp_path = os.path.join(env.TILELANG_TMP_DIR, f"{os.getpid()}_{uuid.uuid4()}")
-        with open(temp_path, mode) as temp_file:
-            operation(temp_file)
-
-        # Use atomic POSIX replace, so other processes cannot see a partial write
-        os.replace(temp_path, path)
+        """Atomically write a cache file through a temporary sibling."""
+        directory, filename = os.path.split(path)
+        temp_path = os.path.join(directory, f".{filename}.{os.getpid()}_{uuid.uuid4().hex}.tmp")
+        try:
+            with open(temp_path, mode) as temp_file:
+                operation(temp_file)
+            os.replace(temp_path, path)
+        finally:
+            with contextlib.suppress(OSError):
+                os.remove(temp_path)
 
     @staticmethod
     def _safe_write_executable(executable: Executable, path: str, export_kwargs: dict | None = None):
-        temp_path = os.path.join(env.TILELANG_TMP_DIR, f"{os.getpid()}_{uuid.uuid4()}.so")
-        executable.export_library(temp_path, **(export_kwargs or {}))
-        os.replace(temp_path, path)
+        """Atomically export an executable through a temporary sibling."""
+        directory, filename = os.path.split(path)
+        stem, suffix = os.path.splitext(filename)
+        temp_path = os.path.join(directory, f".{stem}.{os.getpid()}_{uuid.uuid4().hex}.tmp{suffix}")
+        try:
+            executable.export_library(temp_path, **(export_kwargs or {}))
+            os.replace(temp_path, path)
+        finally:
+            with contextlib.suppress(OSError):
+                os.remove(temp_path)
 
     def _save_kernel_to_disk(self, key: str, kernel: JITKernel, func: Callable = None, verbose: bool = False):
         """

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -354,7 +354,6 @@ class Environment:
     # TileLang resources
     TILELANG_TEMPLATE_PATH = EnvVar("TL_TEMPLATE_PATH", None)
     TILELANG_CACHE_DIR = EnvVar("TILELANG_CACHE_DIR", os.path.expanduser("~/.tilelang/cache"))
-    TILELANG_TMP_DIR = EnvVar("TILELANG_TMP_DIR", lambda: os.path.join(Environment.TILELANG_CACHE_DIR, "tmp"))
 
     # Kernel Build options
     TILELANG_PRINT_ON_COMPILATION = EnvVar("TILELANG_PRINT_ON_COMPILATION", "1")  # print kernel name on compile


### PR DESCRIPTION
## Summary

- Remove the separately configurable `TILELANG_TMP_DIR`.
- Keep cache publication atomic by staging each temporary file beside its final destination.
- Prevent `EXDEV` failures when cache storage and temporary storage use different filesystems.

## Changes

- Update `KernelCache`, `AutotuneResult`, and `CUDABinaryCache` to use unique hidden sibling files for atomic replacement.
- Preserve executable filename extensions during staging and clean up temporary files after success or failure.
- Remove `TILELANG_TMP_DIR` from environment configuration and autotuning documentation.
- Remove obsolete temporary-directory setup from existing cache tests.

## Validation

- `./format.sh`
- `python -m pytest testing/python/cache/test_tilelang_cuda_binary_cache.py testing/python/cache/test_tilelang_kernel_cache_atomic_save.py testing/python/autotune/test_tilelang_autotune_atomic_save.py -q -k "not lazy_jit_closure_specialization_re_elaborates_before_kernel_cache"` (19 passed, 1 deselected)
- `python -m pytest testing/python/components/test_tilelang_env.py testing/python/jit/test_tilelang_jit_diagnostics.py -q` (24 passed, 1 skipped)
- `python -m pytest testing/python/cache/test_tilelang_kernel_cache.py -q` (9 passed, 3 skipped)
- `python -m pytest testing/python/autotune/test_tilelang_autotune_cutedsl_cache.py -q` (1 passed, 1 skipped)
- `python -m py_compile tilelang/env.py tilelang/cache/kernel_cache.py tilelang/cache/cuda_binary_cache.py tilelang/autotuner/param.py`

## Notes

- `TILELANG_CACHE_DIR` is now the only cache location setting.
- Existing unused `tmp` directories are left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevented `EXDEV` failures during cache publication.
- Staged temporary files beside cache destinations for atomic replacement.
- Preserved executable file extensions during staging.
- Removed `TILELANG_TMP_DIR` configuration and documentation.
- Cleaned up staging files after successful or failed writes.
- Added regression coverage for staging, atomic replacement, cleanup, and export arguments.

## Testing

- Formatting checks passed.
- Targeted cache, autotune, environment, JIT diagnostics, and Python compilation checks passed.
- One test was deselected and one test was skipped as indicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->