### PR TITLE
Fix incomplete batched finalize_reducer lowering

### DIFF
--- a/src/backend/common/op/finalize_reducer.h
+++ b/src/backend/common/op/finalize_reducer.h
@@ -94,7 +94,7 @@ template <typename Impl> struct FinalizeReducerLowerer {
       reduce::CheckAllReduceWidth(reducing_threads, scale,
                                   "tl.finalize_reducer");
 
-      bool use_batch = effective_batch > 1 &&
+      bool use_batch = effective_batch > 1 && layout_batch_size > 0 &&
                        reducing_threads > Impl::WarpSize(lower_args.target);
 
       if (use_batch) {
@@ -106,9 +106,31 @@ template <typename Impl> struct FinalizeReducerLowerer {
             workspace_stride, lower_args.target);
         int ws_size = workspace_stride * static_cast<int>(effective_batch);
         PrimExpr workspace = lower_args.add_workspace(ws_size, buffer->dtype);
-        Array<PrimExpr> args = {StringImm(allreduce), buffer->data, workspace};
-        step_stmts.push_back(
-            Evaluate(Call(DataType::Handle(), builtin::call_extern(), args)));
+
+        std::vector<int64_t> shape_values;
+        shape_values.reserve(layout->OutputDim());
+        for (int i = 0; i < layout->OutputDim(); ++i) {
+          shape_values.push_back(*as_const_int(layout->OutputShape()[i]));
+        }
+        std::vector<int64_t> strides(layout->OutputDim(), 1);
+        for (int i = layout->OutputDim() - 2; i >= 0; --i) {
+          strides[i] = strides[i + 1] * shape_values[i + 1];
+        }
+
+        int num_chunks = static_cast<int>(layout_batch_size / effective_batch);
+        for (int chunk = 0; chunk < num_chunks; ++chunk) {
+          int64_t flat_offset = static_cast<int64_t>(chunk) * effective_batch;
+          Array<PrimExpr> chunk_indices;
+          for (int i = 0; i < layout->OutputDim(); ++i) {
+            int64_t index = (flat_offset / strides[i]) % shape_values[i];
+            chunk_indices.push_back(Integer(index));
+          }
+          PrimExpr ptr = Call(DataType::Handle(), builtin::address_of(),
+                              {BufferLoad(buffer, chunk_indices)});
+          Array<PrimExpr> args = {StringImm(allreduce), ptr, workspace};
+          step_stmts.push_back(
+              Evaluate(Call(DataType::Handle(), builtin::call_extern(), args)));
+        }
         continue;
       }
 

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -739,12 +739,28 @@ def test_finalize_reducer_sm80_uses_named_barrier(batch):
     ids=[f"{op}-{dtype}-{bM}x{bN}" for op, dtype, bM, bN, batch in FINALIZE_REDUCER_CASES if batch == 1],
 )
 def test_finalize_reducer_correctness(op, dtype, block_M, block_N, batch):
-    """Numerical correctness (batch=1 scalar path; batch>1 blocked by fragment layout bug)."""
+    """Numerical correctness for the scalar finalization path."""
     A = torch.randn(block_M, block_N, dtype=getattr(torch, dtype)).cuda()
     B = tl.compile(
         _make_finalize_reducer_kernel(block_M, block_N, dtype, op, batch),
         out_idx=-1,
         pass_configs=_COMPILE_FLAGS,
+    )(A)
+    torch.testing.assert_close(B, _ref(A, op), atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize(
+    ("op", "dtype", "block_M", "block_N", "batch"),
+    [c for c in FINALIZE_REDUCER_CASES if c[4] > 1],
+    ids=[f"{op}-{dtype}-{bM}x{bN}-b{batch}" for op, dtype, bM, bN, batch in FINALIZE_REDUCER_CASES if batch > 1],
+)
+def test_finalize_reducer_batched_correctness(op, dtype, block_M, block_N, batch):
+    """Every output chunk must be processed by the batched wide plan."""
+    A = torch.randn(block_M, block_N, dtype=getattr(torch, dtype)).cuda()
+    B = tl.compile(
+        _make_finalize_reducer_kernel(block_M, block_N, dtype, op, batch),
+        out_idx=-1,
+        pass_configs={**_COMPILE_FLAGS, "tl.reducer_force_baseline": True},
     )(A)
     torch.testing.assert_close(B, _ref(A, op), atol=1e-2, rtol=1e-2)
 


### PR DESCRIPTION
## Summary

Fix the batched `finalize_reducer` lowering so that every contiguous
output chunk is processed, rather than invoking `run_batch` only once
at the beginning of the buffer.

For 128 outputs with `batch=4`, the lowering now emits 32 batched
all-reduce calls with correctly offset pointers.

## Testing

Tested on an NVIDIA L40S:

- Added numerical regression tests for sum, max, and min
- Covered fp16 and fp32
- Covered batch sizes 4, 8, and 16
- 23 related `finalize_reducer` tests passed
- External reproduction matrix: 16/16 cases passed with zero mismatches

Fixes #2623.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed batched `finalize_reducer` lowering to process every output chunk.
- Emits `ceil(OutputDim / batch)` offset `run_batch` calls.
- Preserves sum, max, and min reductions for fp16 and fp32 outputs.
- Added parametrized correctness tests for batch sizes 4, 8, and 16.

## Validation

- Related tests passed.
- External reproduction matrix passed.

## C++ style / lint notes

- The change touches C++ implementation code but does not modify `docs/developer_guide/cpp_style.md`.
- No public or exported declarations changed.
- The C++ API Style Audit (warning only) is advisory. Any existing TLCPP003/TLCPP004 warnings are not merge blockers unless this change introduces an API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->