### PR TITLE
[BugFix][Transform] Clamp short symbolic software-pipeline epilogues

### DIFF
--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -1228,9 +1228,31 @@ public:
     Stmt body =
         EmitImpl(pipeline_loop_->min + max_stage_,
                  pipeline_loop_->min + pipeline_loop_->extent, false, false);
-    Stmt epilogue = EmitImpl(
-        pipeline_loop_->min + pipeline_loop_->extent,
-        pipeline_loop_->min + pipeline_loop_->extent + max_stage_, true, true);
+    // For a symbolic short loop, the ordinary epilogue overlaps with the
+    // prologue.  Emit only the non-overlapping tail interval instead of
+    // guarding individual pipeline stages: copy, commit, and wait scopes must
+    // stay in the same control-flow region for async-pipeline bookkeeping.
+    PrimExpr epilogue_start = pipeline_loop_->min + pipeline_loop_->extent;
+    PrimExpr epilogue_end = epilogue_start + max_stage_;
+    Stmt epilogue;
+    if (max_stage_ > 1 &&
+        !analyzer_.CanProveGreaterEqual(pipeline_loop_->extent, max_stage_)) {
+      PrimExpr stage_count = IntImm(pipeline_loop_->extent.dtype(), max_stage_);
+      epilogue_start =
+          pipeline_loop_->min + tirx::Max(pipeline_loop_->extent, stage_count);
+      epilogue_end = pipeline_loop_->min + pipeline_loop_->extent + stage_count;
+      PrimExpr epilogue_extent =
+          analyzer_.Simplify(epilogue_end - epilogue_start);
+      bool epilogue_is_static = as_const_int(epilogue_extent) != nullptr;
+      // A dynamic tail must not inherit the pipeline-loop annotation: it is a
+      // drain loop, not a steady-state pipeline loop for wait relaxation.  It
+      // may otherwise retain the original loop kind, except kUnrolled, which
+      // LoopUnroller cannot apply to a symbolic extent.
+      epilogue = EmitImpl(epilogue_start, epilogue_end, epilogue_is_static,
+                          true, !epilogue_is_static);
+    } else {
+      epilogue = EmitImpl(epilogue_start, epilogue_end, true, true);
+    }
 
     Array<Stmt> pipeline_parts;
     for (const Stmt &part : {prologue, body, epilogue}) {
@@ -2826,10 +2848,12 @@ private:
    * \param start The start of the range
    * \param end The end of the range
    * \param unroll_loop Whether the loop should be unrolled.
+   * \param is_dynamic_drain_loop Whether this is a dynamic epilogue drain
+   * loop.
    * \return The result loop.
    */
   Stmt EmitImpl(const PrimExpr &start, const PrimExpr &end, bool unroll_loop,
-                bool need_bound_check) {
+                bool need_bound_check, bool is_dynamic_drain_loop = false) {
     PrimExpr new_loop_var;
     PrimExpr extent = end - start;
     Optional<Integer> pipeline_num_stages =
@@ -2848,8 +2872,8 @@ private:
                 analyzer_.Simplify(start + IntImm(extent.dtype(), iter));
             PrimExpr unit_end =
                 analyzer_.Simplify(start + IntImm(extent.dtype(), iter + 1));
-            Stmt unit_stmt =
-                EmitImpl(unit_start, unit_end, false, need_bound_check);
+            Stmt unit_stmt = EmitImpl(unit_start, unit_end, false,
+                                      need_bound_check, is_dynamic_drain_loop);
             expanded.push_back(unit_stmt);
           }
           Stmt result = expanded.size() == 1 ? expanded[0] : SeqStmt(expanded);
@@ -3024,20 +3048,25 @@ private:
             kv.first != kPipelineAsyncProducerGroups &&
             kv.first != kPipelineTmaCopies &&
             kv.first != kPipelineReplayableScalarBinds &&
-            kv.first != "num_stages") {
+            kv.first != "num_stages" &&
+            (!is_dynamic_drain_loop || kv.first != "tl_pipelined_num_stages")) {
           preserved_annotations.Set(key, kv.second);
         }
       }
-      if (pipeline_num_stages &&
+      if (!is_dynamic_drain_loop && pipeline_num_stages &&
           preserved_annotations.find("tl_pipelined_num_stages") ==
               preserved_annotations.end()) {
         preserved_annotations.Set("tl_pipelined_num_stages",
                                   pipeline_num_stages.value());
       }
+      ForKind loop_kind =
+          unroll_loop ? ForKind::kUnrolled : pipeline_loop_->kind;
+      if (is_dynamic_drain_loop && loop_kind == ForKind::kUnrolled) {
+        loop_kind = ForKind::kSerial;
+      }
       new_loop = For(Downcast<Var>(new_loop_var), pipeline_loop_->min, extent,
-                     unroll_loop ? ForKind::kUnrolled : pipeline_loop_->kind,
-                     std::move(new_loop), std::nullopt, preserved_annotations,
-                     std::nullopt, pipeline_loop_->span);
+                     loop_kind, std::move(new_loop), std::nullopt,
+                     preserved_annotations, std::nullopt, pipeline_loop_->span);
     }
     Stmt result = SBlockRealize({}, Bool(true),
                                 MakeBlock(new_loop, buffer_data_to_buffer_));

--- a/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
+++ b/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
@@ -733,5 +733,68 @@ def test_inject_software_pipeline_replays_scalar_bind_dependencies():
     assert "offset = T.int32()" not in script
 
 
+def test_inject_software_pipeline_clamps_short_symbolic_epilogue():
+    """Symbolic min (blockIdx.y>>1 style) with short remaining trips.
+
+    Mirrors GQA bwd causal ``loop_st``.  When ``by == 14`` or ``15``, the
+    trip count is below the three pipeline stages.  The epilogue must therefore
+    begin at ``loop_st + 2``; otherwise it replays pipeline stages that overlap
+    the prologue.
+    """
+
+    @T.prim_func
+    def before(
+        A: T.Tensor((16, 16), T.float32),
+        C: T.Tensor((16, 16), T.float32),
+    ):
+        for by in T.thread_binding(0, 16, thread="blockIdx.y"):
+            for tx in T.thread_binding(0, 16, thread="threadIdx.x"):
+                B = T.alloc_buffer((16, 1), dtype=T.float32, scope="shared")
+                loop_st = by // 2
+                for i in T.unroll(
+                    loop_st,
+                    8,
+                    annotations={
+                        "software_pipeline_stage": [0, 1, 2],
+                        "software_pipeline_order": [0, 1, 2],
+                    },
+                ):
+                    with T.sblock("copy"):
+                        T.reads(A[tx, i])
+                        T.writes(B[tx, 0])
+                        B[tx, 0] = A[tx, i]
+                    with T.sblock("compute"):
+                        T.reads(B[tx, 0])
+                        T.writes(B[tx, 0])
+                        B[tx, 0] = B[tx, 0] * T.float32(2.0)
+                    with T.sblock("consume"):
+                        T.reads(B[tx, 0])
+                        T.writes(C[tx, i])
+                        C[tx, i] = B[tx, 0]
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = tl.transform.InjectSoftwarePipeline()(mod)
+    # The clamped tail starts at loop_st + max(remaining_trips, 2).  It is a
+    # drain loop, so it must not retain steady-state pipeline metadata.
+    clamped_tail_loops = []
+
+    def _visit_for(node):
+        if isinstance(node, tvm.tirx.For) and "max(" in str(node.extent):
+            clamped_tail_loops.append(node)
+
+    post_order_visit(mod["main"].body, _visit_for)
+    assert clamped_tail_loops
+    assert all(loop.kind == tvm.tirx.ForKind.SERIAL for loop in clamped_tail_loops)
+    assert all("tl_pipelined_num_stages" not in loop.annotations for loop in clamped_tail_loops)
+    for loop in clamped_tail_loops:
+        stage_distance = tvm.tirx.IntImm(loop.min.dtype, 2)
+        loop_end = tvm.tirx.IntImm(loop.min.dtype, 8)
+        remaining_trips = loop_end - loop.min
+        clamped_drain_start = loop.min + tvm.tirx.max(remaining_trips, stage_distance)
+        pipeline_loop_end = loop.min + remaining_trips
+        expected_drain_extent = pipeline_loop_end + stage_distance - clamped_drain_start
+        tvm.ir.assert_structural_equal(loop.extent, expected_drain_extent)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Motivation

`InjectSoftwarePipeline` can generate an overlapping epilogue when a pipelined
loop has a symbolic lower bound and fewer remaining iterations than the
pipeline depth.

For example, the causal-GQA-style loop below has a symbolic start
`loop_st = by // 2`. Near the tail, the remaining trip count can be one or two
iterations while the pipeline has three stages.

```python
loop_st = by // 2
for i in T.Pipelined(loop_st, 8, num_stages=3):
    T.copy(A[tx, i], B[tx, 0])
    B[tx, 0] = B[tx, 0] * T.float32(2)
    C[tx, i] = B[tx, 0]
```

The epilogue previously replayed pipeline stages whose logical iterations
overlap the prologue. This can cause duplicate work and invalid memory accesses
in application workloads.

A complete application-level reproducer is available in this public Gist:

<https://gist.github.com/3402956340/258d838a555b672269345f215e5c1d17>

## Changes

- For symbolic loop extents that cannot be proven to be at least the pipeline
  stage distance, clamp the epilogue to the non-overlapping drain interval:
  `loop_min + max(loop_extent, max_stage)` through
  `loop_min + loop_extent + max_stage`.
- Emit the resulting epilogue as a dynamic drain loop when its extent is
  symbolic, instead of preserving a fixed-size unrolled epilogue and guarding
  individual stages.
- Remove `tl_pipelined_num_stages` from dynamic drain loops so wait relaxation
  does not treat them as steady-state pipeline loops.
- Use a serial loop kind for a dynamic drain loop when the original loop kind
  is unrolled.
- Add a regression test for a three-stage pipeline with
  `loop_st = blockIdx.y // 2`.

## Correctness

For short symbolic pipelines, the epilogue now contains only the drain interval
that is not already covered by the prologue. This keeps async copy, commit, and
wait scopes in the same control-flow region, rather than splitting them with
per-stage predicates.

In the example above, the clamped epilogue begins at:

```text
loop_st + max(8 - loop_st, 2)
```

When only one iteration remains, this becomes `loop_st + 2`, so no pipeline
stage already emitted by the prologue is replayed.

Pipelines whose extent is provably at least the stage distance retain the
previous generated form.

## Tests

- Renamed and updated the regression test to
  `test_inject_software_pipeline_clamps_short_symbolic_epilogue` in
  `testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py`.
- The regression checks the `InjectSoftwarePipeline` IR directly and verifies
  that the symbolic tail is emitted as a clamped drain loop.
- It also verifies that the drain loop is serial and does not retain
  `tl_pipelined_num_stages`.
- The Gist reproducer validates both output values and the number of executions
  for each logical pipeline iteration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevent overlapping software-pipeline epilogues for symbolic loop bounds whose remaining trip count is shorter than the pipeline depth.
- Clamp symbolic epilogues to a non-overlapping dynamic drain interval.
- Remove `tl_pipelined_num_stages` from dynamic drain annotations.
- Convert symbolic drains from unrolled loops to serial loops.
- Add a regression test for a three-stage pipeline with `loop_st = blockIdx.y // 2`.
- Verify the clamped drain interval, serial loop kind, and removed pipeline-stage annotation.

## C++ style / lint notes

- The PR changes C++ implementation code in `src/transform/inject_pipeline.cc`.
- It does not change public C++ API declarations.
- Review the implementation against the rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) may report advisory findings. These findings do not block correctness, build, or regression-test validation unless the PR introduces a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->