### PR TITLE
[Language] Honor declared strides in pointer helpers

### DIFF
--- a/testing/python/issue/test_tilelang_issue_3025.py
+++ b/testing/python/issue/test_tilelang_issue_3025.py
@@ -1,0 +1,73 @@
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.utils.language import retrieve_stride
+
+
+M = 4
+N = 3
+PITCH = 8
+
+
+def _make_store_kernel():
+    @T.prim_func
+    def main(dst: T.StridedTensor((M, N), (PITCH, 1), "int32")):
+        with T.Kernel(1, threads=1):
+            for row in T.serial(M):
+                T.stg32(dst[row, 0], T.Cast("uint32", row + 1))
+
+    return main
+
+
+def _make_load_kernel():
+    @T.prim_func
+    def main(
+        src: T.StridedTensor((M, N), (PITCH, 1), "int32"),
+        out: T.Tensor((M,), "int32"),
+    ):
+        with T.Kernel(1, threads=1):
+            for row in T.serial(M):
+                out[row] = T.reinterpret(T.ldg32(src[row, 0]), "int32")
+
+    return main
+
+
+def test_retrieve_stride_preserves_scalar_rank():
+    scalar = T.Tensor((), "float32")
+    assert retrieve_stride(scalar) == []
+
+
+@tilelang.testing.requires_cuda
+def test_strided_stg32_uses_declared_stride():
+    kernel = tilelang.compile(_make_store_kernel(), target="cuda")
+    physical = torch.zeros(M * PITCH, dtype=torch.int32, device="cuda")
+    view = physical.as_strided((M, N), (PITCH, 1))
+
+    kernel(view)
+
+    expected = torch.arange(1, M + 1, dtype=torch.int32, device="cuda")
+    torch.testing.assert_close(view[:, 0], expected, rtol=0, atol=0)
+    source = kernel.get_kernel_source()
+    assert "dst[(row * 8)]" in source
+    assert "dst[(row * 3)]" not in source
+
+
+@tilelang.testing.requires_cuda
+def test_strided_ldg32_uses_declared_stride():
+    physical = torch.arange(M * PITCH, dtype=torch.int32, device="cuda")
+    view = physical.as_strided((M, N), (PITCH, 1))
+    out = torch.empty(M, dtype=torch.int32, device="cuda")
+    kernel = tilelang.compile(_make_load_kernel(), target="cuda")
+
+    kernel(view, out)
+
+    torch.testing.assert_close(out, view[:, 0], rtol=0, atol=0)
+    source = kernel.get_kernel_source()
+    assert "src[(row * 8)]" in source
+    assert "src[(row * 3)]" not in source
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/utils/language.py
+++ b/tilelang/utils/language.py
@@ -251,20 +251,24 @@ def retrieve_shape(obj: BufferLikeType) -> list:
 
 def retrieve_stride(obj: BufferLikeType) -> list:
     """
-    Retrieve row-major strides for a buffer-like object based on its buffer.shape.
+    Retrieve strides for a buffer-like object.
 
-    For BufferRegion and BufferLoad, uses the underlying buffer's `shape`.
+    For BufferRegion and BufferLoad, uses the underlying buffer. Declared
+    strides take precedence, with compact row-major strides as the fallback.
     """
     if isinstance(obj, tirx.Buffer):
-        shape = obj.shape
+        buffer = obj
     elif isinstance(obj, (tirx.BufferRegion, tirx.BufferLoad)):
-        shape = obj.buffer.shape
+        buffer = obj.buffer
     else:
         raise ValueError(f"Unsupported retrieve_stride argument type: {type(obj)} for object {obj}")
 
+    if len(buffer.strides) == len(buffer.shape) and len(buffer.strides) > 0:
+        return list(buffer.strides)
+
     strides = []
     stride = 1
-    for s in reversed(shape):
+    for s in reversed(buffer.shape):
         strides.insert(0, stride)
         stride *= s
     return strides


### PR DESCRIPTION
## Problem

`retrieve_stride` always rebuilt compact row-major strides from `buffer.shape`. For a `T.StridedTensor`, explicit pointer primitives such as `T.ldg32` and `T.stg32` therefore flattened `[row, col]` with the logical width instead of the declared physical pitch. The kernel compiled and ran, but accessed the wrong elements.

For a `(4, 3)` tensor with strides `(8, 1)`, the generated CUDA used `row * 3` rather than `row * 8`.

Fixes #3025.

## Change

- Return declared `buffer.strides` when they are present and their rank matches `buffer.shape`.
- Keep the existing compact row-major fallback for buffers without valid declared strides. The rank check also preserves rank-0 behavior on the current frontend.
- Add CUDA regressions for both the `T.stg32` and `T.ldg32` paths, including generated-address assertions.

## Validation

Environment: upstream `e3bef1ceacfd0b536665dacb815315e8ff354740`, Python 3.10.12, TileLang editable build, PyTorch `2.8.0+cu128`, CUDA toolkit 13.0, RTX 3090 (`sm_86`). Each compile-time comparison used a fresh TileLang cache; runtime is the CUDA-event average after 100 warmups and 1,000 launches.

| Minimal kernel | Before | After |
| --- | --- | --- |
| `stg32` column 0 | `[1, 0, 0, 0]` | `[1, 2, 3, 4]` |
| `stg32` CUDA address | `dst[(row * 3)]` | `dst[(row * 8)]` |
| `stg32` compile time | `1935.309830 ms` | `1824.298307 ms` |
| `stg32` runtime | `0.008419 ms` | `0.008650 ms` |
| `ldg32` output | `[0, 3, 6, 9]` | `[0, 8, 16, 24]` |
| `ldg32` CUDA address | `src[(row * 3)]` | `src[(row * 8)]` |
| `ldg32` compile time | `1542.041246 ms` | `1596.831108 ms` |
| `ldg32` runtime | `0.018235 ms` | `0.019923 ms` |

The microkernel timing differences are noise-scale; this is a correctness fix, not a performance claim.

Targeted tests:

```text
python -m pytest -q testing/python/issue/test_tilelang_issue_3025.py
3 passed

python -m pytest -q \
  testing/python/language/test_tilelang_language_ldst.py \
  testing/python/language/test_tilelang_language_ldg.py
15 passed, 4 skipped

python -m pytest -q testing/python/language/test_tilelang_language_copy.py -k stride
1 passed, 34 deselected

python -m pytest -q testing/python/language/test_tilelang_language_subtype.py -k "stride or noncontig"
12 passed, 22 deselected
```

Static checks: `git diff --check`, `ruff check`, `ruff format --check`, and `py_compile` passed for both changed files. The repository pre-commit hooks reported pass/skip for all selected-file checks.

## Risk and limitations

- The behavior change is limited to buffers with valid declared strides; compact buffers and buffers without stride metadata retain the old fallback.
- SM100-only 256-bit load/store tests were skipped on `sm_86`; the supported 32/64/128-bit paths passed locally.
- This was runtime-tested on CUDA/SM86. The helper is target-independent, but ROCm and Metal runtime tests were not run.
- #3016 also touches `retrieve_stride`, but only consolidates compact stride construction. If it lands first, this change's declared-stride early return should remain before its compact fallback.
