### PR TITLE
[Runtime][Cache] Detect and repair corrupted cache entries

### DIFF
--- a/testing/python/cache/test_tilelang_cuda_binary_cache.py
+++ b/testing/python/cache/test_tilelang_cuda_binary_cache.py
@@ -72,6 +72,52 @@ def test_cuda_binary_cache_hit_skips_nvcc_compile(monkeypatch, tmp_path):
     assert len(cache_files) == 2
 
 
+def test_cuda_binary_cache_corrupted_entry_recompiles(monkeypatch, tmp_path):
+    _set_cache_dirs(monkeypatch, tmp_path)
+    from tilelang.cuda import backend as cuda_backend
+
+    monkeypatch.setattr(env, "TILELANG_KERNEL_CACHE_USE_LIB_STAMP", "0")
+
+    compile_calls = []
+
+    def fake_compile_cuda(code, target_format, arch, options=None, verbose=False):
+        compile_calls.append(code)
+        return bytearray(b"fake-cubin")
+
+    monkeypatch.setattr(cuda_backend.nvcc, "compile_cuda", fake_compile_cuda)
+
+    target = Target({"kind": "cuda", "arch": "sm_90a"})
+    source = 'extern "C" __global__ void kernel() {}'
+
+    cuda_backend.tilelang_callback_cuda_compile(source, target)
+    assert len(compile_calls) == 1
+
+    [cache_file] = (tmp_path / "cache").glob("*/cuda-binaries/*.cubin")
+    assert cache_file.with_name(cache_file.name + ".sha256").exists()
+    # Same-size corruption, as left behind by a crashed writer/filesystem client.
+    cache_file.write_bytes(b"\x00" * len(b"fake-cubin"))
+
+    recompiled = cuda_backend.tilelang_callback_cuda_compile(source, target)
+    assert bytes(recompiled) == b"fake-cubin"
+    assert len(compile_calls) == 2
+
+    # The corrupted entry was rewritten, so the next call hits the cache again.
+    cuda_backend.tilelang_callback_cuda_compile(source, target)
+    assert len(compile_calls) == 2
+
+
+def test_cuda_binary_cache_accepts_legacy_entry_without_sidecar(monkeypatch, tmp_path):
+    _set_cache_dirs(monkeypatch, tmp_path)
+
+    key = "legacy-key"
+    path = CUDABinaryCache.get_path(key, "cubin")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(b"legacy-cubin")
+
+    assert CUDABinaryCache.load(key, "cubin") == b"legacy-cubin"
+
+
 def test_disk_cache_load_failure_is_cache_miss(monkeypatch, tmp_path):
     _set_cache_dirs(monkeypatch, tmp_path)
     cache = KernelCache()
@@ -83,6 +129,7 @@ def test_disk_cache_load_failure_is_cache_miss(monkeypatch, tmp_path):
     (cache_path / cache.kernel_lib_path).write_bytes(b"not-loadable")
     with (cache_path / cache.params_path).open("wb") as f:
         cloudpickle.dump(["param"], f)
+    cache._write_manifest(str(cache_path))
 
     def fail_from_database(*args, **kwargs):
         raise RuntimeError("bad host executable")

--- a/testing/python/cache/test_tilelang_kernel_cache_atomic_save.py
+++ b/testing/python/cache/test_tilelang_kernel_cache_atomic_save.py
@@ -64,6 +64,7 @@ def _write_complete_kernel_cache_entry(
     (cache_path / cache.kernel_lib_path).write_bytes(b"fake-so")
     with (cache_path / cache.params_path).open("wb") as f:
         cloudpickle.dump(["param"], f)
+    cache._write_manifest(str(cache_path))
     return cache_path
 
 

--- a/testing/python/cache/test_tilelang_kernel_cache_integrity.py
+++ b/testing/python/cache/test_tilelang_kernel_cache_integrity.py
@@ -1,0 +1,178 @@
+"""Regression tests for cache-entry integrity verification.
+
+A crashed writer (or crashed network-filesystem client) can publish a cache
+entry whose kernel_lib.so is truncated or partially written. Such a binary can
+dlopen fine and only fail at first kernel launch with CUDA_ERROR_INVALID_IMAGE,
+where nothing repairs the entry. The kernel cache therefore records a manifest
+of file sizes/hashes on save and verifies it on load, treating mismatches as
+cache misses.
+"""
+
+import json
+from hashlib import sha256
+from pathlib import Path
+
+import cloudpickle
+import pytest
+
+import tilelang.cache.kernel_cache as kernel_cache_mod
+from tilelang.backend import create_backend_context
+from tilelang.cache.kernel_cache import KernelCache
+from tilelang.env import env
+
+
+class _FakeAdapter:
+    def __init__(self, libpath: str):
+        self.libpath = libpath
+
+    def get_kernel_source(self):
+        return "// host kernel"
+
+
+class _FakeKernel:
+    def __init__(self, libpath: str):
+        self.adapter = _FakeAdapter(libpath)
+        self.kernel_source = "// device kernel"
+        self.params = ["param"]
+
+
+@pytest.fixture
+def cache_dirs(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(env, "TILELANG_CACHE_DIR", str(cache_dir))
+    return cache_dir
+
+
+def _make_fake_kernel(tmp_path):
+    lib_path = tmp_path / "kernel_lib.so"
+    lib_path.write_bytes(b"fake-so-contents")
+    return _FakeKernel(str(lib_path))
+
+
+def _load_expecting_no_build(cache: KernelCache, key: str, monkeypatch):
+    def fail_from_database(cls, **kwargs):
+        raise AssertionError("corrupted cache entries must miss before rebuilding from database")
+
+    monkeypatch.setattr(kernel_cache_mod.JITKernel, "from_database", classmethod(fail_from_database))
+    return cache._load_kernel_from_disk(
+        key,
+        backend_context=create_backend_context("cuda", execution_backend="tvm_ffi"),
+        out_idx=[0],
+        pass_configs=None,
+        compile_flags=None,
+        func=None,
+    )
+
+
+def _load_expecting_hit(cache: KernelCache, key: str, monkeypatch):
+    sentinel = object()
+    monkeypatch.setattr(kernel_cache_mod.JITKernel, "from_database", classmethod(lambda cls, **kwargs: sentinel))
+    loaded = cache._load_kernel_from_disk(
+        key,
+        backend_context=create_backend_context("cuda", execution_backend="tvm_ffi"),
+        out_idx=[0],
+        pass_configs=None,
+        compile_flags=None,
+        func=None,
+    )
+    return loaded is sentinel
+
+
+def test_save_writes_manifest_covering_all_files(cache_dirs, tmp_path):
+    cache = KernelCache()
+    key = "manifest-on-save"
+    cache._save_kernel_to_disk(key, _make_fake_kernel(tmp_path))
+
+    cache_path = Path(cache._get_cache_path(key))
+    manifest = json.loads((cache_path / cache.manifest_path).read_text())
+
+    expected_files = {
+        cache.device_kernel_path,
+        cache.host_kernel_path,
+        cache.kernel_lib_path,
+        cache.params_path,
+    }
+    assert set(manifest["files"]) == expected_files
+    lib_bytes = (cache_path / cache.kernel_lib_path).read_bytes()
+    assert manifest["files"][cache.kernel_lib_path]["size"] == len(lib_bytes)
+    assert manifest["files"][cache.kernel_lib_path]["sha256"] == sha256(lib_bytes).hexdigest()
+
+
+def test_load_removes_entry_with_truncated_kernel_lib(cache_dirs, tmp_path, monkeypatch):
+    cache = KernelCache()
+    key = "truncated-lib"
+    cache._save_kernel_to_disk(key, _make_fake_kernel(tmp_path))
+    cache_path = Path(cache._get_cache_path(key))
+
+    lib_file = cache_path / cache.kernel_lib_path
+    lib_file.write_bytes(lib_file.read_bytes()[: len(b"fake-so-contents") // 2])
+
+    assert _load_expecting_no_build(cache, key, monkeypatch) is None
+    assert not cache_path.exists()
+
+
+def test_load_removes_entry_with_same_size_corruption(cache_dirs, tmp_path, monkeypatch):
+    cache = KernelCache()
+    key = "bitflipped-lib"
+    cache._save_kernel_to_disk(key, _make_fake_kernel(tmp_path))
+    cache_path = Path(cache._get_cache_path(key))
+
+    lib_file = cache_path / cache.kernel_lib_path
+    original = lib_file.read_bytes()
+    lib_file.write_bytes(b"\x00" * len(original))
+
+    assert _load_expecting_no_build(cache, key, monkeypatch) is None
+    assert not cache_path.exists()
+
+
+def test_hash_check_disabled_still_catches_truncation(cache_dirs, tmp_path, monkeypatch):
+    monkeypatch.setattr(env, "TILELANG_CACHE_VERIFY_HASH", "0")
+    cache = KernelCache()
+    key = "size-only-check"
+    cache._save_kernel_to_disk(key, _make_fake_kernel(tmp_path))
+    cache_path = Path(cache._get_cache_path(key))
+
+    lib_file = cache_path / cache.kernel_lib_path
+    lib_file.write_bytes(b"short")
+
+    assert _load_expecting_no_build(cache, key, monkeypatch) is None
+    assert not cache_path.exists()
+
+
+def test_source_files_are_size_checked_but_not_hashed(cache_dirs, tmp_path, monkeypatch):
+    # Hashing sources on load would regress lazy source loading; only their
+    # size is checked, so a same-size rewrite of a source file must not
+    # invalidate the entry.
+    cache = KernelCache()
+    key = "source-not-hashed"
+    cache._save_kernel_to_disk(key, _make_fake_kernel(tmp_path))
+    cache_path = Path(cache._get_cache_path(key))
+
+    device_file = cache_path / cache.device_kernel_path
+    device_file.write_text("X" * len(device_file.read_text()))
+
+    assert _load_expecting_hit(cache, key, monkeypatch)
+
+
+def test_legacy_entry_without_manifest_misses_and_save_repairs(cache_dirs, tmp_path, monkeypatch):
+    cache = KernelCache()
+    key = "legacy-no-manifest"
+    cache_path = Path(cache._get_cache_path(key))
+    cache_path.mkdir(parents=True)
+    (cache_path / cache.device_kernel_path).write_text("// device kernel")
+    (cache_path / cache.host_kernel_path).write_text("// host kernel")
+    (cache_path / cache.kernel_lib_path).write_bytes(b"legacy-truncated")
+    with (cache_path / cache.params_path).open("wb") as f:
+        cloudpickle.dump(["param"], f)
+
+    assert _load_expecting_no_build(cache, key, monkeypatch) is None
+
+    cache._save_kernel_to_disk(key, _make_fake_kernel(tmp_path))
+    assert (cache_path / cache.manifest_path).exists()
+    assert (cache_path / cache.kernel_lib_path).read_bytes() == b"fake-so-contents"
+    assert _load_expecting_hit(cache, key, monkeypatch)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -186,6 +186,10 @@ class AutotuneResult:
         try:
             with open(temp_path, mode) as temp_file:
                 operation(temp_file)
+                # Without this barrier a crash can persist the rename below
+                # before the file data, publishing a truncated file.
+                temp_file.flush()
+                os.fsync(temp_file.fileno())
             os.replace(temp_path, path)
         finally:
             with contextlib.suppress(OSError):
@@ -199,6 +203,9 @@ class AutotuneResult:
         temp_path = os.path.join(directory, f".{stem}.{os.getpid()}_{uuid.uuid4().hex}.tmp{suffix}")
         try:
             executable.export_library(temp_path)
+            # Flush exported data before the rename publishes the file.
+            with open(temp_path, "rb+") as temp_file:
+                os.fsync(temp_file.fileno())
             os.replace(temp_path, path)
         finally:
             with contextlib.suppress(OSError):
@@ -467,6 +474,13 @@ class AutotuneResult:
 
             # Repair stale/incomplete entries before making the new directory visible.
             self._remove_incomplete_result_dir(path, self.kernel.execution_backend)
+
+            # Durability barrier: keep the staged data ahead of the rename so a
+            # crash cannot publish a truncated cache entry.
+            for entry in os.scandir(staging_path):
+                if entry.is_file(follow_symlinks=False):
+                    with open(entry.path, "rb+") as staged_file:
+                        os.fsync(staged_file.fileno())
 
             # Atomic rename — directory becomes visible in one step.
             try:

--- a/tilelang/cache/cuda_binary_cache.py
+++ b/tilelang/cache/cuda_binary_cache.py
@@ -124,15 +124,36 @@ class CUDABinaryCache:
         return os.path.join(cls._get_cache_root(), filename)
 
     @classmethod
+    def _sidecar_path(cls, path: str) -> str:
+        return path + ".sha256"
+
+    @classmethod
     def load(cls, key: str, compile_format: str) -> bytes | None:
         if not env.is_cache_enabled():
             return None
         path = cls.get_path(key, compile_format)
         try:
             with open(path, "rb") as f:
-                return f.read()
+                data = f.read()
         except FileNotFoundError:
             return None
+        if not env.should_verify_cache_hash():
+            return data
+        try:
+            with open(cls._sidecar_path(path)) as f:
+                expected_hash = f.read().strip()
+        except OSError:
+            # Entries written before content hashes were recorded.
+            return data
+        if sha256(data).hexdigest() == expected_hash:
+            return data
+        # Corrupted entry (e.g. truncated by a crashed writer): feeding it to
+        # cuModuleLoadData would fail with CUDA_ERROR_INVALID_IMAGE on every
+        # future run. Drop it so the caller recompiles and rewrites it.
+        for stale in (path, cls._sidecar_path(path)):
+            with contextlib.suppress(OSError):
+                os.remove(stale)
+        return None
 
     @classmethod
     def save(cls, key: str, compile_format: str, data: bytes) -> None:
@@ -142,13 +163,26 @@ class CUDABinaryCache:
         cache_root = cls._get_cache_root()
         os.makedirs(cache_root, exist_ok=True)
         path = cls.get_path(key, compile_format)
+        # Sidecar first: a crash between the two renames then leaves a hash
+        # without a payload (a plain cache miss) instead of an unverifiable
+        # payload.
+        cls._write_atomic(cls._sidecar_path(path), sha256(data).hexdigest().encode())
+        cls._write_atomic(path, data)
+
+    @classmethod
+    def _write_atomic(cls, path: str, data: bytes) -> None:
+        directory, filename = os.path.split(path)
         # Atomic replacement requires the temporary file and destination to be
         # on the same filesystem, so keep the temporary file next to the cache
         # entry.
-        temp_path = os.path.join(cache_root, f".{os.getpid()}_{uuid.uuid4()}.{compile_format}.tmp")
+        temp_path = os.path.join(directory, f".{filename}.{os.getpid()}_{uuid.uuid4().hex}.tmp")
         try:
             with open(temp_path, "wb") as f:
                 f.write(data)
+                # Without this barrier a crash can persist the rename below
+                # before the file data, publishing a truncated binary.
+                f.flush()
+                os.fsync(f.fileno())
             os.replace(temp_path, path)
         finally:
             with contextlib.suppress(OSError):

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -54,6 +54,7 @@ class KernelCache:
     kernel_lib_path = "kernel_lib.so"
     params_path = "params.pkl"
     resource_usage_path = "resource_usage.json"
+    manifest_path = "manifest.json"
     cache_root_dir = "kernels"
     staging_root_dir = ".staging"
 
@@ -492,6 +493,33 @@ class KernelCache:
         return binary
 
     @staticmethod
+    def _fsync_file_contents(path: str):
+        """Flush a written file's data to stable storage before publishing it."""
+        with open(path, "rb+") as file:
+            os.fsync(file.fileno())
+
+    @staticmethod
+    def _fsync_dir(path: str):
+        """Best-effort directory fsync; unsupported on some platforms/filesystems."""
+        try:
+            fd = os.open(path, os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            with contextlib.suppress(OSError):
+                os.fsync(fd)
+        finally:
+            os.close(fd)
+
+    @staticmethod
+    def _hash_file(path: str) -> str:
+        file_hash = sha256()
+        with open(path, "rb") as file:
+            for chunk in iter(lambda: file.read(1 << 20), b""):
+                file_hash.update(chunk)
+        return file_hash.hexdigest()
+
+    @staticmethod
     def _safe_write_file(path: str, mode: str, operation: Callable):
         """Atomically write a cache file through a temporary sibling."""
         directory, filename = os.path.split(path)
@@ -499,6 +527,10 @@ class KernelCache:
         try:
             with open(temp_path, mode) as temp_file:
                 operation(temp_file)
+                # Without this barrier a crash can persist the rename below
+                # before the file data, publishing a truncated file.
+                temp_file.flush()
+                os.fsync(temp_file.fileno())
             os.replace(temp_path, path)
         finally:
             with contextlib.suppress(OSError):
@@ -512,6 +544,7 @@ class KernelCache:
         temp_path = os.path.join(directory, f".{stem}.{os.getpid()}_{uuid.uuid4().hex}.tmp{suffix}")
         try:
             executable.export_library(temp_path, **(export_kwargs or {}))
+            KernelCache._fsync_file_contents(temp_path)
             os.replace(temp_path, path)
         finally:
             with contextlib.suppress(OSError):
@@ -571,10 +604,23 @@ class KernelCache:
             if usage:
                 dump_to_file(usage, os.path.join(staging_path, self.resource_usage_path))
 
+            # Record every staged file's size and content hash so loads can
+            # detect corrupted entries and treat them as cache misses.
+            self._write_manifest(staging_path)
+
             missing_files = self._get_missing_complete_cache_files(staging_path)
             if missing_files:
                 missing_names = ", ".join(os.path.basename(path) for path in missing_files)
                 raise RuntimeError(f"Incomplete cache staging directory is missing required file(s): {missing_names}")
+
+            # Durability barrier: a node or filesystem-client crash may otherwise
+            # persist the rename below before the staged file data, publishing a
+            # truncated entry (surfaces as CUDA_ERROR_INVALID_IMAGE at launch,
+            # notably on shared network caches).
+            for entry in os.scandir(staging_path):
+                if entry.is_file(follow_symlinks=False):
+                    KernelCache._fsync_file_contents(entry.path)
+            KernelCache._fsync_dir(staging_path)
 
             # Repair stale/incomplete entries before making the new directory visible.
             self._remove_incomplete_cache_dir(cache_path)
@@ -587,6 +633,8 @@ class KernelCache:
                     raise
                 # Another process won the race with a complete cache entry.
                 shutil.rmtree(staging_path, ignore_errors=True)
+            else:
+                KernelCache._fsync_dir(self._get_cache_root())
         except Exception:
             shutil.rmtree(staging_path, ignore_errors=True)
             self.logger.exception("Error during atomic cache save")
@@ -625,6 +673,18 @@ class KernelCache:
         if missing_files:
             if verbose:
                 self.logger.debug("Disk cache entry is incomplete; missing files: %s", missing_files)
+            return None
+
+        if not self._verify_cache_dir_integrity(cache_path):
+            # A crashed writer (or crashed filesystem client) can publish a
+            # truncated kernel_lib.so that dlopens fine but fails only at first
+            # launch (CUDA_ERROR_INVALID_IMAGE), where nothing repairs the
+            # entry. Catch it here and self-heal by recompiling.
+            self.logger.warning(
+                "Disk cache entry at %s failed integrity verification (corrupted or partially written); removing it and recompiling.",
+                cache_path,
+            )
+            shutil.rmtree(cache_path, ignore_errors=True)
             return None
 
         # Load kernel parameters
@@ -719,6 +779,7 @@ class KernelCache:
                 [
                     os.path.join(cache_path, self.device_kernel_path),
                     os.path.join(cache_path, self.host_kernel_path),
+                    os.path.join(cache_path, self.manifest_path),
                     *self._get_required_files(cache_path),
                 ]
             )
@@ -726,6 +787,54 @@ class KernelCache:
 
     def _get_missing_complete_cache_files(self, cache_path: str) -> list[str]:
         return [file for file in self._get_complete_cache_files(cache_path) if not os.path.exists(file)]
+
+    def _write_manifest(self, cache_path: str):
+        """Record size and content hash of every cache file for load-time verification."""
+        files: dict[str, dict] = {}
+        for entry in sorted(os.scandir(cache_path), key=lambda item: item.name):
+            if not entry.is_file(follow_symlinks=False) or entry.name == self.manifest_path:
+                continue
+            files[entry.name] = {
+                "size": entry.stat().st_size,
+                "sha256": KernelCache._hash_file(entry.path),
+            }
+        manifest = {"version": 1, "files": files}
+        KernelCache._safe_write_file(
+            os.path.join(cache_path, self.manifest_path),
+            "w",
+            lambda file: json.dump(manifest, file, indent=2, sort_keys=True),
+        )
+
+    def _verify_cache_dir_integrity(self, cache_path: str) -> bool:
+        """Check a cache entry against its manifest.
+
+        Every listed file must match its recorded size; the required binary
+        artifacts (e.g. kernel_lib.so, params.pkl) must also match their
+        recorded content hash. Source files are size-checked only so disk
+        cache hits keep deferring source reads. Returns False for entries
+        whose manifest is unreadable or that do not cover the required files.
+        """
+        manifest_file = os.path.join(cache_path, self.manifest_path)
+        try:
+            with open(manifest_file) as file:
+                files = json.load(file)["files"]
+            entries = list(files.items())
+        except (OSError, ValueError, KeyError, TypeError, AttributeError):
+            return False
+        required_names = {os.path.basename(path) for path in self._get_required_files(cache_path)}
+        if not required_names.issubset(files):
+            return False
+        verify_hash = env.should_verify_cache_hash()
+        for name, meta in entries:
+            path = os.path.join(cache_path, name)
+            try:
+                if os.path.getsize(path) != meta["size"]:
+                    return False
+                if verify_hash and name in required_names and KernelCache._hash_file(path) != meta["sha256"]:
+                    return False
+            except (OSError, KeyError, TypeError):
+                return False
+        return True
 
     def _is_complete_cache_dir(self, cache_path: str) -> bool:
         return os.path.isdir(cache_path) and not self._get_missing_complete_cache_files(cache_path)

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -363,6 +363,9 @@ class Environment:
     TILELANG_KERNEL_CACHE_USE_LIB_STAMP = EnvVar(
         "TILELANG_KERNEL_CACHE_USE_LIB_STAMP", "0"
     )  # include native TileLang library content hash in kernel cache keys
+    TILELANG_CACHE_VERIFY_HASH = EnvVar(
+        "TILELANG_CACHE_VERIFY_HASH", "1"
+    )  # verify content hashes of cached binary artifacts at load time (set to 0 to only check file sizes)
     TILELANG_CLEANUP_TEMP_FILES = EnvVar(
         "TILELANG_CLEANUP_TEMP_FILES", "1"
     )  # cleanup temporary compiler files/dirs after compilation (set to 0 to keep for debugging)
@@ -434,6 +437,9 @@ class Environment:
 
     def should_use_kernel_cache_lib_stamp(self) -> bool:
         return str(self.TILELANG_KERNEL_CACHE_USE_LIB_STAMP).lower() in ("1", "true", "yes", "on")
+
+    def should_verify_cache_hash(self) -> bool:
+        return str(self.TILELANG_CACHE_VERIFY_HASH).lower() in ("1", "true", "yes", "on")
 
     def is_autotune_cache_disabled(self) -> bool:
         return self.TILELANG_AUTO_TUNING_DISABLE_CACHE.lower() in ("1", "true", "yes", "on")

--- a/tilelang/jit/adapter/cutedsl/adapter.py
+++ b/tilelang/jit/adapter/cutedsl/adapter.py
@@ -354,8 +354,10 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         if cache_path is None:
             return
 
+        import contextlib
         import os
         import shutil
+        import uuid
 
         # Source cubin path (in temp directory)
         src_py_path = self.libpath
@@ -372,12 +374,22 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         if os.path.exists(dst_cubin_path):
             return
 
-        # Copy cubin to cache
+        # Copy cubin to cache through a fsynced temporary sibling: this writes
+        # into an already-published cache directory, so a partial copy must
+        # never become visible under the final name.
+        temp_cubin_path = os.path.join(cache_path, f".kernel.{os.getpid()}_{uuid.uuid4().hex}.tmp.cubin")
         try:
-            shutil.copy2(src_cubin_path, dst_cubin_path)
+            with open(src_cubin_path, "rb") as src, open(temp_cubin_path, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+                dst.flush()
+                os.fsync(dst.fileno())
+            os.replace(temp_cubin_path, dst_cubin_path)
             logger.debug(f"Saved CuTeDSL cubin to cache: {dst_cubin_path}")
         except Exception as e:
             logger.warning(f"Failed to save cubin to cache: {e}", exc_info=True)
+        finally:
+            with contextlib.suppress(OSError):
+                os.remove(temp_cubin_path)
 
     def _wrap_forward_from_prebuild_lib(self, *ins: Any, stream: int | None = None):
         """High-level wrapper for kernel execution.


### PR DESCRIPTION
## Summary

- Prevent cache artifacts from becoming visible before their contents are durably flushed.
- Detect damaged kernel and CUDA binary cache entries and recompile them automatically.
- Cover kernel, CUDA binary, autotuning, and CuTeDSL cache writes.

## Changes

- Add per-file size and SHA-256 metadata to kernel cache manifests and verify required artifacts during load.
- Write CUDA binary hash sidecars and remove entries whose payload no longer matches.
- Add `TILELANG_CACHE_VERIFY_HASH` to allow size-only verification while keeping hash checks enabled by default.
- Fsync staged artifacts and directories before atomic publication, including autotuning and CuTeDSL cubins.
- Add regressions for truncation, same-size corruption, legacy entries, and manifest creation.

## Validation

- `./format.sh`
- `python -m pytest testing/python/cache/ testing/python/autotune/test_autotune_cache_key.py testing/python/autotune/test_tilelang_autotune_atomic_save.py testing/python/autotune/test_tilelang_autotune_cutedsl_cache.py -x` (41 passed, 4 skipped)
- `python -m pytest testing/python/components/test_tilelang_env.py -x` (13 passed)

## Notes

- Existing kernel cache entries without manifests are treated as misses and rebuilt once.
- Existing CUDA binary entries without hash sidecars remain readable for backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Hardened kernel and CUDA cache writes with `fsync` and atomic publication.
- Added kernel cache manifests with per-file sizes and SHA-256 hashes.
- Detects corrupted or incomplete kernel entries and rebuilds them.
- Added CUDA binary hash sidecars with backward compatibility for legacy entries.
- Added `TILELANG_CACHE_VERIFY_HASH` for optional hash verification.
- Applied durable writes to autotuning results, exported executables, and CuTeDSL cubins.
- Added regression tests for truncation, same-size corruption, legacy entries, size-only verification, and manifest creation.

## Validation

- Formatting checks passed.
- 41 cache and autotuning tests passed; 4 skipped.
- 13 environment tests passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->