### PR TITLE
[CUDA] Bridge half-style math intrinsics for 16-bit CUTLASS types

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -224,13 +224,104 @@ TL_PATCH TL_DEVICE bfloat16_t htan(const bfloat16_t x) {
   return bfloat16_t(tanf(float(x)));
 }
 
-// TVM lowers T.exp(bfloat16) to the CUDA half-style `hexp` name. TileLang uses
-// cutlass::bfloat16_t for scalar bf16, while CUDA only overloads hexp for
-// __nv_bfloat16. Keep this narrow bridge in common.h so plain T.exp works
-// without pulling tl_templates/cuda/math.h and cutlass/fast_math.h into every
-// kernel.
+// TVM lowers 16-bit math ops to CUDA's half-style names (hexp, hlog, ...).
+// TileLang emits cutlass::half_t / bfloat16_t for scalar 16-bit values, while
+// CUDA overloads those names only for native __half / __nv_bfloat16. Kept here
+// so plain ops work without pulling cutlass/fast_math.h into every kernel.
+TL_PATCH TL_DEVICE half_t hexp(const half_t x) {
+  return half_t(hexp(x.to_half()));
+}
+
 TL_PATCH TL_DEVICE bfloat16_t hexp(const bfloat16_t x) {
   return bfloat16_t(hexp(x.to_nv_bfloat16()));
+}
+
+TL_PATCH TL_DEVICE half_t hexp2(const half_t x) {
+  return half_t(hexp2(x.to_half()));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hexp2(const bfloat16_t x) {
+  return bfloat16_t(hexp2(x.to_nv_bfloat16()));
+}
+
+TL_PATCH TL_DEVICE half_t hexp10(const half_t x) {
+  return half_t(hexp10(x.to_half()));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hexp10(const bfloat16_t x) {
+  return bfloat16_t(hexp10(x.to_nv_bfloat16()));
+}
+
+TL_PATCH TL_DEVICE half_t hlog(const half_t x) {
+  return half_t(hlog(x.to_half()));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hlog(const bfloat16_t x) {
+  return bfloat16_t(hlog(x.to_nv_bfloat16()));
+}
+
+TL_PATCH TL_DEVICE half_t hlog2(const half_t x) {
+  return half_t(hlog2(x.to_half()));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hlog2(const bfloat16_t x) {
+  return bfloat16_t(hlog2(x.to_nv_bfloat16()));
+}
+
+TL_PATCH TL_DEVICE half_t hlog10(const half_t x) {
+  return half_t(hlog10(x.to_half()));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hlog10(const bfloat16_t x) {
+  return bfloat16_t(hlog10(x.to_nv_bfloat16()));
+}
+
+TL_PATCH TL_DEVICE half_t hsin(const half_t x) {
+  return half_t(hsin(x.to_half()));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hsin(const bfloat16_t x) {
+  return bfloat16_t(hsin(x.to_nv_bfloat16()));
+}
+
+TL_PATCH TL_DEVICE half_t hcos(const half_t x) {
+  return half_t(hcos(x.to_half()));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hcos(const bfloat16_t x) {
+  return bfloat16_t(hcos(x.to_nv_bfloat16()));
+}
+
+TL_PATCH TL_DEVICE half_t hfloor(const half_t x) {
+  return half_t(hfloor(x.to_half()));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hfloor(const bfloat16_t x) {
+  return bfloat16_t(hfloor(x.to_nv_bfloat16()));
+}
+
+TL_PATCH TL_DEVICE half_t hceil(const half_t x) {
+  return half_t(hceil(x.to_half()));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hceil(const bfloat16_t x) {
+  return bfloat16_t(hceil(x.to_nv_bfloat16()));
+}
+
+TL_PATCH TL_DEVICE half_t hrint(const half_t x) {
+  return half_t(hrint(x.to_half()));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hrint(const bfloat16_t x) {
+  return bfloat16_t(hrint(x.to_nv_bfloat16()));
+}
+
+TL_PATCH TL_DEVICE half_t htrunc(const half_t x) {
+  return half_t(htrunc(x.to_half()));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t htrunc(const bfloat16_t x) {
+  return bfloat16_t(htrunc(x.to_nv_bfloat16()));
 }
 
 // CUDA has no __ldg overloads for CUTLASS's 16-bit wrappers. Forward through

--- a/testing/python/language/test_tilelang_language_intrinsics_codegen.py
+++ b/testing/python/language/test_tilelang_language_intrinsics_codegen.py
@@ -52,5 +52,90 @@ def test_language_ldg_roundtrip(dtype):
     run_ldg_roundtrip(dtype)
 
 
+# (op, lowered h* intrinsic, torch reference, input index), in the row order
+# half_math_kernel writes.
+HALF_MATH_OPS = (
+    ("exp", "hexp", torch.exp, 0),
+    ("exp2", "hexp2", torch.exp2, 0),
+    ("exp10", "hexp10", lambda x: torch.pow(10.0, x), 0),
+    ("log", "hlog", torch.log, 0),
+    ("log2", "hlog2", torch.log2, 0),
+    ("log10", "hlog10", torch.log10, 0),
+    ("sin", "hsin", torch.sin, 1),
+    ("cos", "hcos", torch.cos, 1),
+    ("floor", "hfloor", torch.floor, 1),
+    ("ceil", "hceil", torch.ceil, 1),
+    ("round", "hrint", torch.round, 1),
+    ("trunc", "htrunc", torch.trunc, 1),
+)
+
+
+def half_math_kernel(dtype, N):
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        C: T.Tensor((N,), dtype),
+        B: T.Tensor((len(HALF_MATH_OPS), N), dtype),
+    ):
+        with T.Kernel(1, threads=N):
+            i = T.get_thread_binding()
+            # Keep the temporaries: they copy-initialize, a store only assigns.
+            exp_value = T.exp(A[i])
+            exp2_value = T.exp2(A[i])
+            exp10_value = T.exp10(A[i])
+            log_value = T.log(A[i])
+            log2_value = T.log2(A[i])
+            log10_value = T.log10(A[i])
+            sin_value = T.sin(C[i])
+            cos_value = T.cos(C[i])
+            floor_value = T.floor(C[i])
+            ceil_value = T.ceil(C[i])
+            round_value = T.round(C[i])
+            trunc_value = T.trunc(C[i])
+            B[0, i] = exp_value
+            B[1, i] = exp2_value
+            B[2, i] = exp10_value
+            B[3, i] = log_value
+            B[4, i] = log2_value
+            B[5, i] = log10_value
+            B[6, i] = sin_value
+            B[7, i] = cos_value
+            B[8, i] = floor_value
+            B[9, i] = ceil_value
+            B[10, i] = round_value
+            B[11, i] = trunc_value
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", [T.float16, T.bfloat16])
+def test_half_math_intrinsics(dtype):
+    N = 128
+    kernel = tilelang.compile(half_math_kernel(dtype, N), target="cuda")
+    body = kernel.get_kernel_source()
+    body = body[body.rindex("__global__") :]
+
+    torch_dtype = dtype.as_torch()
+    # [0.3, 4.3) keeps exp10 finite in float16; the mixed-sign input avoids
+    # integers and rounding ties.
+    a = (torch.arange(N, device="cuda") * 0.03125 + 0.3).to(torch_dtype)
+    c = ((torch.arange(N, device="cuda") - 63.5) * 0.0625).to(torch_dtype)
+    b = torch.empty(len(HALF_MATH_OPS), N, device="cuda", dtype=torch_dtype)
+    kernel(a, c, b)
+
+    inputs = (a, c)
+    for row, (name, intrinsic, ref_fn, which) in enumerate(HALF_MATH_OPS):
+        assert body.count(f"{intrinsic}(") == 1
+        ref = ref_fn(inputs[which].float()).to(torch_dtype)
+        torch.testing.assert_close(
+            b[row].float(),
+            ref.float(),
+            atol=2e-2,
+            rtol=2e-2,
+            msg=lambda base, name=name: f"T.{name} mismatch\n{base}",
+        )
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

Many unary `T.*` math ops fail on `float16` and `bfloat16` because CUDA lowering emits half-style names such as `hlog` and `hfloor`, while CUDA only overloads them for native `__half` and `__nv_bfloat16`, not CUTLASS wrappers.

## Fix

Add flat `half_t` and `bfloat16_t` forwarding overloads for: `hexp`, `hexp2`, `hexp10`, `hlog`, `hlog2`, `hlog10`, `hsin`, `hcos`, `hfloor`, `hceil`, `hrint`, and `htrunc`. Each overload calls the existing native CUDA intrinsic and wraps the result back in the original type. The existing bfloat16 `hexp` overload is retained as part of the completed set. Codegen and the fast-math path are unchanged.

This enables `T.exp`, `T.exp2`, `T.exp10`, `T.log`, `T.log2`, `T.log10`, `T.sin`, `T.cos`, `T.floor`, `T.ceil`, `T.round`, `T.trunc`, and `T.sigmoid` through its `exp` lowering.

## Tests

Added one kernel per dtype covering all 12 intrinsics with materialized temporaries, valid positive/mixed-sign inputs, entry-body codegen assertions, and torch references.

Verified locally on `sm_75` / CUDA 12.4:

* Touched test file: 5 passed.
* Negative control: 2 failed, 3 passed.
* Related fast-math, clamp, warp-sync, and intrinsic suites: 138 passed.

## Scope

Limited to half-style names that already have native CUDA intrinsics. Operations requiring a float32 fallback, missing lowering rules, or separate float8/integer dtype policy remain out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add CUDA forwarding overloads for 12 half-style math intrinsics on `half_t` and `bfloat16_t`.
- Convert wrapper types to native CUDA types, call the existing intrinsic, and convert the result back.
- Extend coverage to exponential, logarithmic, trigonometric, rounding, and truncation operations.
- Add code generation and Torch reference tests for both data types.
- Cover materialized temporaries and verify each lowered CUDA intrinsic.

## Validation

- Touched tests and related suites passed locally on `sm_75` with CUDA 12.4.
- Code generation and fast-math behavior remain unchanged.

## C++ style / lint notes

- The PR changes C++ overloads in `src/tl_templates/cuda/common.h`.
- It does not change the rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step may report advisory findings. Such warnings are not correctness or build failures and should not block this change without a clear API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->