### PR TITLE
[BugFix][Transform] Reject break in fully expanded loops (#3026)

### DIFF
--- a/src/transform/unroll_loop.cc
+++ b/src/transform/unroll_loop.cc
@@ -13,6 +13,7 @@
 
 #include <unordered_set>
 
+#include "../op/builtin.h"
 #include "runtime/thread_storage_scope.h"
 #include "tir/transforms/ir_utils.h"
 
@@ -78,6 +79,40 @@ public:
 private:
   std::unordered_set<Var> *var_touched_local_;
 };
+
+namespace {
+
+class TargetedLoopBreakDetector : public StmtExprVisitor {
+public:
+  static bool Contains(const Stmt &body) {
+    TargetedLoopBreakDetector detector;
+    detector(body);
+    return detector.found_;
+  }
+
+private:
+  void VisitExpr_(const CallNode *op) final {
+    if (op->op.same_as(tl::loop_break()) ||
+        op->op.same_as(builtin::break_loop())) {
+      found_ = true;
+      return;
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  void VisitStmt_(const ForNode *) final {
+    // A break inside a nested loop targets that loop, not the loop being
+    // considered for full expansion.
+  }
+
+  void VisitStmt_(const WhileNode *) final {
+    // As above, do not attribute a nested while-loop's break to its parent.
+  }
+
+  bool found_{false};
+};
+
+} // namespace
 
 // The Visitor is used to check whether var is used as write index in a local
 // memory If a loop var is used as indices to a local memory, it must be
@@ -267,6 +302,11 @@ public:
   }
 
   Stmt Unroll(const ForNode *op) {
+    CHECK(!TargetedLoopBreakDetector::Contains(op->body), ValueError)
+        << "[TileLang Semantic Check] A loop containing T.loop_break() that "
+           "targets that loop cannot be fully expanded. Use "
+           "T.unroll(..., explicit=False) or T.serial(...) to preserve the "
+           "loop.";
     int value = GetTripCount(op);
     // For loop must have a constant integer extent
     ICHECK_GE(value, 0) << "loop doesn't have a constant integer extent";

--- a/testing/python/transform/test_tilelang_transform_unroll_loop.py
+++ b/testing/python/transform/test_tilelang_transform_unroll_loop.py
@@ -1,4 +1,5 @@
 import tilelang
+import pytest
 from tilelang import tvm
 from tvm.script import ir as I
 from tvm.script import tirx as T
@@ -70,6 +71,57 @@ def test_unroll_explicit_loops_preserves_dynamic_and_factor_loops():
     assert [loop.loop_var.name for loop in loops] == ["j", "k"]
     assert loops[0].kind == tvm.tirx.ForKind.UNROLLED
     assert int(loops[1].annotations["pragma_unroll_factor"]) == 4
+
+
+def test_explicit_unroll_rejects_break_targeting_loop():
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((2,), "int32")):
+            for i in T.unroll(2, annotations={"pragma_unroll_explicit": True}):
+                A[i] = i
+                if A[i] != 0:
+                    T.evaluate(T.call_intrin("handle", tvm.tirx.op.Op.get("tl.loop_break")))
+
+    with pytest.raises(ValueError, match="cannot be fully expanded"):
+        tilelang.transform.UnrollLoop()(Before)
+
+
+def test_non_explicit_unroll_allows_break():
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((2,), "int32")):
+            for i in T.unroll(2):
+                A[i] = i
+                if A[i] != 0:
+                    T.evaluate(T.call_intrin("handle", tvm.tirx.op.Op.get("tl.loop_break")))
+
+    after = tilelang.transform.UnrollLoop()(Before)
+    assert isinstance(after["main"].body, tvm.tirx.For)
+    assert after["main"].body.kind == tvm.tirx.ForKind.UNROLLED
+
+
+def test_explicit_unroll_allows_break_targeting_nested_loop():
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((4,), "int32")):
+            for i in T.unroll(2, annotations={"pragma_unroll_explicit": True}):
+                for j in T.serial(2):
+                    A[i * 2 + j] = j
+                    if A[i * 2 + j] != 0:
+                        T.evaluate(T.call_intrin("handle", tvm.tirx.op.Op.get("tl.loop_break")))
+
+    after = tilelang.transform.UnrollLoop()(Before)
+    loops = []
+    post_order_visit(
+        after["main"].body,
+        lambda node: loops.append(node) if isinstance(node, tvm.tirx.For) else None,
+    )
+
+    assert len(loops) == 2
+    assert all(loop.kind == tvm.tirx.ForKind.SERIAL for loop in loops)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Detect `T.loop_break()` and `builtin::break_loop()` calls that target the loop being fully expanded.
- Ignore breaks inside nested `For` and `While` loops.
- Raise `ValueError` with `"cannot be fully expanded"` when explicit unrolling targets a loop with a break.
- Preserve existing behavior for non-explicit unrolling.
- Allow breaks that target nested serial loops.
- Add tests for all three cases.

## C++ style / lint notes

- The PR changes C++ code but does not modify the rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit remains warning-only when applicable.
- No correctness, build, or test issue is identified from the changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->