### PR TITLE
[Lang][Reducer] Vectorize contiguous reducer updates

### DIFF
--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -939,9 +939,12 @@ private:
         CanProveIndependent(elem_offset, inner_for_->loop_var, analyzer_);
     // For ordinary BufferStore, if indices are invariant or independent with
     // loop_var, vectorization would turn scalar lane stores into a broadcast
-    // store. Keep those scalar. (Reducer v2 combine stores never reach the
-    // vectorizer: loops carrying a multiplicity marker are excluded from
-    // vectorization by LowerTileOp.)
+    // store. Keep those scalar. This is also the guard that keeps reducer
+    // combine stores (read-modify-write chains) correct: a store whose index
+    // does not advance with the loop var is a reduction along the vectorized
+    // axis, and vectorizing it would collapse the dependent chain into
+    // last-lane-wins. Output-axis combines, whose target does advance with
+    // the loop var, vectorize like any other store.
     if (is_store && (is_invariant || is_independent)) {
       return {1, /*requires_scalarization=*/true};
     }

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1382,18 +1382,6 @@ private:
       }
     });
 
-    // Reducer combine stores carry an execution-multiplicity marker; loops
-    // containing one are excluded from vectorization until the reduction
-    // axis can be isolated from the vectorized dimension.
-    bool has_reducer = false;
-    PostOrderVisit(for_node->body, [&](const ObjectRef &obj) {
-      if (const auto *attr_stmt = obj.as<AttrStmtNode>()) {
-        if (attr_stmt->attr_key == attr::kParallelMultiplicity) {
-          has_reducer = true;
-        }
-      }
-    });
-
     // Check if vectorizable cast operations exist
     bool has_cast_operations = false;
     PostOrderVisit(for_node->body, [&](const ObjectRef &obj) {
@@ -1407,11 +1395,14 @@ private:
       }
     });
 
-    // Decide whether to vectorize:
-    // - Only if there are non-local buffers or vectorizable casts
-    // - AND no reducers are present
-    bool should_vectorize =
-        (has_non_local || has_cast_operations) && !has_reducer;
+    // Decide whether to vectorize: only if there are non-local buffers or
+    // vectorizable casts. Reducer combine stores (multiplicity markers were
+    // already lowered by PartitionLoop) need no special exclusion: the
+    // vectorizer's planner keeps stores whose indices do not advance with
+    // the vectorized loop var scalar, which is exactly the reduction-axis
+    // hazard; output-axis contiguous combine stores vectorize like any
+    // other read-modify-write.
+    bool should_vectorize = has_non_local || has_cast_operations;
     // Lower the parallel loop using the common function
     Stmt lowered = LowerParallelLoop(
         for_node, loop_layout, CurrentThreadIndex(), analyzer_, layout_map_,

--- a/testing/python/language/test_tilelang_language_reducer_v2.py
+++ b/testing/python/language/test_tilelang_language_reducer_v2.py
@@ -1356,6 +1356,7 @@ def test_update_reduction_axis_stays_scalar():
     torch.testing.assert_close(kern(A), A.sum(dim=1), atol=0, rtol=0)
 
 
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize(("op", "packed_fn"), [("sum", "add2"), ("max", "max2")])
 def test_update_packed_fp16(op, packed_fn):
     """A vectorized fp16 combine takes the packed-math fast path: codegen
@@ -1370,6 +1371,7 @@ def test_update_packed_fp16(op, packed_fn):
     torch.testing.assert_close(kern(A), A, atol=0, rtol=0)
 
 
+@tilelang.testing.requires_cuda
 def test_update_packed_fp32x2_sm100_codegen():
     """On SM100+, a 2-lane fp32 combine takes the f32x2 packed-math path
     (fadd2). Codegen-only: lower for sm_100a and inspect the source."""

--- a/testing/python/language/test_tilelang_language_reducer_v2.py
+++ b/testing/python/language/test_tilelang_language_reducer_v2.py
@@ -18,6 +18,7 @@ import tilelang as tl
 import tilelang.language as T
 import tilelang.testing
 import torch
+import tvm
 
 tilelang.testing.set_random_seed()
 
@@ -1239,6 +1240,143 @@ def test_wide_plan_dst_extra_consumer_not_overridden():
     ref = A @ A2.T
     torch.testing.assert_close(B, ref, atol=1e-2, rtol=1e-2)
     torch.testing.assert_close(C, ref * 2, atol=1e-2, rtol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# Vectorized reducer updates: the combine store is an ordinary RMW to the
+# vectorizer. Output-axis contiguous updates vectorize (and 16-bit/f32x2
+# dtypes take the packed-math fast path in codegen); reduction-axis updates
+# are kept scalar by the planner's invariant-store clamp. A float4/float2
+# LOAD DECLARATION of `acc` discriminates a vectorized RMW from the identity
+# fill and the finalize publish copy, which never declare vector loads of it.
+# ---------------------------------------------------------------------------
+
+_VECTOR_RMW_RE = r"float\d+ v\w* = \*\(float\d+\*\)\(acc"
+
+
+def _contiguous_update_kernel(M, threads, dtype, run, op="sum"):
+    layout = T.Fragment((M,), forward_fn=lambda i: (i // run, i % run))
+
+    @T.prim_func
+    def kernel(A: T.Tensor((M,), dtype), B: T.Tensor((M,), dtype)):
+        with T.Kernel(1, threads=threads):
+            a_buf = T.alloc_shared((M,), dtype)
+            T.copy(A, a_buf)
+            acc = T.alloc_reducer((M,), dtype, op=op)
+            T.reducer_init(acc)
+            for i in T.Parallel(M, loop_layout=layout):
+                T.reducer_update(acc[i], a_buf[i])
+            result = T.alloc_fragment((M,), dtype)
+            T.finalize_reducer(acc, result)
+            T.copy(result, B)
+
+    return kernel
+
+
+def test_update_vectorizes_on_contiguous_layout():
+    """Narrow plan, thread-contiguous output runs: the combine RMW lowers to
+    a vector load / add / store of the accumulator."""
+    M, threads = 512, 128
+    kern = tl.compile(_contiguous_update_kernel(M, threads, T.float32, run=4), out_idx=-1)
+    src = kern.get_kernel_source()
+    assert re.search(_VECTOR_RMW_RE, src), src
+    A = torch.randn(M, dtype=torch.float32, device="cuda")
+    torch.testing.assert_close(kern(A), A, atol=0, rtol=0)
+
+
+def test_update_vectorizes_wide_plan():
+    """The forced FullParticipant baseline vectorizes too: wide combine
+    stores are plain RMWs once the multiplicity marker is lowered, and the
+    former blanket vectorization exclusion is gone."""
+    M, threads = 256, 64
+    kern = tl.compile(
+        _contiguous_update_kernel(M, threads, T.float32, run=4),
+        out_idx=-1,
+        pass_configs={tilelang.PassConfigKey.TL_REDUCER_FORCE_BASELINE: True},
+    )
+    src = kern.get_kernel_source()
+    assert re.search(_VECTOR_RMW_RE, src), src
+    A = torch.randn(M, dtype=torch.float32, device="cuda")
+    torch.testing.assert_close(kern(A), A, atol=0, rtol=0)
+
+
+def test_update_vectorize_attempt_keeps_replica_guard():
+    """A wide epoch whose loop layout replicates (8 iterations on 128
+    threads) carries a replica guard; attempting vectorization on the loop
+    must not change contribution multiplicity. 36, not 576."""
+    extent, threads = 8, 128
+
+    @T.prim_func
+    def kernel(A: T.Tensor((extent,), T.float32), B: T.Tensor((1,), T.float32)):
+        with T.Kernel(1, threads=threads):
+            a_buf = T.alloc_shared((extent,), T.float32)
+            T.copy(A, a_buf)
+            acc = T.alloc_reducer((1,), T.float32, op="sum")
+            T.reducer_init(acc)
+            for i in T.Parallel(extent):
+                T.reducer_update(acc[0], a_buf[i])
+            result = T.alloc_fragment((1,), T.float32)
+            T.finalize_reducer(acc, result)
+            if T.get_thread_binding() == 0:
+                B[0] = result[0]
+
+    kern = tl.compile(
+        kernel,
+        out_idx=-1,
+        pass_configs={tilelang.PassConfigKey.TL_REDUCER_FORCE_BASELINE: True},
+    )
+    A = torch.arange(1, extent + 1, dtype=torch.float32, device="cuda")
+    torch.testing.assert_close(kern(A), A.sum().reshape(1), atol=0, rtol=0)
+
+
+def test_update_reduction_axis_stays_scalar():
+    """When the per-thread serial axis is the reduction axis (the combine
+    store's index does not advance with it), the planner must keep the RMW
+    scalar — vectorizing it would collapse the dependent chain."""
+    M, K, threads = 4, 128, 128
+    layout = T.Fragment((M, K), forward_fn=lambda i, k: (i * 32 + k // 4, k % 4))
+
+    @T.prim_func
+    def kernel(A: T.Tensor((M, K), T.float32), B: T.Tensor((M,), T.float32)):
+        with T.Kernel(1, threads=threads):
+            a_buf = T.alloc_shared((M, K), T.float32)
+            T.copy(A, a_buf)
+            acc = T.alloc_reducer((M,), T.float32, op="sum")
+            T.reducer_init(acc)
+            for i, k in T.Parallel(M, K, loop_layout=layout):
+                T.reducer_update(acc[i], a_buf[i, k])
+            result = T.alloc_fragment((M,), T.float32)
+            T.finalize_reducer(acc, result)
+            T.copy(result, B)
+
+    kern = tl.compile(kernel, out_idx=-1)
+    src = kern.get_kernel_source()
+    assert re.search(_VECTOR_RMW_RE, src) is None, src
+    A = torch.arange(M * K, dtype=torch.float32, device="cuda").reshape(M, K)
+    torch.testing.assert_close(kern(A), A.sum(dim=1), atol=0, rtol=0)
+
+
+@pytest.mark.parametrize(("op", "packed_fn"), [("sum", "add2"), ("max", "max2")])
+def test_update_packed_fp16(op, packed_fn):
+    """A vectorized fp16 combine takes the packed-math fast path: codegen
+    emits tl::add2/max2 (__hadd2/__hmax2) pairs instead of per-lane scalar
+    half ops. The vectorization itself is op-agnostic; the packed fast path
+    covers add/sub/mul/fma/min/max."""
+    M, threads = 512, 128
+    kern = tl.compile(_contiguous_update_kernel(M, threads, T.float16, run=4, op=op), out_idx=-1)
+    src = kern.get_kernel_source()
+    assert packed_fn in src, src
+    A = torch.randn(M, dtype=torch.float16, device="cuda")
+    torch.testing.assert_close(kern(A), A, atol=0, rtol=0)
+
+
+def test_update_packed_fp32x2_sm100_codegen():
+    """On SM100+, a 2-lane fp32 combine takes the f32x2 packed-math path
+    (fadd2). Codegen-only: lower for sm_100a and inspect the source."""
+    target = {"kind": "cuda", "arch": "sm_100a"}
+    with tvm.transform.PassContext(), tvm.target.Target(target):
+        artifact = tilelang.lower(_contiguous_update_kernel(256, 128, T.float32, run=2), target=target)
+    assert "add2" in artifact.kernel_source, artifact.kernel_source
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Enable reducer combine loops to use loop vectorization after execution-multiplicity markers have been lowered.
- Preserve reduction-axis correctness while allowing contiguous output-axis updates to use vector and packed-math code generation.

## Changes

- Remove the blanket reducer exclusion from `LowerTileOp` vectorization decisions.
- Keep read-modify-write stores scalar when their target index is invariant or independent of the vectorized loop variable, preserving dependent reduction chains.
- Add runtime and source-inspection coverage for narrow and wide reducer plans, replica guards, scalar reduction axes, packed FP16 add/max operations, and SM100 FP32x2 code generation.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/language/test_tilelang_language_reducer_v2.py -x -k 'test_update_'` (7 passed)
- `python -m pytest testing/python/language/test_tilelang_language_reducer_v2.py -x` (59 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Enables vectorization for contiguous reducer combine-loop updates after execution-multiplicity markers are lowered.
- Keeps read-modify-write reducer stores scalar when their target index is invariant or independent of the vectorized loop variable.
- Adds coverage for narrow and wide plans, replica guards, scalar reduction axes, packed FP16 operations, and SM100 FP32x2 code generation.
- Validation passed with formatting, compilation, seven targeted tests, and 59 reducer-language tests.

## C++ style / lint notes

- The PR changes C++ implementation files but does not modify `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) applies when configured in CI.
- No correctness or build issues are reported. Any TLCPP003/TLCPP004 findings remain advisory unless they identify a new API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->