### PR TITLE
[BugFix] Don't drop syncs from the other if branch

### DIFF
--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -991,22 +991,26 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       ConditionThreadPropertyChecker checker(&analyzer, env_threads_,
                                              let_var_properties_, warp_size_);
       IterVar tx = GetThreadVar("threadIdx.x");
-      auto condition_prop = checker.AnalyzeCondition(op->condition, tx);
+      auto must_hoist = [&](const PrimExpr &branch_condition) {
+        auto condition_prop = checker.AnalyzeCondition(branch_condition, tx);
 
-      // The estimate calls anything mentioning a thread variable divergent; ask
-      // the prover before hoisting. Only added to it, never subtracted, and
-      // only asked when something below could act on the answer.
-      bool may_hoist =
-          condition_prop.depends_on_runtime || condition_prop.requires_hoist;
-      bool proven_uniform = may_hoist && IsBlockUniformCondition(op->condition);
-      bool is_block_uniform = condition_prop.is_block_uniform || proven_uniform;
-      // requires_hoist means the participation count was not established, so
-      // ThreadPartialSyncRewriter cannot emit `bar.sync id, count`. Uniformity
-      // answers that: the barrier is reached by the whole block or by nobody,
-      // and a plain __syncthreads() is right. Only a proof counts, not the
-      // heuristic.
-      if ((condition_prop.depends_on_runtime && !is_block_uniform) ||
-          (condition_prop.requires_hoist && !proven_uniform)) {
+        // 估计器会把引用线程变量的条件视为发散；提升前必须再用证明器确认。
+        bool may_hoist =
+            condition_prop.depends_on_runtime || condition_prop.requires_hoist;
+        bool proven_uniform =
+            may_hoist && IsBlockUniformCondition(branch_condition);
+        bool is_block_uniform =
+            condition_prop.is_block_uniform || proven_uniform;
+        // 无法确定参与线程数时，partial barrier 不能安全生成；只有严格证明
+        // 整个线程块条件一致，才能保留普通的 __syncthreads()。
+        return (condition_prop.depends_on_runtime && !is_block_uniform) ||
+               (condition_prop.requires_hoist && !proven_uniform);
+      };
+
+      bool hoist_then = !syncs_in_then.empty() && must_hoist(op->condition);
+      bool hoist_else =
+          !syncs_in_else.empty() && must_hoist(tirx::Not(op->condition));
+      if (hoist_then || hoist_else) {
         LOG(WARNING)
             << "[ThreadSync] Hoisting sync out of an if whose condition is not "
                "safe for an in-if sync. This is not a fix: both ends of the "
@@ -1016,14 +1020,18 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
                "the "
                "barrier in place instead. Condition: "
             << op->condition;
-        for (const auto &sync : syncs_in_then) {
-          syncs_inserted_.erase(sync);
+        if (hoist_then) {
+          for (const auto &sync : syncs_in_then) {
+            syncs_inserted_.erase(sync);
+          }
         }
-        for (const auto &sync : syncs_in_else) {
-          syncs_inserted_.erase(sync);
+        if (hoist_else) {
+          for (const auto &sync : syncs_in_else) {
+            syncs_inserted_.erase(sync);
+          }
         }
 
-        // Insert sync before the if-statement itself
+        // 为无法安全执行分支内同步的路径，在 if 语句前插入全块同步。
         insert_syncs(op);
       }
     }

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -994,15 +994,17 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       auto must_hoist = [&](const PrimExpr &branch_condition) {
         auto condition_prop = checker.AnalyzeCondition(branch_condition, tx);
 
-        // 估计器会把引用线程变量的条件视为发散；提升前必须再用证明器确认。
+        // The estimate treats any condition using a thread variable as
+        // divergent, so ask the prover before hoisting.
         bool may_hoist =
             condition_prop.depends_on_runtime || condition_prop.requires_hoist;
         bool proven_uniform =
             may_hoist && IsBlockUniformCondition(branch_condition);
         bool is_block_uniform =
             condition_prop.is_block_uniform || proven_uniform;
-        // 无法确定参与线程数时，partial barrier 不能安全生成；只有严格证明
-        // 整个线程块条件一致，才能保留普通的 __syncthreads()。
+        // A partial barrier is unsafe when the participating thread count is
+        // unknown. Keep a plain __syncthreads() only for proven block-uniform
+        // conditions.
         return (condition_prop.depends_on_runtime && !is_block_uniform) ||
                (condition_prop.requires_hoist && !proven_uniform);
       };
@@ -1031,7 +1033,8 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
           }
         }
 
-        // 为无法安全执行分支内同步的路径，在 if 语句前插入全块同步。
+        // Insert a block-wide sync before the if for branches that cannot
+        // safely synchronize in place.
         insert_syncs(op);
       }
     }

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -978,7 +978,7 @@ def test_unorderable_hazard_in_divergent_else_branch_is_reported(capfd):
 
 
 def test_safe_else_sync_survives_unsafe_then_condition(capfd):
-    """then 条件不可安全同步时，不应删除 else 中可生成的 partial barrier。"""
+    """An unsafe then condition must not remove a valid else partial barrier."""
     import re
 
     @T.prim_func(private=True)

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -977,6 +977,31 @@ def test_unorderable_hazard_in_divergent_else_branch_is_reported(capfd):
     assert "no longer separates" in warnings, f"Expected the pass to report the hazard:\n{warnings}"
 
 
+def test_safe_else_sync_survives_unsafe_then_condition(capfd):
+    """then 条件不可安全同步时，不应删除 else 中可生成的 partial barrier。"""
+    import re
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        if tx == 0 or tx >= 33:
+            l[0] = T.float32(0)
+        else:
+            s[tx] = T.cast(tx, "float32")
+            l[0] = s[33 - tx]
+
+    s = run_passes_script(func)
+    warnings = capfd.readouterr().err
+    assert re.search(r'tvm_storage_sync\("shared",\s*\d+,\s*32\)', s), f"Expected a 32-thread barrier:\n{s}"
+    assert s.index('T.tvm_storage_sync("shared"') > s.index("else:"), f"Barrier must stay in else branch:\n{s}"
+    assert "no longer separates" not in warnings, f"Safe else branch should not be hoisted:\n{warnings}"
+
+
 def test_sync_stays_inside_guard_proven_uniform_by_premise(capfd):
     """A premise can make a threadIdx-dependent guard provably block uniform.
 


### PR DESCRIPTION
Fixes #3042.

## What went wrong

`ThreadSync` was checking only the `then` condition when it decided if a barrier had to be moved out of an `if`. If that check said yes, it removed barriers from **both** the `then` and `else` branches.

That is not always right becuase the two branches can have different sets of participating threads. A barrier may be unsafe in `then`, but still be a perfectly valid partial barrier in `else`.

## Small repro

The test uses 128 threads and this branch:

```python
if tx == 0 or tx >= 33:
    l[0] = 0.0
else:
    s[tx] = T.cast(tx, "float32")
    l[0] = s[33 - tx]
```

Only threads `1..32` enter the `else`. They all write shared memory first, then read the value written by another thread (`1 <-> 32`, `2 <-> 31`, etc), so we need a 32-thread partial barrier between those two ops.

Before this fix the pass looked at the `then` condition, decided to hoist, and generated something like:

```python
T.tvm_storage_sync("shared")
if tx == 0 or tx >= 33:
    ...
else:
    s[tx] = ...
    l[0] = s[33 - tx]
```

The barrier is now before both accesses, so it doesnt order anything inside `else`. One warp can read before the other warp writes and get an old/uninitialized value.

## Fix

Check the branches seperately:

- use `op->condition` for `then`
- use `Not(op->condition)` for `else`
- only remove syncs from the branch that actually needs hoisting

After the fix the reprodcuer keeps this in the `else` branch:

```python
s[tx] = ...
T.tvm_storage_sync("shared", barrier_id, 32)
l[0] = s[33 - tx]
```

## When it triggers

It needs this combo:

1. `ThreadSync` finds a cross-thread shared-memory dependency inside one arm of an `IfThenElse`.
2. The two arms have different partial-barrier participation patterns.
3. The old decision based on the `then` condition gets applied to syncs from both arms.

## Tested

- rebuilt with cmake
- full `test_tilelang_transform_thread_sync.py`: `21 passed, 21 skipped` on my Mac
- pre-commit passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed `ThreadSync` barrier hoisting for divergent `IfThenElse` branches.
- Analyzed each branch independently.
- Preserved required partial barriers in the `else` branch.
- Added a regression test for shared-memory synchronization.

## Validation

- Rebuild passed.
- Thread-sync tests: 21 passed, 21 skipped.
- Pre-commit checks passed.

## C++ style / lint notes

- The C++ change follows the conventions documented in `docs/developer_guide/cpp_style.md`.
- The `C++ API Style Audit (warning only)` CI step applies.
- The PR changes no public or exported API declarations.
- Any audit findings are advisory and do not indicate correctness or build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->