### PR TITLE
[BugFix] Don't drop syncs from the other if branch

### DIFF
--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -1064,8 +1064,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       ConditionThreadPropertyChecker checker(&analyzer, env_threads_,
                                              let_var_properties_);
       auto validate_sync_condition = [&](const PrimExpr &branch_condition,
-                                         const char *branch_name,
-                                         const Stmt &branch_body) {
+                                         const char *branch_name) {
         auto condition_prop = checker.AnalyzeExpr(branch_condition);
         bool proven_block_uniform = !condition_prop.is_block_uniform &&
                                     IsBlockUniformCondition(branch_condition);
@@ -1090,16 +1089,14 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
                "barrier lowering. Hoisting the barrier before the if would "
                "not order the conflicting accesses inside the branch. "
                "Condition: "
-            << branch_condition << "\nBranch IR:\n"
-            << branch_body;
+            << branch_condition;
       };
 
       if (has_sync_in_then) {
-        validate_sync_condition(op->condition, "then", op->then_case);
+        validate_sync_condition(op->condition, "then");
       }
       if (has_sync_in_else) {
-        validate_sync_condition(tirx::Not(op->condition), "else",
-                                op->else_case.value());
+        validate_sync_condition(tirx::Not(op->condition), "else");
       }
     }
 
@@ -2187,6 +2184,35 @@ private:
         ICHECK(prev_indice_bytes.dtype() == curr_indice_bytes.dtype());
         provably_disjoint =
             analyzer.CanProve(tirx::NE(prev_indice_bytes, curr_indice_bytes));
+        // 对短小展开循环逐次代入迭代值，避免 div/mod 组合让符号证明返回
+        // unknown。
+        if (!provably_disjoint && loop != nullptr &&
+            loop->kind == ForKind::kUnrolled) {
+          const auto *loop_min = loop->min.as<IntImmNode>();
+          const auto *loop_extent = loop->extent.as<IntImmNode>();
+          constexpr int64_t kMaxEnumeratedUnrollExtent = 64;
+          if (loop_min != nullptr && loop_extent != nullptr &&
+              loop_extent->value > 1 &&
+              loop_extent->value <= kMaxEnumeratedUnrollExtent) {
+            provably_disjoint = true;
+            for (int64_t offset = 0; offset < loop_extent->value - 1;
+                 ++offset) {
+              Map<Var, PrimExpr> iteration_sub;
+              iteration_sub.Set(
+                  loop->loop_var,
+                  make_const(loop->loop_var.dtype(), loop_min->value + offset));
+              PrimExpr prev_at_iteration =
+                  Substitute(prev_indice_bytes, iteration_sub);
+              PrimExpr curr_at_iteration =
+                  Substitute(curr_indice_bytes, iteration_sub);
+              if (!analyzer.CanProve(
+                      tirx::NE(prev_at_iteration, curr_at_iteration))) {
+                provably_disjoint = false;
+                break;
+              }
+            }
+          }
+        }
       } else {
         try {
           auto prev_min = analyzer.Simplify(

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -437,10 +437,12 @@ private:
 struct ConditionThreadProperty {
   bool depends_on_runtime{false};
   bool is_block_uniform{true};
+  bool requires_hoist{false};
 
   void Merge(const ConditionThreadProperty &other) {
     depends_on_runtime = depends_on_runtime || other.depends_on_runtime;
     is_block_uniform = is_block_uniform && other.is_block_uniform;
+    requires_hoist = requires_hoist || other.requires_hoist;
   }
 };
 
@@ -448,7 +450,7 @@ struct ConditionThreadProperty {
  * \brief Analyze whether an if-condition is runtime-dependent and/or uniform
  * across all threads in a block.
  *
- * For branch-local sync validation we care about two independent properties:
+ * For sync hoisting decisions we care about two independent properties:
  *
  * 1. Does the condition depend on runtime values such as memory loads?
  * 2. Even if it does, is it still block-uniform, i.e. identical for every
@@ -458,25 +460,48 @@ struct ConditionThreadProperty {
  * - `token_ids[tx] != -1` is runtime-dependent and non-uniform.
  * - `batch_sizes[bx] > 0` is runtime-dependent but block-uniform.
  *
- * Runtime-dependent, non-uniform conditions cannot use the current static-count
- * partial barrier. Thread-only conditions additionally need a warp-uniformity
- * proof before ThreadPartialSyncRewriter can lower them safely.
+ * Runtime-dependent, non-uniform conditions use the existing conservative
+ * hoisting path. Thread-only conditions that otherwise remain in place need a
+ * warp-uniformity proof before ThreadPartialSyncRewriter can lower them safely.
  */
 class ConditionThreadPropertyChecker : public IRMutatorWithAnalyzer {
 public:
   explicit ConditionThreadPropertyChecker(
       arith::Analyzer *analyzer, const Array<IterVar> &env_threads,
       const std::unordered_map<const VarNode *, ConditionThreadProperty>
-          &let_var_properties)
+          &let_var_properties,
+      int warp_size = 32)
       : IRMutatorWithAnalyzer(analyzer), env_threads_(env_threads),
-        let_var_properties_(let_var_properties) {}
+        let_var_properties_(let_var_properties), warp_size_(warp_size) {}
 
   /*!
-   * \brief Analyze condition properties relevant to branch-local syncs.
+   * \brief Analyze condition properties relevant to thread-sync hoisting.
    */
   ConditionThreadProperty AnalyzeExpr(const PrimExpr &expr) {
     current_ = ConditionThreadProperty();
     this->VisitExpr(expr);
+    return current_;
+  }
+
+  ConditionThreadProperty AnalyzeCondition(const PrimExpr &expr,
+                                           const IterVar &iv) {
+    current_ = ConditionThreadProperty();
+    this->VisitExpr(expr);
+    auto extent_opt = as_const_int(iv->dom->extent);
+    ICHECK(extent_opt != nullptr)
+        << "AnalyzeCondition: thread extent must be a "
+           "constant, but got: "
+        << iv->dom->extent;
+    int64_t thread_extent = *extent_opt;
+    {
+      With<arith::ConstraintContext> ctx(analyzer_, expr);
+      auto count = analyzer_->z3_prover.CountSatisfyingValues(
+          iv->var, thread_extent, /*min_consecutive=*/warp_size_);
+      if (count < 0) {
+        // ThreadPartialSyncRewriter cannot safely lower this condition.
+        current_.requires_hoist = true;
+      }
+    }
     return current_;
   }
 
@@ -572,6 +597,7 @@ private:
   const Array<IterVar> &env_threads_;
   const std::unordered_map<const VarNode *, ConditionThreadProperty>
       &let_var_properties_;
+  int warp_size_;
 };
 
 struct TileLangThreadSyncPlanner : public ConstrVisitor {
@@ -586,7 +612,6 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     kRead,
     kWrite,
     kSync,
-    kSyncWarp,
     kAlloc,
     // acquired version of read, only need to handle WAR dep.
     kReadAcquire
@@ -613,8 +638,6 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     AccessType type;
     /*! \brief The storage scope */
     StorageScope scope;
-    /*! \brief warp 级同步显式使用的掩码。 */
-    Optional<PrimExpr> warp_sync_mask;
     /*! \brief Whether the access is pointer access */
     bool is_pointer_access = false;
     /*! \brief Whether this access originates from an async copy context
@@ -699,6 +722,15 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     }
     shared_memory_alias_byte_offsets_[alias_var.get()] = byte_offset;
   }
+  IterVar GetThreadVar(const std::string &tag) const {
+    for (const auto &iv : env_threads_) {
+      if (iv->thread_tag == tag) {
+        return iv;
+      }
+    }
+    LOG(FATAL) << "Thread variable " << tag << " not found";
+    return IterVar();
+  }
   /*!
    * \brief Try to prove that every thread reaches the same verdict on
    *        \p condition, using the live constraint set as premises.
@@ -770,37 +802,6 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     PrimExpr agree = tirx::Or(tirx::And(lhs, rhs),
                               tirx::And(tirx::Not(lhs), tirx::Not(rhs)));
     return analyzer.CanProve(tirx::Or(tirx::Not(same_warp), agree));
-  }
-
-  /*! \brief Return whether \p condition describes one axis-aligned region. */
-  bool IsAxisAlignedThreadRegion(const PrimExpr &condition) {
-    ConstrSet cset = GetConstrSet();
-    arith::Analyzer bound_analyzer;
-    cset.Populate(bound_analyzer);
-
-    PrimExpr region = Bool(true);
-    {
-      With<arith::ConstraintContext> ctx(&bound_analyzer, condition);
-      for (const auto &iv : env_threads_) {
-        if (runtime::ThreadScope::Create(iv->thread_tag).rank != 1)
-          continue;
-        if (!bound_analyzer.const_int_bound.IsBound(iv->var)) {
-          return false;
-        }
-        auto bound = bound_analyzer.const_int_bound(iv->var);
-        PrimExpr min_value = make_const(iv->var.dtype(), bound->min_value);
-        PrimExpr max_value = make_const(iv->var.dtype(), bound->max_value);
-        region = tirx::And(region, iv->var >= min_value);
-        region = tirx::And(region, iv->var <= max_value);
-      }
-    }
-
-    arith::Analyzer analyzer;
-    cset.Populate(analyzer);
-    PrimExpr equivalent =
-        tirx::Or(tirx::And(condition, region),
-                 tirx::And(tirx::Not(condition), tirx::Not(region)));
-    return analyzer.CanProve(equivalent);
   }
 
   void VisitExpr_(const BufferLoadNode *op) final {
@@ -887,7 +888,6 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     // Record let var properties
     auto let_prop = AnalyzeExprProperty(op->value);
     let_var_properties_[op->var.get()] = let_prop;
-    let_var_values_[op->var.get()] = op->value;
   }
   void VisitStmt_(const SBlockNode *op) final {
     auto block = Downcast<SBlock>(op);
@@ -961,19 +961,16 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
    * buffer reads, writes, and synchronization events under the condition's
    * constraints.
    *
-   * IMPORTANT: A sync inside a thread-divergent branch is valid only when every
-   * hardware warp agrees on branch participation. Hoisting is not a repair when
-   * both conflicting accesses remain inside the branch, so unsupported
-   * participation patterns must be rejected.
+   * IMPORTANT: Before preserving a partial barrier in a thread-divergent
+   * branch, prove that every hardware warp agrees on branch participation.
+   * Conditions already handled by the legacy conservative hoisting path keep
+   * that behavior for compatibility.
    */
   void VisitStmt_(const IfThenElseNode *op) final {
     StmtEntry s;
     // Track syncs inserted before visiting the if body
     std::unordered_set<const Object *> syncs_before_then;
     std::unordered_set<const Object *> syncs_before_else;
-    std::unordered_set<const Object *> explicit_syncs_before_then =
-        explicit_syncs_seen_;
-    std::unordered_set<const Object *> explicit_syncs_before_else;
     for (const auto &sync : syncs_inserted_) {
       syncs_before_then.insert(sync);
     }
@@ -1010,7 +1007,6 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     for (const auto &sync : syncs_inserted_) {
       syncs_before_else.insert(sync);
     }
-    explicit_syncs_before_else = explicit_syncs_seen_;
 
     if (op->else_case) {
       auto guard = MakeGuard(tirx::Not(op->condition));
@@ -1038,19 +1034,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       }
     }
 
-    auto has_new_sync = [](const std::unordered_set<const Object *> &after,
-                           const std::unordered_set<const Object *> &before) {
-      return std::any_of(after.begin(), after.end(), [&](const Object *sync) {
-        return before.count(sync) == 0;
-      });
-    };
-    bool has_sync_in_then =
-        !syncs_in_then.empty() ||
-        has_new_sync(explicit_syncs_before_else, explicit_syncs_before_then);
-    bool has_sync_in_else =
-        !syncs_in_else.empty() ||
-        has_new_sync(explicit_syncs_seen_, explicit_syncs_before_else);
-    bool has_syncs_inside = has_sync_in_then || has_sync_in_else;
+    bool has_syncs_inside = !syncs_in_then.empty() || !syncs_in_else.empty();
 
     if (has_syncs_inside) {
       // Runtime-dependent conditions are only problematic when they can differ
@@ -1058,45 +1042,64 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       // such as `batch_sizes[blockIdx.z] > 0` are safe to keep in-place.
       //
       // Separately, some threadIdx-only non-uniform conditions still need
+      // hoisting when ThreadPartialSyncRewriter cannot lower them safely.
       arith::Analyzer analyzer;
       ConstrSet constr_set = GetConstrSet();
       constr_set.Populate(analyzer);
       ConditionThreadPropertyChecker checker(&analyzer, env_threads_,
-                                             let_var_properties_);
-      auto validate_sync_condition = [&](const PrimExpr &branch_condition,
-                                         const char *branch_name) {
-        auto condition_prop = checker.AnalyzeExpr(branch_condition);
-        bool proven_block_uniform = !condition_prop.is_block_uniform &&
-                                    IsBlockUniformCondition(branch_condition);
-        if (condition_prop.is_block_uniform || proven_block_uniform) {
-          return;
-        }
+                                             let_var_properties_, warp_size_);
+      IterVar tx = GetThreadVar("threadIdx.x");
+      auto must_hoist = [&](const PrimExpr &branch_condition,
+                            const char *branch_name) {
+        auto condition_prop = checker.AnalyzeCondition(branch_condition, tx);
+        bool may_hoist =
+            condition_prop.depends_on_runtime || condition_prop.requires_hoist;
+        bool proven_uniform =
+            may_hoist && IsBlockUniformCondition(branch_condition);
+        bool is_block_uniform =
+            condition_prop.is_block_uniform || proven_uniform;
+        bool should_hoist =
+            (condition_prop.depends_on_runtime && !is_block_uniform) ||
+            (condition_prop.requires_hoist && !proven_uniform);
 
-        bool is_static_warp_uniform =
-            !condition_prop.depends_on_runtime &&
-            IsAxisAlignedThreadRegion(branch_condition) &&
-            IsWarpUniformCondition(branch_condition);
-        if (is_static_warp_uniform) {
-          return;
+        if (!should_hoist && !is_block_uniform &&
+            !IsWarpUniformCondition(branch_condition)) {
+          LOG(FATAL)
+              << "[ThreadSync] Cannot lower a required shared-memory sync "
+                 "inside the "
+              << branch_name
+              << " branch: its participating threads are not warp-uniform. "
+                 "A partial barrier requires every non-exited thread in each "
+                 "participating warp to reach the barrier. Condition: "
+              << branch_condition;
         }
-
-        LOG(FATAL)
-            << "[ThreadSync] Cannot lower a required shared-memory sync "
-               "inside the "
-            << branch_name
-            << " branch: its participating threads are not a compile-time "
-               "warp-uniform set representable by the current partial "
-               "barrier lowering. Hoisting the barrier before the if would "
-               "not order the conflicting accesses inside the branch. "
-               "Condition: "
-            << branch_condition;
+        return should_hoist;
       };
 
-      if (has_sync_in_then) {
-        validate_sync_condition(op->condition, "then");
-      }
-      if (has_sync_in_else) {
-        validate_sync_condition(tirx::Not(op->condition), "else");
+      bool hoist_then =
+          !syncs_in_then.empty() && must_hoist(op->condition, "then");
+      bool hoist_else = !syncs_in_else.empty() &&
+                        must_hoist(tirx::Not(op->condition), "else");
+      if (hoist_then || hoist_else) {
+        LOG(WARNING)
+            << "[ThreadSync] Hoisting sync out of an if whose condition is not "
+               "safe for an in-if sync. This is not a fix: both ends of the "
+               "conflict are inside the branch, so the hoisted barrier no "
+               "longer separates them and the race remains. Constraining the "
+               "condition -- a T.assume on the parameters it reads -- keeps "
+               "the barrier in place instead. Condition: "
+            << op->condition;
+        if (hoist_then) {
+          for (const auto &sync : syncs_in_then) {
+            syncs_inserted_.erase(sync);
+          }
+        }
+        if (hoist_else) {
+          for (const auto &sync : syncs_in_else) {
+            syncs_inserted_.erase(sync);
+          }
+        }
+        insert_syncs(op);
       }
     }
 
@@ -1324,9 +1327,6 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
         e.type = kSync;
         e.scope = StorageScope::Create(s);
         curr_stmt_.access.emplace_back(std::move(e));
-        if (op->args.size() == 1 && scope.rank == StorageRank::kShared) {
-          explicit_syncs_seen_.insert(curr_stmt_.stmt);
-        }
       }
     } else if (op->op.same_as(tl::sync_grid())) {
       // grid.sync() synchronizes every thread of every block and is a full
@@ -1337,16 +1337,6 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       e.threads = env_threads();
       e.type = kSync;
       e.scope = sync_scope_;
-      curr_stmt_.access.emplace_back(std::move(e));
-    } else if (op->op.same_as(tl::sync_warp())) {
-      ICHECK(allow_append_);
-      AccessEntry e{.cset = {constr_stack_}};
-      e.threads = env_threads();
-      e.type = kSyncWarp;
-      e.scope = sync_scope_;
-      if (!op->args.empty()) {
-        e.warp_sync_mask = op->args[0];
-      }
       curr_stmt_.access.emplace_back(std::move(e));
     } else {
       ConstrVisitor::VisitExpr_(op);
@@ -1375,38 +1365,9 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       }
     }
 
-    struct PendingAccess {
-      AccessEntry access;
-      std::vector<AccessEntry> warp_syncs_after;
-    };
-    std::vector<PendingAccess> reads;
-    std::vector<PendingAccess> writes;
-    auto has_conflict = [&](const std::vector<PendingAccess> &pending,
-                            const AccessEntry &curr, const ForNode *loop) {
-      for (const PendingAccess &item : pending) {
-        if (!FindConflict(item.access, curr, loop)) {
-          continue;
-        }
-        if (loop == nullptr && std::any_of(item.warp_syncs_after.begin(),
-                                           item.warp_syncs_after.end(),
-                                           [&](const AccessEntry &sync) {
-                                             return WarpSyncOrders(item.access,
-                                                                   curr, sync);
-                                           })) {
-          continue;
-        }
-        return true;
-      }
-      return false;
-    };
-    auto record_warp_sync = [&](const AccessEntry &sync) {
-      for (PendingAccess &item : reads) {
-        item.warp_syncs_after.push_back(sync);
-      }
-      for (PendingAccess &item : writes) {
-        item.warp_syncs_after.push_back(sync);
-      }
-    };
+    // Unsynced reads and writes
+    std::vector<AccessEntry> reads;
+    std::vector<AccessEntry> writes;
     // if it is a loop, rotate two times to consider effect of loop.
     // simulation based approach to find dependencies
     for (size_t i = 0; i < seq.size(); ++i) {
@@ -1423,14 +1384,14 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       for (const AccessEntry &acc : s.access) {
         if (acc.type == kRead) {
           // Same-iteration conflict: loop=nullptr
-          if (has_conflict(writes, acc, nullptr)) {
+          if (FindConflict(writes, acc, nullptr)) {
             sync_before_stmt = true;
             break;
           }
         } else if (acc.type == kWrite) {
           // Same-iteration conflict: loop=nullptr
-          if (has_conflict(reads, acc, nullptr) ||
-              has_conflict(writes, acc, nullptr)) {
+          if (FindConflict(reads, acc, nullptr) ||
+              FindConflict(writes, acc, nullptr)) {
             sync_before_stmt = true;
             break;
           }
@@ -1447,14 +1408,12 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       // Add the read/write of current statement
       for (const AccessEntry &acc : s.access) {
         if (acc.type == kRead) {
-          reads.push_back({acc, {}});
+          reads.push_back(acc);
         } else if (acc.type == kWrite) {
-          writes.push_back({acc, {}});
+          writes.push_back(acc);
         } else if (acc.type == kSync) {
           reads.clear();
           writes.clear();
-        } else if (acc.type == kSyncWarp) {
-          record_warp_sync(acc);
         }
       }
 
@@ -1505,22 +1464,20 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
         for (const AccessEntry &acc : s.access) {
           if (acc.type == kRead) {
             // Loop-carry conflict: pass loop for iteration shift analysis
-            if (has_conflict(writes, acc, loop)) {
+            if (FindConflict(writes, acc, loop)) {
               need_loop_sync = true;
               break;
             }
           } else if (acc.type == kWrite) {
             // Loop-carry conflict: pass loop for iteration shift analysis
-            if (has_conflict(reads, acc, loop) ||
-                has_conflict(writes, acc, loop)) {
+            if (FindConflict(reads, acc, loop) ||
+                FindConflict(writes, acc, loop)) {
               need_loop_sync = true;
               break;
             }
           } else if (acc.type == kSync) {
             reads.clear();
             writes.clear();
-          } else if (acc.type == kSyncWarp) {
-            record_warp_sync(acc);
           }
         }
         if (need_loop_sync) {
@@ -1586,139 +1543,8 @@ private:
     ConstrSet constr_set = GetConstrSet();
     constr_set.Populate(analyzer);
     ConditionThreadPropertyChecker checker(&analyzer, env_threads_,
-                                           let_var_properties_);
+                                           let_var_properties_, warp_size_);
     return checker.AnalyzeExpr(expr);
-  }
-
-  PrimExpr ResolveLetValue(PrimExpr expr) const {
-    std::unordered_set<const VarNode *> visited;
-    while (true) {
-      if (const auto *cast = expr.as<CastNode>()) {
-        expr = cast->value;
-        continue;
-      }
-      const auto *var = expr.as<VarNode>();
-      if (var == nullptr || !visited.insert(var).second) {
-        return expr;
-      }
-      auto it = let_var_values_.find(var);
-      if (it == let_var_values_.end()) {
-        return expr;
-      }
-      expr = it->second;
-    }
-  }
-
-  bool IsBallotDerivedWarpSync(const AccessEntry &sync) const {
-    if (!sync.warp_sync_mask.defined()) {
-      return false;
-    }
-    PrimExpr mask = ResolveLetValue(sync.warp_sync_mask.value());
-    const auto *call = mask.as<CallNode>();
-    return call != nullptr && call->op.same_as(tl::ballot_sync());
-  }
-
-  bool HaveEquivalentConstraints(const AccessEntry &lhs,
-                                 const AccessEntry &rhs) const {
-    auto participation_condition = [](const ConstrSet &cset) {
-      PrimExpr condition = Bool(true);
-      for (const Constr &constr : cset.constrs_) {
-        if (constr.kind != Constr::kBindValue) {
-          condition = tirx::And(condition, constr.ToGenericConstr());
-        }
-      }
-      return condition;
-    };
-    PrimExpr lhs_condition = participation_condition(lhs.cset);
-    PrimExpr rhs_condition = participation_condition(rhs.cset);
-    if (ExprDeepEqual()(lhs_condition, rhs_condition)) {
-      return true;
-    }
-
-    arith::Analyzer analyzer;
-    std::unordered_set<const VarNode *> bound;
-    for (const Array<IterVar> *threads : {&lhs.threads, &rhs.threads}) {
-      for (const IterVar &iv : *threads) {
-        if (iv->dom.defined() && bound.insert(iv->var.get()).second) {
-          analyzer.Bind(iv->var, iv->dom);
-        }
-      }
-    }
-    PrimExpr equivalent =
-        tirx::Or(tirx::And(lhs_condition, rhs_condition),
-                 tirx::And(tirx::Not(lhs_condition), tirx::Not(rhs_condition)));
-    return analyzer.z3_prover.CanProve(equivalent);
-  }
-
-  bool ConflictsOnlyWithinWarp(const AccessEntry &prev,
-                               const AccessEntry &curr) const {
-    if (prev.is_pointer_access || curr.is_pointer_access ||
-        prev.buffer_indices.size() != 1 || curr.buffer_indices.size() != 1) {
-      return false;
-    }
-
-    Map<Var, PrimExpr> prev_sub, curr_sub;
-    for (const IterVar &prev_iv : prev.threads) {
-      if (runtime::ThreadScope::Create(prev_iv->thread_tag).rank != 1) {
-        continue;
-      }
-      IterVar curr_iv;
-      for (const IterVar &candidate : curr.threads) {
-        if (candidate->thread_tag == prev_iv->thread_tag) {
-          curr_iv = candidate;
-          break;
-        }
-      }
-      if (!curr_iv.defined()) {
-        return false;
-      }
-      std::string suffix = prev_iv->thread_tag;
-      prev_sub.Set(prev_iv->var, Var(suffix + "<W1>", prev_iv->var.dtype()));
-      curr_sub.Set(curr_iv->var, Var(suffix + "<W2>", curr_iv->var.dtype()));
-    }
-    if (prev_sub.empty() || curr_sub.empty()) {
-      return false;
-    }
-
-    ConstrSet prev_cset{prev.cset};
-    ConstrSet curr_cset{curr.cset};
-    prev_cset = prev_cset.RenameFrom("<W1>", prev_sub, std::nullopt,
-                                     /*rename_ranges=*/false);
-    curr_cset = curr_cset.RenameFrom("<W2>", curr_sub, std::nullopt,
-                                     /*rename_ranges=*/false);
-    arith::Analyzer analyzer;
-    prev_cset.ToConstraints()
-        .Merge(curr_cset.ToConstraints())
-        .Populate(analyzer);
-
-    DataType index_dtype = DataType::Int(64);
-    PrimExpr prev_index = Substitute(prev.buffer_indices[0], prev_sub);
-    PrimExpr curr_index = Substitute(curr.buffer_indices[0], curr_sub);
-    if (!prev_index.dtype().is_scalar() || !curr_index.dtype().is_scalar()) {
-      return false;
-    }
-    PrimExpr prev_address = Cast(index_dtype, prev_index) *
-                            make_const(index_dtype, prev.dtype.bytes());
-    PrimExpr curr_address = Cast(index_dtype, curr_index) *
-                            make_const(index_dtype, curr.dtype.bytes());
-
-    PrimExpr prev_linear =
-        Substitute(MakeLinearThreadId(prev.threads), prev_sub);
-    PrimExpr curr_linear =
-        Substitute(MakeLinearThreadId(curr.threads), curr_sub);
-    PrimExpr warp_size = make_const(index_dtype, warp_size_);
-    PrimExpr same_warp =
-        FloorDiv(prev_linear, warp_size) == FloorDiv(curr_linear, warp_size);
-    return analyzer.CanProve(
-        tirx::Or(same_warp, tirx::NE(prev_address, curr_address)));
-  }
-
-  bool WarpSyncOrders(const AccessEntry &prev, const AccessEntry &curr,
-                      const AccessEntry &sync) const {
-    return IsBallotDerivedWarpSync(sync) &&
-           HaveEquivalentConstraints(prev, sync) &&
-           HaveEquivalentConstraints(curr, sync) &&
-           ConflictsOnlyWithinWarp(prev, curr);
   }
 
   bool Enabled(const VarNode *buf, const StorageScope &scope) {
@@ -1747,10 +1573,6 @@ private:
   // current lexical scope.
   std::unordered_map<const VarNode *, ConditionThreadProperty>
       let_var_properties_;
-  // 保存 flat Bind 的定义，用于识别 LowerThreadAllreduce 生成的 ballot 掩码。
-  std::unordered_map<const VarNode *, PrimExpr> let_var_values_;
-  // 记录会被 ThreadPartialSyncRewriter 改写的显式 shared barrier。
-  std::unordered_set<const Object *> explicit_syncs_seen_;
   // The buffer map
   Map<Var, Buffer> buffer_data_to_buffer_;
   // synchronization scope
@@ -1847,9 +1669,6 @@ private:
       break;
     case kSync:
       type_str = "Sync";
-      break;
-    case kSyncWarp:
-      type_str = "SyncWarp";
       break;
     case kAlloc:
       type_str = "Alloc";
@@ -2184,35 +2003,6 @@ private:
         ICHECK(prev_indice_bytes.dtype() == curr_indice_bytes.dtype());
         provably_disjoint =
             analyzer.CanProve(tirx::NE(prev_indice_bytes, curr_indice_bytes));
-        // 对短小展开循环逐次代入迭代值，避免 div/mod 组合让符号证明返回
-        // unknown。
-        if (!provably_disjoint && loop != nullptr &&
-            loop->kind == ForKind::kUnrolled) {
-          const auto *loop_min = loop->min.as<IntImmNode>();
-          const auto *loop_extent = loop->extent.as<IntImmNode>();
-          constexpr int64_t kMaxEnumeratedUnrollExtent = 64;
-          if (loop_min != nullptr && loop_extent != nullptr &&
-              loop_extent->value > 1 &&
-              loop_extent->value <= kMaxEnumeratedUnrollExtent) {
-            provably_disjoint = true;
-            for (int64_t offset = 0; offset < loop_extent->value - 1;
-                 ++offset) {
-              Map<Var, PrimExpr> iteration_sub;
-              iteration_sub.Set(
-                  loop->loop_var,
-                  make_const(loop->loop_var.dtype(), loop_min->value + offset));
-              PrimExpr prev_at_iteration =
-                  Substitute(prev_indice_bytes, iteration_sub);
-              PrimExpr curr_at_iteration =
-                  Substitute(curr_indice_bytes, iteration_sub);
-              if (!analyzer.CanProve(
-                      tirx::NE(prev_at_iteration, curr_at_iteration))) {
-                provably_disjoint = false;
-                break;
-              }
-            }
-          }
-        }
       } else {
         try {
           auto prev_min = analyzer.Simplify(

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -437,10 +437,12 @@ private:
 struct ConditionThreadProperty {
   bool depends_on_runtime{false};
   bool is_block_uniform{true};
+  bool requires_hoist{false};
 
   void Merge(const ConditionThreadProperty &other) {
     depends_on_runtime = depends_on_runtime || other.depends_on_runtime;
     is_block_uniform = is_block_uniform && other.is_block_uniform;
+    requires_hoist = requires_hoist || other.requires_hoist;
   }
 };
 
@@ -448,7 +450,7 @@ struct ConditionThreadProperty {
  * \brief Analyze whether an if-condition is runtime-dependent and/or uniform
  * across all threads in a block.
  *
- * For branch-local sync validation we care about two independent properties:
+ * For sync hoisting decisions we care about two independent properties:
  *
  * 1. Does the condition depend on runtime values such as memory loads?
  * 2. Even if it does, is it still block-uniform, i.e. identical for every
@@ -458,25 +460,48 @@ struct ConditionThreadProperty {
  * - `token_ids[tx] != -1` is runtime-dependent and non-uniform.
  * - `batch_sizes[bx] > 0` is runtime-dependent but block-uniform.
  *
- * Runtime-dependent, non-uniform conditions cannot use the current static-count
- * partial barrier. Thread-only conditions additionally need a warp-uniformity
- * proof before ThreadPartialSyncRewriter can lower them safely.
+ * Runtime-dependent, non-uniform conditions use the existing conservative
+ * hoisting path. Thread-only conditions that otherwise remain in place need a
+ * warp-uniformity proof before ThreadPartialSyncRewriter can lower them safely.
  */
 class ConditionThreadPropertyChecker : public IRMutatorWithAnalyzer {
 public:
   explicit ConditionThreadPropertyChecker(
       arith::Analyzer *analyzer, const Array<IterVar> &env_threads,
       const std::unordered_map<const VarNode *, ConditionThreadProperty>
-          &let_var_properties)
+          &let_var_properties,
+      int warp_size = 32)
       : IRMutatorWithAnalyzer(analyzer), env_threads_(env_threads),
-        let_var_properties_(let_var_properties) {}
+        let_var_properties_(let_var_properties), warp_size_(warp_size) {}
 
   /*!
-   * \brief Analyze condition properties relevant to branch-local syncs.
+   * \brief Analyze condition properties relevant to thread-sync hoisting.
    */
   ConditionThreadProperty AnalyzeExpr(const PrimExpr &expr) {
     current_ = ConditionThreadProperty();
     this->VisitExpr(expr);
+    return current_;
+  }
+
+  ConditionThreadProperty AnalyzeCondition(const PrimExpr &expr,
+                                           const IterVar &iv) {
+    current_ = ConditionThreadProperty();
+    this->VisitExpr(expr);
+    auto extent_opt = as_const_int(iv->dom->extent);
+    ICHECK(extent_opt != nullptr)
+        << "AnalyzeCondition: thread extent must be a "
+           "constant, but got: "
+        << iv->dom->extent;
+    int64_t thread_extent = *extent_opt;
+    {
+      With<arith::ConstraintContext> ctx(analyzer_, expr);
+      auto count = analyzer_->z3_prover.CountSatisfyingValues(
+          iv->var, thread_extent, /*min_consecutive=*/warp_size_);
+      if (count < 0) {
+        // ThreadPartialSyncRewriter cannot safely lower this condition.
+        current_.requires_hoist = true;
+      }
+    }
     return current_;
   }
 
@@ -572,6 +597,7 @@ private:
   const Array<IterVar> &env_threads_;
   const std::unordered_map<const VarNode *, ConditionThreadProperty>
       &let_var_properties_;
+  int warp_size_;
 };
 
 struct TileLangThreadSyncPlanner : public ConstrVisitor {
@@ -696,6 +722,15 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     }
     shared_memory_alias_byte_offsets_[alias_var.get()] = byte_offset;
   }
+  IterVar GetThreadVar(const std::string &tag) const {
+    for (const auto &iv : env_threads_) {
+      if (iv->thread_tag == tag) {
+        return iv;
+      }
+    }
+    LOG(FATAL) << "Thread variable " << tag << " not found";
+    return IterVar();
+  }
   /*!
    * \brief Try to prove that every thread reaches the same verdict on
    *        \p condition, using the live constraint set as premises.
@@ -767,37 +802,6 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     PrimExpr agree = tirx::Or(tirx::And(lhs, rhs),
                               tirx::And(tirx::Not(lhs), tirx::Not(rhs)));
     return analyzer.CanProve(tirx::Or(tirx::Not(same_warp), agree));
-  }
-
-  /*! \brief Return whether \p condition describes one axis-aligned region. */
-  bool IsAxisAlignedThreadRegion(const PrimExpr &condition) {
-    ConstrSet cset = GetConstrSet();
-    arith::Analyzer bound_analyzer;
-    cset.Populate(bound_analyzer);
-
-    PrimExpr region = Bool(true);
-    {
-      With<arith::ConstraintContext> ctx(&bound_analyzer, condition);
-      for (const auto &iv : env_threads_) {
-        if (runtime::ThreadScope::Create(iv->thread_tag).rank != 1)
-          continue;
-        if (!bound_analyzer.const_int_bound.IsBound(iv->var)) {
-          return false;
-        }
-        auto bound = bound_analyzer.const_int_bound(iv->var);
-        PrimExpr min_value = make_const(iv->var.dtype(), bound->min_value);
-        PrimExpr max_value = make_const(iv->var.dtype(), bound->max_value);
-        region = tirx::And(region, iv->var >= min_value);
-        region = tirx::And(region, iv->var <= max_value);
-      }
-    }
-
-    arith::Analyzer analyzer;
-    cset.Populate(analyzer);
-    PrimExpr equivalent =
-        tirx::Or(tirx::And(condition, region),
-                 tirx::And(tirx::Not(condition), tirx::Not(region)));
-    return analyzer.CanProve(equivalent);
   }
 
   void VisitExpr_(const BufferLoadNode *op) final {
@@ -957,10 +961,10 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
    * buffer reads, writes, and synchronization events under the condition's
    * constraints.
    *
-   * IMPORTANT: A sync inside a thread-divergent branch is valid only when every
-   * hardware warp agrees on branch participation. Hoisting is not a repair when
-   * both conflicting accesses remain inside the branch, so unsupported
-   * participation patterns must be rejected.
+   * IMPORTANT: Before preserving a partial barrier in a thread-divergent
+   * branch, prove that every hardware warp agrees on branch participation.
+   * Conditions already handled by the legacy conservative hoisting path keep
+   * that behavior for compatibility.
    */
   void VisitStmt_(const IfThenElseNode *op) final {
     StmtEntry s;
@@ -1043,41 +1047,59 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       ConstrSet constr_set = GetConstrSet();
       constr_set.Populate(analyzer);
       ConditionThreadPropertyChecker checker(&analyzer, env_threads_,
-                                             let_var_properties_);
-      auto validate_sync_condition = [&](const PrimExpr &branch_condition,
-                                         const char *branch_name) {
-        auto condition_prop = checker.AnalyzeExpr(branch_condition);
-        bool proven_block_uniform = !condition_prop.is_block_uniform &&
-                                    IsBlockUniformCondition(branch_condition);
-        if (condition_prop.is_block_uniform || proven_block_uniform) {
-          return;
-        }
+                                             let_var_properties_, warp_size_);
+      IterVar tx = GetThreadVar("threadIdx.x");
+      auto must_hoist = [&](const PrimExpr &branch_condition,
+                            const char *branch_name) {
+        auto condition_prop = checker.AnalyzeCondition(branch_condition, tx);
+        bool may_hoist =
+            condition_prop.depends_on_runtime || condition_prop.requires_hoist;
+        bool proven_uniform =
+            may_hoist && IsBlockUniformCondition(branch_condition);
+        bool is_block_uniform =
+            condition_prop.is_block_uniform || proven_uniform;
+        bool should_hoist =
+            (condition_prop.depends_on_runtime && !is_block_uniform) ||
+            (condition_prop.requires_hoist && !proven_uniform);
 
-        bool is_static_warp_uniform =
-            !condition_prop.depends_on_runtime &&
-            IsAxisAlignedThreadRegion(branch_condition) &&
-            IsWarpUniformCondition(branch_condition);
-        if (is_static_warp_uniform) {
-          return;
+        if (!should_hoist && !is_block_uniform &&
+            !IsWarpUniformCondition(branch_condition)) {
+          LOG(FATAL)
+              << "[ThreadSync] Cannot lower a required shared-memory sync "
+                 "inside the "
+              << branch_name
+              << " branch: its participating threads are not warp-uniform. "
+                 "A partial barrier requires every non-exited thread in each "
+                 "participating warp to reach the barrier. Condition: "
+              << branch_condition;
         }
-
-        LOG(FATAL)
-            << "[ThreadSync] Cannot lower a required shared-memory sync "
-               "inside the "
-            << branch_name
-            << " branch: its participating threads are not a compile-time "
-               "warp-uniform set representable by the current partial "
-               "barrier lowering. Hoisting the barrier before the if would "
-               "not order the conflicting accesses inside the branch. "
-               "Condition: "
-            << branch_condition;
+        return should_hoist;
       };
 
-      if (!syncs_in_then.empty()) {
-        validate_sync_condition(op->condition, "then");
-      }
-      if (!syncs_in_else.empty()) {
-        validate_sync_condition(tirx::Not(op->condition), "else");
+      bool hoist_then =
+          !syncs_in_then.empty() && must_hoist(op->condition, "then");
+      bool hoist_else = !syncs_in_else.empty() &&
+                        must_hoist(tirx::Not(op->condition), "else");
+      if (hoist_then || hoist_else) {
+        LOG(WARNING)
+            << "[ThreadSync] Hoisting sync out of an if whose condition is not "
+               "safe for an in-if sync. This is not a fix: both ends of the "
+               "conflict are inside the branch, so the hoisted barrier no "
+               "longer separates them and the race remains. Constraining the "
+               "condition -- a T.assume on the parameters it reads -- keeps "
+               "the barrier in place instead. Condition: "
+            << op->condition;
+        if (hoist_then) {
+          for (const auto &sync : syncs_in_then) {
+            syncs_inserted_.erase(sync);
+          }
+        }
+        if (hoist_else) {
+          for (const auto &sync : syncs_in_else) {
+            syncs_inserted_.erase(sync);
+          }
+        }
+        insert_syncs(op);
       }
     }
 
@@ -1521,7 +1543,7 @@ private:
     ConstrSet constr_set = GetConstrSet();
     constr_set.Populate(analyzer);
     ConditionThreadPropertyChecker checker(&analyzer, env_threads_,
-                                           let_var_properties_);
+                                           let_var_properties_, warp_size_);
     return checker.AnalyzeExpr(expr);
   }
 

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -237,6 +237,29 @@ private:
   const std::unordered_set<const Object *> &syncs_;
 };
 
+namespace {
+
+PrimExpr MakeLinearThreadId(const Array<IterVar> &thread_vars) {
+  DataType index_dtype = DataType::Int(64);
+  PrimExpr linear_thread_id = make_const(index_dtype, 0);
+  PrimExpr stride = make_const(index_dtype, 1);
+  static const char *kThreadTags[] = {"threadIdx.x", "threadIdx.y",
+                                      "threadIdx.z"};
+  for (const char *thread_tag : kThreadTags) {
+    for (const auto &iv : thread_vars) {
+      if (iv->thread_tag != thread_tag)
+        continue;
+      PrimExpr index = Cast(index_dtype, iv->var - iv->dom->min);
+      linear_thread_id = linear_thread_id + index * stride;
+      stride = stride * Cast(index_dtype, iv->dom->extent);
+      break;
+    }
+  }
+  return linear_thread_id;
+}
+
+} // namespace
+
 class ThreadPartialSyncRewriter : public IRMutatorWithAnalyzer {
 public:
   static Stmt Rewrite(Stmt stmt, int warp_size = 32) {
@@ -414,12 +437,10 @@ private:
 struct ConditionThreadProperty {
   bool depends_on_runtime{false};
   bool is_block_uniform{true};
-  bool requires_hoist{false};
 
   void Merge(const ConditionThreadProperty &other) {
     depends_on_runtime = depends_on_runtime || other.depends_on_runtime;
     is_block_uniform = is_block_uniform && other.is_block_uniform;
-    requires_hoist = requires_hoist || other.requires_hoist;
   }
 };
 
@@ -427,7 +448,7 @@ struct ConditionThreadProperty {
  * \brief Analyze whether an if-condition is runtime-dependent and/or uniform
  * across all threads in a block.
  *
- * For sync hoisting decisions we care about two independent properties:
+ * For branch-local sync validation we care about two independent properties:
  *
  * 1. Does the condition depend on runtime values such as memory loads?
  * 2. Even if it does, is it still block-uniform, i.e. identical for every
@@ -437,48 +458,25 @@ struct ConditionThreadProperty {
  * - `token_ids[tx] != -1` is runtime-dependent and non-uniform.
  * - `batch_sizes[bx] > 0` is runtime-dependent but block-uniform.
  *
- * Only runtime-dependent, non-uniform conditions need to force sync hoisting.
- * In addition, some non-uniform threadIdx-only conditions still need hoisting
- * when ThreadPartialSyncRewriter cannot handle them.
+ * Runtime-dependent, non-uniform conditions cannot use the current static-count
+ * partial barrier. Thread-only conditions additionally need a warp-uniformity
+ * proof before ThreadPartialSyncRewriter can lower them safely.
  */
 class ConditionThreadPropertyChecker : public IRMutatorWithAnalyzer {
 public:
   explicit ConditionThreadPropertyChecker(
       arith::Analyzer *analyzer, const Array<IterVar> &env_threads,
       const std::unordered_map<const VarNode *, ConditionThreadProperty>
-          &let_var_properties,
-      int warp_size = 32)
+          &let_var_properties)
       : IRMutatorWithAnalyzer(analyzer), env_threads_(env_threads),
-        let_var_properties_(let_var_properties), warp_size_(warp_size) {}
+        let_var_properties_(let_var_properties) {}
 
   /*!
-   * \brief Analyze condition properties relevant to thread-sync hoisting.
+   * \brief Analyze condition properties relevant to branch-local syncs.
    */
   ConditionThreadProperty AnalyzeExpr(const PrimExpr &expr) {
     current_ = ConditionThreadProperty();
     this->VisitExpr(expr);
-    return current_;
-  }
-
-  ConditionThreadProperty AnalyzeCondition(const PrimExpr &expr,
-                                           const IterVar &iv) {
-    current_ = ConditionThreadProperty();
-    this->VisitExpr(expr);
-    auto extent_opt = as_const_int(iv->dom->extent);
-    ICHECK(extent_opt != nullptr)
-        << "AnalyzeCondition: thread extent must be a "
-           "constant, but got: "
-        << iv->dom->extent;
-    int64_t thread_extent = *extent_opt;
-    {
-      With<arith::ConstraintContext> ctx(analyzer_, expr);
-      auto count = analyzer_->z3_prover.CountSatisfyingValues(
-          iv->var, thread_extent, /*min_consecutive=*/warp_size_);
-      if (count < 0) {
-        // ThreadPartialSyncRewriter cannot safely lower this condition.
-        current_.requires_hoist = true;
-      }
-    }
     return current_;
   }
 
@@ -574,7 +572,6 @@ private:
   const Array<IterVar> &env_threads_;
   const std::unordered_map<const VarNode *, ConditionThreadProperty>
       &let_var_properties_;
-  int warp_size_;
 };
 
 struct TileLangThreadSyncPlanner : public ConstrVisitor {
@@ -699,16 +696,6 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     }
     shared_memory_alias_byte_offsets_[alias_var.get()] = byte_offset;
   }
-  IterVar GetThreadVar(const std::string &tag) const {
-    for (const auto &iv : env_threads_) {
-      if (iv->thread_tag == tag) {
-        return iv;
-      }
-    }
-    LOG(FATAL) << "Thread variable " << tag << " not found";
-    return IterVar();
-  }
-
   /*!
    * \brief Try to prove that every thread reaches the same verdict on
    *        \p condition, using the live constraint set as premises.
@@ -744,6 +731,73 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     PrimExpr agree = tirx::Or(tirx::And(lhs, rhs),
                               tirx::And(tirx::Not(lhs), tirx::Not(rhs)));
     return analyzer.CanProve(agree);
+  }
+
+  /*! \brief Return whether every hardware warp agrees on \p condition. */
+  bool IsWarpUniformCondition(const PrimExpr &condition) {
+    Map<Var, PrimExpr> sub1, sub2;
+    for (const auto &iv : env_threads_) {
+      if (runtime::ThreadScope::Create(iv->thread_tag).rank != 1)
+        continue;
+      sub1.Set(iv->var, Var(iv->var->name_hint + "<T1>", iv->var.dtype()));
+      sub2.Set(iv->var, Var(iv->var->name_hint + "<T2>", iv->var.dtype()));
+    }
+    if (sub1.empty()) {
+      return true;
+    }
+
+    DataType index_dtype = DataType::Int(64);
+    PrimExpr linear_thread_id = MakeLinearThreadId(env_threads_);
+
+    ConstrSet cset = GetConstrSet();
+    ConstrSet c1 =
+        cset.RenameFrom("<T1>", sub1, std::nullopt, /*rename_ranges=*/false);
+    ConstrSet c2 =
+        cset.RenameFrom("<T2>", sub2, std::nullopt, /*rename_ranges=*/false);
+    arith::Analyzer analyzer;
+    c1.ToConstraints().Merge(c2.ToConstraints()).Populate(analyzer);
+
+    PrimExpr lhs = Substitute(condition, sub1);
+    PrimExpr rhs = Substitute(condition, sub2);
+    PrimExpr linear1 = Substitute(linear_thread_id, sub1);
+    PrimExpr linear2 = Substitute(linear_thread_id, sub2);
+    PrimExpr warp_size = make_const(index_dtype, warp_size_);
+    PrimExpr same_warp =
+        FloorDiv(linear1, warp_size) == FloorDiv(linear2, warp_size);
+    PrimExpr agree = tirx::Or(tirx::And(lhs, rhs),
+                              tirx::And(tirx::Not(lhs), tirx::Not(rhs)));
+    return analyzer.CanProve(tirx::Or(tirx::Not(same_warp), agree));
+  }
+
+  /*! \brief Return whether \p condition describes one axis-aligned region. */
+  bool IsAxisAlignedThreadRegion(const PrimExpr &condition) {
+    ConstrSet cset = GetConstrSet();
+    arith::Analyzer bound_analyzer;
+    cset.Populate(bound_analyzer);
+
+    PrimExpr region = Bool(true);
+    {
+      With<arith::ConstraintContext> ctx(&bound_analyzer, condition);
+      for (const auto &iv : env_threads_) {
+        if (runtime::ThreadScope::Create(iv->thread_tag).rank != 1)
+          continue;
+        if (!bound_analyzer.const_int_bound.IsBound(iv->var)) {
+          return false;
+        }
+        auto bound = bound_analyzer.const_int_bound(iv->var);
+        PrimExpr min_value = make_const(iv->var.dtype(), bound->min_value);
+        PrimExpr max_value = make_const(iv->var.dtype(), bound->max_value);
+        region = tirx::And(region, iv->var >= min_value);
+        region = tirx::And(region, iv->var <= max_value);
+      }
+    }
+
+    arith::Analyzer analyzer;
+    cset.Populate(analyzer);
+    PrimExpr equivalent =
+        tirx::Or(tirx::And(condition, region),
+                 tirx::And(tirx::Not(condition), tirx::Not(region)));
+    return analyzer.CanProve(equivalent);
   }
 
   void VisitExpr_(const BufferLoadNode *op) final {
@@ -903,10 +957,10 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
    * buffer reads, writes, and synchronization events under the condition's
    * constraints.
    *
-   * IMPORTANT: If syncs are inserted inside an if-statement with a non-uniform
-   * condition (i.e., the condition depends on threadIdx), we must hoist the
-   * sync to before the if-statement. Otherwise, only some threads will reach
-   * the sync point, causing a deadlock.
+   * IMPORTANT: A sync inside a thread-divergent branch is valid only when every
+   * hardware warp agrees on branch participation. Hoisting is not a repair when
+   * both conflicting accesses remain inside the branch, so unsupported
+   * participation patterns must be rejected.
    */
   void VisitStmt_(const IfThenElseNode *op) final {
     StmtEntry s;
@@ -989,53 +1043,41 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       ConstrSet constr_set = GetConstrSet();
       constr_set.Populate(analyzer);
       ConditionThreadPropertyChecker checker(&analyzer, env_threads_,
-                                             let_var_properties_, warp_size_);
-      IterVar tx = GetThreadVar("threadIdx.x");
-      auto must_hoist = [&](const PrimExpr &branch_condition) {
-        auto condition_prop = checker.AnalyzeCondition(branch_condition, tx);
+                                             let_var_properties_);
+      auto validate_sync_condition = [&](const PrimExpr &branch_condition,
+                                         const char *branch_name) {
+        auto condition_prop = checker.AnalyzeExpr(branch_condition);
+        bool proven_block_uniform = !condition_prop.is_block_uniform &&
+                                    IsBlockUniformCondition(branch_condition);
+        if (condition_prop.is_block_uniform || proven_block_uniform) {
+          return;
+        }
 
-        // The estimate treats any condition using a thread variable as
-        // divergent, so ask the prover before hoisting.
-        bool may_hoist =
-            condition_prop.depends_on_runtime || condition_prop.requires_hoist;
-        bool proven_uniform =
-            may_hoist && IsBlockUniformCondition(branch_condition);
-        bool is_block_uniform =
-            condition_prop.is_block_uniform || proven_uniform;
-        // A partial barrier is unsafe when the participating thread count is
-        // unknown. Keep a plain __syncthreads() only for proven block-uniform
-        // conditions.
-        return (condition_prop.depends_on_runtime && !is_block_uniform) ||
-               (condition_prop.requires_hoist && !proven_uniform);
+        bool is_static_warp_uniform =
+            !condition_prop.depends_on_runtime &&
+            IsAxisAlignedThreadRegion(branch_condition) &&
+            IsWarpUniformCondition(branch_condition);
+        if (is_static_warp_uniform) {
+          return;
+        }
+
+        LOG(FATAL)
+            << "[ThreadSync] Cannot lower a required shared-memory sync "
+               "inside the "
+            << branch_name
+            << " branch: its participating threads are not a compile-time "
+               "warp-uniform set representable by the current partial "
+               "barrier lowering. Hoisting the barrier before the if would "
+               "not order the conflicting accesses inside the branch. "
+               "Condition: "
+            << branch_condition;
       };
 
-      bool hoist_then = !syncs_in_then.empty() && must_hoist(op->condition);
-      bool hoist_else =
-          !syncs_in_else.empty() && must_hoist(tirx::Not(op->condition));
-      if (hoist_then || hoist_else) {
-        LOG(WARNING)
-            << "[ThreadSync] Hoisting sync out of an if whose condition is not "
-               "safe for an in-if sync. This is not a fix: both ends of the "
-               "conflict are inside the branch, so the hoisted barrier no "
-               "longer separates them and the race remains. Constraining the "
-               "condition -- a T.assume on the parameters it reads -- keeps "
-               "the "
-               "barrier in place instead. Condition: "
-            << op->condition;
-        if (hoist_then) {
-          for (const auto &sync : syncs_in_then) {
-            syncs_inserted_.erase(sync);
-          }
-        }
-        if (hoist_else) {
-          for (const auto &sync : syncs_in_else) {
-            syncs_inserted_.erase(sync);
-          }
-        }
-
-        // Insert a block-wide sync before the if for branches that cannot
-        // safely synchronize in place.
-        insert_syncs(op);
+      if (!syncs_in_then.empty()) {
+        validate_sync_condition(op->condition, "then");
+      }
+      if (!syncs_in_else.empty()) {
+        validate_sync_condition(tirx::Not(op->condition), "else");
       }
     }
 
@@ -1479,7 +1521,7 @@ private:
     ConstrSet constr_set = GetConstrSet();
     constr_set.Populate(analyzer);
     ConditionThreadPropertyChecker checker(&analyzer, env_threads_,
-                                           let_var_properties_, warp_size_);
+                                           let_var_properties_);
     return checker.AnalyzeExpr(expr);
   }
 

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -1620,8 +1620,17 @@ private:
 
   bool HaveEquivalentConstraints(const AccessEntry &lhs,
                                  const AccessEntry &rhs) const {
-    PrimExpr lhs_condition = lhs.cset.ToConjunction();
-    PrimExpr rhs_condition = rhs.cset.ToConjunction();
+    auto participation_condition = [](const ConstrSet &cset) {
+      PrimExpr condition = Bool(true);
+      for (const Constr &constr : cset.constrs_) {
+        if (constr.kind != Constr::kBindValue) {
+          condition = tirx::And(condition, constr.ToGenericConstr());
+        }
+      }
+      return condition;
+    };
+    PrimExpr lhs_condition = participation_condition(lhs.cset);
+    PrimExpr rhs_condition = participation_condition(rhs.cset);
     if (ExprDeepEqual()(lhs_condition, rhs_condition)) {
       return true;
     }

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -586,6 +586,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     kRead,
     kWrite,
     kSync,
+    kSyncWarp,
     kAlloc,
     // acquired version of read, only need to handle WAR dep.
     kReadAcquire
@@ -612,6 +613,8 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     AccessType type;
     /*! \brief The storage scope */
     StorageScope scope;
+    /*! \brief warp 级同步显式使用的掩码。 */
+    Optional<PrimExpr> warp_sync_mask;
     /*! \brief Whether the access is pointer access */
     bool is_pointer_access = false;
     /*! \brief Whether this access originates from an async copy context
@@ -884,6 +887,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     // Record let var properties
     auto let_prop = AnalyzeExprProperty(op->value);
     let_var_properties_[op->var.get()] = let_prop;
+    let_var_values_[op->var.get()] = op->value;
   }
   void VisitStmt_(const SBlockNode *op) final {
     auto block = Downcast<SBlock>(op);
@@ -967,6 +971,9 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     // Track syncs inserted before visiting the if body
     std::unordered_set<const Object *> syncs_before_then;
     std::unordered_set<const Object *> syncs_before_else;
+    std::unordered_set<const Object *> explicit_syncs_before_then =
+        explicit_syncs_seen_;
+    std::unordered_set<const Object *> explicit_syncs_before_else;
     for (const auto &sync : syncs_inserted_) {
       syncs_before_then.insert(sync);
     }
@@ -1003,6 +1010,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     for (const auto &sync : syncs_inserted_) {
       syncs_before_else.insert(sync);
     }
+    explicit_syncs_before_else = explicit_syncs_seen_;
 
     if (op->else_case) {
       auto guard = MakeGuard(tirx::Not(op->condition));
@@ -1030,7 +1038,19 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       }
     }
 
-    bool has_syncs_inside = !syncs_in_then.empty() || !syncs_in_else.empty();
+    auto has_new_sync = [](const std::unordered_set<const Object *> &after,
+                           const std::unordered_set<const Object *> &before) {
+      return std::any_of(after.begin(), after.end(), [&](const Object *sync) {
+        return before.count(sync) == 0;
+      });
+    };
+    bool has_sync_in_then =
+        !syncs_in_then.empty() ||
+        has_new_sync(explicit_syncs_before_else, explicit_syncs_before_then);
+    bool has_sync_in_else =
+        !syncs_in_else.empty() ||
+        has_new_sync(explicit_syncs_seen_, explicit_syncs_before_else);
+    bool has_syncs_inside = has_sync_in_then || has_sync_in_else;
 
     if (has_syncs_inside) {
       // Runtime-dependent conditions are only problematic when they can differ
@@ -1038,7 +1058,6 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       // such as `batch_sizes[blockIdx.z] > 0` are safe to keep in-place.
       //
       // Separately, some threadIdx-only non-uniform conditions still need
-      // hoisting when ThreadPartialSyncRewriter cannot lower them safely.
       arith::Analyzer analyzer;
       ConstrSet constr_set = GetConstrSet();
       constr_set.Populate(analyzer);
@@ -1073,10 +1092,10 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
             << branch_condition;
       };
 
-      if (!syncs_in_then.empty()) {
+      if (has_sync_in_then) {
         validate_sync_condition(op->condition, "then");
       }
-      if (!syncs_in_else.empty()) {
+      if (has_sync_in_else) {
         validate_sync_condition(tirx::Not(op->condition), "else");
       }
     }
@@ -1305,6 +1324,9 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
         e.type = kSync;
         e.scope = StorageScope::Create(s);
         curr_stmt_.access.emplace_back(std::move(e));
+        if (op->args.size() == 1 && scope.rank == StorageRank::kShared) {
+          explicit_syncs_seen_.insert(curr_stmt_.stmt);
+        }
       }
     } else if (op->op.same_as(tl::sync_grid())) {
       // grid.sync() synchronizes every thread of every block and is a full
@@ -1315,6 +1337,16 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       e.threads = env_threads();
       e.type = kSync;
       e.scope = sync_scope_;
+      curr_stmt_.access.emplace_back(std::move(e));
+    } else if (op->op.same_as(tl::sync_warp())) {
+      ICHECK(allow_append_);
+      AccessEntry e{.cset = {constr_stack_}};
+      e.threads = env_threads();
+      e.type = kSyncWarp;
+      e.scope = sync_scope_;
+      if (!op->args.empty()) {
+        e.warp_sync_mask = op->args[0];
+      }
       curr_stmt_.access.emplace_back(std::move(e));
     } else {
       ConstrVisitor::VisitExpr_(op);
@@ -1343,9 +1375,38 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       }
     }
 
-    // Unsynced reads and writes
-    std::vector<AccessEntry> reads;
-    std::vector<AccessEntry> writes;
+    struct PendingAccess {
+      AccessEntry access;
+      std::vector<AccessEntry> warp_syncs_after;
+    };
+    std::vector<PendingAccess> reads;
+    std::vector<PendingAccess> writes;
+    auto has_conflict = [&](const std::vector<PendingAccess> &pending,
+                            const AccessEntry &curr, const ForNode *loop) {
+      for (const PendingAccess &item : pending) {
+        if (!FindConflict(item.access, curr, loop)) {
+          continue;
+        }
+        if (loop == nullptr && std::any_of(item.warp_syncs_after.begin(),
+                                           item.warp_syncs_after.end(),
+                                           [&](const AccessEntry &sync) {
+                                             return WarpSyncOrders(item.access,
+                                                                   curr, sync);
+                                           })) {
+          continue;
+        }
+        return true;
+      }
+      return false;
+    };
+    auto record_warp_sync = [&](const AccessEntry &sync) {
+      for (PendingAccess &item : reads) {
+        item.warp_syncs_after.push_back(sync);
+      }
+      for (PendingAccess &item : writes) {
+        item.warp_syncs_after.push_back(sync);
+      }
+    };
     // if it is a loop, rotate two times to consider effect of loop.
     // simulation based approach to find dependencies
     for (size_t i = 0; i < seq.size(); ++i) {
@@ -1362,14 +1423,14 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       for (const AccessEntry &acc : s.access) {
         if (acc.type == kRead) {
           // Same-iteration conflict: loop=nullptr
-          if (FindConflict(writes, acc, nullptr)) {
+          if (has_conflict(writes, acc, nullptr)) {
             sync_before_stmt = true;
             break;
           }
         } else if (acc.type == kWrite) {
           // Same-iteration conflict: loop=nullptr
-          if (FindConflict(reads, acc, nullptr) ||
-              FindConflict(writes, acc, nullptr)) {
+          if (has_conflict(reads, acc, nullptr) ||
+              has_conflict(writes, acc, nullptr)) {
             sync_before_stmt = true;
             break;
           }
@@ -1386,12 +1447,14 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       // Add the read/write of current statement
       for (const AccessEntry &acc : s.access) {
         if (acc.type == kRead) {
-          reads.push_back(acc);
+          reads.push_back({acc, {}});
         } else if (acc.type == kWrite) {
-          writes.push_back(acc);
+          writes.push_back({acc, {}});
         } else if (acc.type == kSync) {
           reads.clear();
           writes.clear();
+        } else if (acc.type == kSyncWarp) {
+          record_warp_sync(acc);
         }
       }
 
@@ -1442,20 +1505,22 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
         for (const AccessEntry &acc : s.access) {
           if (acc.type == kRead) {
             // Loop-carry conflict: pass loop for iteration shift analysis
-            if (FindConflict(writes, acc, loop)) {
+            if (has_conflict(writes, acc, loop)) {
               need_loop_sync = true;
               break;
             }
           } else if (acc.type == kWrite) {
             // Loop-carry conflict: pass loop for iteration shift analysis
-            if (FindConflict(reads, acc, loop) ||
-                FindConflict(writes, acc, loop)) {
+            if (has_conflict(reads, acc, loop) ||
+                has_conflict(writes, acc, loop)) {
               need_loop_sync = true;
               break;
             }
           } else if (acc.type == kSync) {
             reads.clear();
             writes.clear();
+          } else if (acc.type == kSyncWarp) {
+            record_warp_sync(acc);
           }
         }
         if (need_loop_sync) {
@@ -1525,6 +1590,128 @@ private:
     return checker.AnalyzeExpr(expr);
   }
 
+  PrimExpr ResolveLetValue(PrimExpr expr) const {
+    std::unordered_set<const VarNode *> visited;
+    while (true) {
+      if (const auto *cast = expr.as<CastNode>()) {
+        expr = cast->value;
+        continue;
+      }
+      const auto *var = expr.as<VarNode>();
+      if (var == nullptr || !visited.insert(var).second) {
+        return expr;
+      }
+      auto it = let_var_values_.find(var);
+      if (it == let_var_values_.end()) {
+        return expr;
+      }
+      expr = it->second;
+    }
+  }
+
+  bool IsBallotDerivedWarpSync(const AccessEntry &sync) const {
+    if (!sync.warp_sync_mask.defined()) {
+      return false;
+    }
+    PrimExpr mask = ResolveLetValue(sync.warp_sync_mask.value());
+    const auto *call = mask.as<CallNode>();
+    return call != nullptr && call->op.same_as(tl::ballot_sync());
+  }
+
+  bool HaveEquivalentConstraints(const AccessEntry &lhs,
+                                 const AccessEntry &rhs) const {
+    PrimExpr lhs_condition = lhs.cset.ToConjunction();
+    PrimExpr rhs_condition = rhs.cset.ToConjunction();
+    if (ExprDeepEqual()(lhs_condition, rhs_condition)) {
+      return true;
+    }
+
+    arith::Analyzer analyzer;
+    std::unordered_set<const VarNode *> bound;
+    for (const Array<IterVar> *threads : {&lhs.threads, &rhs.threads}) {
+      for (const IterVar &iv : *threads) {
+        if (iv->dom.defined() && bound.insert(iv->var.get()).second) {
+          analyzer.Bind(iv->var, iv->dom);
+        }
+      }
+    }
+    PrimExpr equivalent =
+        tirx::Or(tirx::And(lhs_condition, rhs_condition),
+                 tirx::And(tirx::Not(lhs_condition), tirx::Not(rhs_condition)));
+    return analyzer.z3_prover.CanProve(equivalent);
+  }
+
+  bool ConflictsOnlyWithinWarp(const AccessEntry &prev,
+                               const AccessEntry &curr) const {
+    if (prev.is_pointer_access || curr.is_pointer_access ||
+        prev.buffer_indices.size() != 1 || curr.buffer_indices.size() != 1) {
+      return false;
+    }
+
+    Map<Var, PrimExpr> prev_sub, curr_sub;
+    for (const IterVar &prev_iv : prev.threads) {
+      if (runtime::ThreadScope::Create(prev_iv->thread_tag).rank != 1) {
+        continue;
+      }
+      IterVar curr_iv;
+      for (const IterVar &candidate : curr.threads) {
+        if (candidate->thread_tag == prev_iv->thread_tag) {
+          curr_iv = candidate;
+          break;
+        }
+      }
+      if (!curr_iv.defined()) {
+        return false;
+      }
+      std::string suffix = prev_iv->thread_tag;
+      prev_sub.Set(prev_iv->var, Var(suffix + "<W1>", prev_iv->var.dtype()));
+      curr_sub.Set(curr_iv->var, Var(suffix + "<W2>", curr_iv->var.dtype()));
+    }
+    if (prev_sub.empty() || curr_sub.empty()) {
+      return false;
+    }
+
+    ConstrSet prev_cset{prev.cset};
+    ConstrSet curr_cset{curr.cset};
+    prev_cset = prev_cset.RenameFrom("<W1>", prev_sub, std::nullopt,
+                                     /*rename_ranges=*/false);
+    curr_cset = curr_cset.RenameFrom("<W2>", curr_sub, std::nullopt,
+                                     /*rename_ranges=*/false);
+    arith::Analyzer analyzer;
+    prev_cset.ToConstraints()
+        .Merge(curr_cset.ToConstraints())
+        .Populate(analyzer);
+
+    DataType index_dtype = DataType::Int(64);
+    PrimExpr prev_index = Substitute(prev.buffer_indices[0], prev_sub);
+    PrimExpr curr_index = Substitute(curr.buffer_indices[0], curr_sub);
+    if (!prev_index.dtype().is_scalar() || !curr_index.dtype().is_scalar()) {
+      return false;
+    }
+    PrimExpr prev_address = Cast(index_dtype, prev_index) *
+                            make_const(index_dtype, prev.dtype.bytes());
+    PrimExpr curr_address = Cast(index_dtype, curr_index) *
+                            make_const(index_dtype, curr.dtype.bytes());
+
+    PrimExpr prev_linear =
+        Substitute(MakeLinearThreadId(prev.threads), prev_sub);
+    PrimExpr curr_linear =
+        Substitute(MakeLinearThreadId(curr.threads), curr_sub);
+    PrimExpr warp_size = make_const(index_dtype, warp_size_);
+    PrimExpr same_warp =
+        FloorDiv(prev_linear, warp_size) == FloorDiv(curr_linear, warp_size);
+    return analyzer.CanProve(
+        tirx::Or(same_warp, tirx::NE(prev_address, curr_address)));
+  }
+
+  bool WarpSyncOrders(const AccessEntry &prev, const AccessEntry &curr,
+                      const AccessEntry &sync) const {
+    return IsBallotDerivedWarpSync(sync) &&
+           HaveEquivalentConstraints(prev, sync) &&
+           HaveEquivalentConstraints(curr, sync) &&
+           ConflictsOnlyWithinWarp(prev, curr);
+  }
+
   bool Enabled(const VarNode *buf, const StorageScope &scope) {
     return in_device_env() && scope == sync_scope_;
   }
@@ -1551,6 +1738,10 @@ private:
   // current lexical scope.
   std::unordered_map<const VarNode *, ConditionThreadProperty>
       let_var_properties_;
+  // 保存 flat Bind 的定义，用于识别 LowerThreadAllreduce 生成的 ballot 掩码。
+  std::unordered_map<const VarNode *, PrimExpr> let_var_values_;
+  // 记录会被 ThreadPartialSyncRewriter 改写的显式 shared barrier。
+  std::unordered_set<const Object *> explicit_syncs_seen_;
   // The buffer map
   Map<Var, Buffer> buffer_data_to_buffer_;
   // synchronization scope
@@ -1647,6 +1838,9 @@ private:
       break;
     case kSync:
       type_str = "Sync";
+      break;
+    case kSyncWarp:
+      type_str = "SyncWarp";
       break;
     case kAlloc:
       type_str = "Alloc";

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -991,22 +991,28 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       ConditionThreadPropertyChecker checker(&analyzer, env_threads_,
                                              let_var_properties_, warp_size_);
       IterVar tx = GetThreadVar("threadIdx.x");
-      auto condition_prop = checker.AnalyzeCondition(op->condition, tx);
+      auto must_hoist = [&](const PrimExpr &branch_condition) {
+        auto condition_prop = checker.AnalyzeCondition(branch_condition, tx);
 
-      // The estimate calls anything mentioning a thread variable divergent; ask
-      // the prover before hoisting. Only added to it, never subtracted, and
-      // only asked when something below could act on the answer.
-      bool may_hoist =
-          condition_prop.depends_on_runtime || condition_prop.requires_hoist;
-      bool proven_uniform = may_hoist && IsBlockUniformCondition(op->condition);
-      bool is_block_uniform = condition_prop.is_block_uniform || proven_uniform;
-      // requires_hoist means the participation count was not established, so
-      // ThreadPartialSyncRewriter cannot emit `bar.sync id, count`. Uniformity
-      // answers that: the barrier is reached by the whole block or by nobody,
-      // and a plain __syncthreads() is right. Only a proof counts, not the
-      // heuristic.
-      if ((condition_prop.depends_on_runtime && !is_block_uniform) ||
-          (condition_prop.requires_hoist && !proven_uniform)) {
+        // The estimate treats any condition using a thread variable as
+        // divergent, so ask the prover before hoisting.
+        bool may_hoist =
+            condition_prop.depends_on_runtime || condition_prop.requires_hoist;
+        bool proven_uniform =
+            may_hoist && IsBlockUniformCondition(branch_condition);
+        bool is_block_uniform =
+            condition_prop.is_block_uniform || proven_uniform;
+        // A partial barrier is unsafe when the participating thread count is
+        // unknown. Keep a plain __syncthreads() only for proven block-uniform
+        // conditions.
+        return (condition_prop.depends_on_runtime && !is_block_uniform) ||
+               (condition_prop.requires_hoist && !proven_uniform);
+      };
+
+      bool hoist_then = !syncs_in_then.empty() && must_hoist(op->condition);
+      bool hoist_else =
+          !syncs_in_else.empty() && must_hoist(tirx::Not(op->condition));
+      if (hoist_then || hoist_else) {
         LOG(WARNING)
             << "[ThreadSync] Hoisting sync out of an if whose condition is not "
                "safe for an in-if sync. This is not a fix: both ends of the "
@@ -1016,14 +1022,19 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
                "the "
                "barrier in place instead. Condition: "
             << op->condition;
-        for (const auto &sync : syncs_in_then) {
-          syncs_inserted_.erase(sync);
+        if (hoist_then) {
+          for (const auto &sync : syncs_in_then) {
+            syncs_inserted_.erase(sync);
+          }
         }
-        for (const auto &sync : syncs_in_else) {
-          syncs_inserted_.erase(sync);
+        if (hoist_else) {
+          for (const auto &sync : syncs_in_else) {
+            syncs_inserted_.erase(sync);
+          }
         }
 
-        // Insert sync before the if-statement itself
+        // Insert a block-wide sync before the if for branches that cannot
+        // safely synchronize in place.
         insert_syncs(op);
       }
     }

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -1064,7 +1064,8 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       ConditionThreadPropertyChecker checker(&analyzer, env_threads_,
                                              let_var_properties_);
       auto validate_sync_condition = [&](const PrimExpr &branch_condition,
-                                         const char *branch_name) {
+                                         const char *branch_name,
+                                         const Stmt &branch_body) {
         auto condition_prop = checker.AnalyzeExpr(branch_condition);
         bool proven_block_uniform = !condition_prop.is_block_uniform &&
                                     IsBlockUniformCondition(branch_condition);
@@ -1089,14 +1090,16 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
                "barrier lowering. Hoisting the barrier before the if would "
                "not order the conflicting accesses inside the branch. "
                "Condition: "
-            << branch_condition;
+            << branch_condition << "\nBranch IR:\n"
+            << branch_body;
       };
 
       if (has_sync_in_then) {
-        validate_sync_condition(op->condition, "then");
+        validate_sync_condition(op->condition, "then", op->then_case);
       }
       if (has_sync_in_else) {
-        validate_sync_condition(tirx::Not(op->condition), "else");
+        validate_sync_condition(tirx::Not(op->condition), "else",
+                                op->else_case.value());
       }
     }
 

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -827,6 +827,61 @@ def test_partial_sync_warp_multiple_still_lowered():
     assert re.search(r'tvm_storage_sync\("shared",\s*\d+,\s*32\)', s), f"Expected a partial barrier with thread_count=32:\n{s}"
 
 
+def test_masked_warp_sync_orders_only_intra_warp_hazards():
+    """ballot 掩码生成的 warp barrier 足以排序同一 warp 内的冲突。"""
+
+    @T.prim_func(private=True)
+    def func():
+        S = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        acc = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 64)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        active_mask = T.bind(T.cast(T.call_intrin("uint64", tvm.tirx.op.Op.get("tl.activemask")), "uint32"))
+        participant_mask = T.bind(
+            T.cast(
+                T.call_intrin("uint64", tvm.tirx.op.Op.get("tl.ballot_sync"), active_mask, tx % 4 == 0),
+                "uint32",
+            )
+        )
+        if tx % 4 == 0:
+            acc[0] = S[tx // 32 * 32 + (tx + 4) % 32]
+            T.evaluate(T.call_intrin("void", tvm.tirx.op.Op.get("tl.sync_warp"), participant_mask))
+            S[tx] = acc[0]
+
+    s = run_passes_script(func)
+    assert "T.tvm_storage_sync" not in s, f"Masked warp sync should order the intra-warp hazard:\n{s}"
+
+
+def test_masked_warp_sync_does_not_order_cross_warp_hazards():
+    """warp barrier 不能掩盖跨 warp 的共享内存冲突。"""
+    import pytest
+
+    @T.prim_func(private=True)
+    def func():
+        S = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        acc = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 64)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        active_mask = T.bind(T.cast(T.call_intrin("uint64", tvm.tirx.op.Op.get("tl.activemask")), "uint32"))
+        participant_mask = T.bind(
+            T.cast(
+                T.call_intrin("uint64", tvm.tirx.op.Op.get("tl.ballot_sync"), active_mask, tx % 4 == 0),
+                "uint32",
+            )
+        )
+        if tx % 4 == 0:
+            acc[0] = S[(tx + 32) % 64]
+            T.evaluate(T.call_intrin("void", tvm.tirx.op.Op.get("tl.sync_warp"), participant_mask))
+            S[tx] = acc[0]
+
+    with pytest.raises(Exception, match="compile-time warp-uniform"):
+        run_passes_script(func)
+
+
 # =============================================================================
 # Tests for flat Bind definitions inside the recorded constraint sets
 #
@@ -1017,6 +1072,29 @@ def test_misaligned_else_partial_sync_is_rejected():
             l[0] = T.float32(0)
         else:
             s[tx] = T.cast(tx, "float32")
+            l[0] = s[33 - tx]
+
+    with pytest.raises(Exception, match="compile-time warp-uniform"):
+        run_passes_script(func)
+
+
+def test_explicit_misaligned_else_partial_sync_is_rejected():
+    """显式 barrier 也不能绕过非 warp 对齐参与集合的校验。"""
+    import pytest
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        if tx == 0 or tx >= 33:
+            l[0] = T.float32(0)
+        else:
+            s[tx] = T.cast(tx, "float32")
+            T.tvm_storage_sync("shared")
             l[0] = s[33 - tx]
 
     with pytest.raises(Exception, match="compile-time warp-uniform"):

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -796,7 +796,7 @@ def test_partial_sync_non_warp_multiple_rejected():
                 acc[0] += S[47 - tx]
 
     mod = tvm.IRModule({"main": func})
-    with pytest.raises(Exception, match="compile-time warp-uniform"):
+    with pytest.raises(Exception, match="not warp-uniform"):
         tilelang.transform.ThreadSync("shared")(mod)
 
 
@@ -921,7 +921,7 @@ def test_no_plain_sync_inside_divergent_symbolic_guard():
         assert sync_pos < if_pos, f"Barrier must be hoisted out of the divergent guard:\n{s}"
 
 
-def test_unorderable_hazard_in_divergent_guard_is_rejected():
+def test_unorderable_hazard_in_divergent_guard_is_reported(capfd):
     """A hazard confined to a divergent branch has no correct barrier placement.
 
     ``bx * 4 + tx // 32 < n`` mixes a thread variable with a runtime parameter, so
@@ -929,7 +929,8 @@ def test_unorderable_hazard_in_divergent_guard_is_rejected():
     that branch. A barrier inside it hangs on the threads that skip the branch,
     while one in front of it is reached by everyone but no longer separates the
     accesses. Ordering this needs the branch split around the barrier, which the
-    pass cannot express, so compilation must reject the program.
+    pass cannot express, so reporting the program is the only thing it can get
+    right. Where the barrier ends up is deliberately not asserted.
     """
 
     @T.prim_func(private=True)
@@ -944,18 +945,17 @@ def test_unorderable_hazard_in_divergent_guard_is_rejected():
             s[tx] = T.cast(tx, "float32")
             l[0] = s[(tx + 64) % 128]
 
-    import pytest
+    run_passes_script(func)
+    warnings = capfd.readouterr().err
+    assert "no longer separates" in warnings, f"Expected the pass to report the hazard:\n{warnings}"
 
-    with pytest.raises(Exception, match="compile-time warp-uniform"):
-        run_passes_script(func)
 
-
-def test_unorderable_hazard_in_divergent_else_branch_is_rejected():
+def test_unorderable_hazard_in_divergent_else_branch_is_reported(capfd):
     """The else branch needs the same treatment as the then branch.
 
     Syncs found in either arm are tracked separately, so a hazard placed only in
     the else arm exercises the second of the two paths. It is as unorderable as
-    the one above, so compilation must reject it as well.
+    the one above, so again only the report is asserted.
     """
 
     @T.prim_func(private=True)
@@ -972,10 +972,9 @@ def test_unorderable_hazard_in_divergent_else_branch_is_rejected():
             s[tx] = T.cast(tx, "float32")
             l[0] = s[(tx + 64) % 128]
 
-    import pytest
-
-    with pytest.raises(Exception, match="compile-time warp-uniform"):
-        run_passes_script(func)
+    run_passes_script(func)
+    warnings = capfd.readouterr().err
+    assert "no longer separates" in warnings, f"Expected the pass to report the hazard:\n{warnings}"
 
 
 def test_aligned_else_partial_sync_is_preserved():
@@ -1019,7 +1018,7 @@ def test_misaligned_else_partial_sync_is_rejected():
             s[tx] = T.cast(tx, "float32")
             l[0] = s[33 - tx]
 
-    with pytest.raises(Exception, match="compile-time warp-uniform"):
+    with pytest.raises(Exception, match="not warp-uniform"):
         run_passes_script(func)
 
 
@@ -1055,13 +1054,13 @@ def test_sync_stays_inside_guard_proven_uniform_by_premise(capfd):
     assert "no longer separates" not in warnings, f"A provably uniform guard should not be reported:\n{warnings}"
 
 
-def test_premise_weaker_than_the_block_is_rejected():
+def test_premise_weaker_than_the_block_is_not_taken_as_uniform(capfd):
     """The premise has to rule divergence out for the block size actually used.
 
     ``n % 64 == 0`` with a block of 128 threads still admits ``n == 64``, where
     half the block enters. This pins down the boundary of the check above: it must
     accept a premise only when the premise really excludes divergence. The guard
-    is therefore unsupported and must be rejected.
+    is therefore treated as divergent, which for this shape means reported.
     """
 
     @T.prim_func(private=True)
@@ -1077,10 +1076,9 @@ def test_premise_weaker_than_the_block_is_rejected():
                 s[tx] = T.cast(tx, "float32")
                 l[0] = s[(tx + 64) % 128]
 
-    import pytest
-
-    with pytest.raises(Exception, match="compile-time warp-uniform"):
-        run_passes_script(func)
+    run_passes_script(func)
+    warnings = capfd.readouterr().err
+    assert "no longer separates" in warnings, f"A premise that still allows divergence must not be accepted:\n{warnings}"
 
 
 def test_premise_holds_across_an_enclosing_guard():

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -377,6 +377,47 @@ def test_sync_shared_dyn_stmatrix_loop_hoist():
     assert s.index('T.tvm_storage_sync("shared.dyn")') < s.index("for i in T.unroll(8)")
 
 
+def test_unrolled_inplace_vector_update_has_no_loop_carry_sync():
+    """展开循环中互不重叠的原地向量更新不需要跨线程 barrier。"""
+
+    @T.prim_func(private=True)
+    def func():
+        S_shared = T.alloc_buffer((4096,), scope="shared.dyn")
+        scores_max = T.alloc_buffer((2,), scope="local")
+        logsum = T.alloc_buffer((2,), scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        if tx % 4 == 0:
+            for i in T.unroll(32):
+                S_shared[
+                    T.Ramp(
+                        tx // 32 * 1024 + i // 16 * 512 + tx % 32 // 4 * 64 + i % 16 * 4 - 4096,
+                        1,
+                        4,
+                    )
+                ] = T.exp2(
+                    S_shared[
+                        T.Ramp(
+                            tx // 32 * 1024 + i // 16 * 512 + tx % 32 // 4 * 64 + i % 16 * 4 - 4096,
+                            1,
+                            4,
+                        )
+                    ]
+                    - T.Broadcast(scores_max[i // 16], 4)
+                ) / T.Broadcast(logsum[i // 16], 4)
+
+    target = tvm.target.Target(
+        {"kind": "cuda", "arch": "sm_90", "thread_warp_size": 32, "max_num_threads": 1024},
+        host="llvm",
+    )
+    mod = tvm.IRModule({"main": func.with_attr({"global_symbol": "test", "target": target})})
+    mod = tilelang.transform.ThreadSync("shared.dyn")(mod)
+    s = str(mod.script())
+    assert 'T.tvm_storage_sync("shared.dyn")' not in s, f"Unexpected loop-carried sync:\n{s}"
+
+
 @tilelang.testing.requires_cuda
 def test_loop_carry_no_dependency_same_index():
     """Test that A[i] write followed by A[i] read in a loop does NOT need barrier.

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -977,6 +977,31 @@ def test_unorderable_hazard_in_divergent_else_branch_is_reported(capfd):
     assert "no longer separates" in warnings, f"Expected the pass to report the hazard:\n{warnings}"
 
 
+def test_safe_else_sync_survives_unsafe_then_condition(capfd):
+    """An unsafe then condition must not remove a valid else partial barrier."""
+    import re
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        if tx == 0 or tx >= 33:
+            l[0] = T.float32(0)
+        else:
+            s[tx] = T.cast(tx, "float32")
+            l[0] = s[33 - tx]
+
+    s = run_passes_script(func)
+    warnings = capfd.readouterr().err
+    assert re.search(r'tvm_storage_sync\("shared",\s*\d+,\s*32\)', s), f"Expected a 32-thread barrier:\n{s}"
+    assert s.index('T.tvm_storage_sync("shared"') > s.index("else:"), f"Barrier must stay in else branch:\n{s}"
+    assert "no longer separates" not in warnings, f"Safe else branch should not be hoisted:\n{warnings}"
+
+
 def test_sync_stays_inside_guard_proven_uniform_by_premise(capfd):
     """A premise can make a threadIdx-dependent guard provably block uniform.
 

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -775,8 +775,8 @@ def test_no_sync_for_thread_private_write_read_by_if_condition_in_loop():
 @tilelang.testing.requires_cuda
 def test_partial_sync_non_warp_multiple_rejected():
     """Regression test for issue #2556: a required barrier inside a divergent
-    region whose participating thread count is not a multiple of the warp size
-    must be a compile-time error, not silently dropped (data race)."""
+    region that splits a warp must be a compile-time error, not silently
+    dropped or lowered to an invalid partial barrier."""
     import pytest
 
     @T.prim_func(private=True)
@@ -796,7 +796,7 @@ def test_partial_sync_non_warp_multiple_rejected():
                 acc[0] += S[47 - tx]
 
     mod = tvm.IRModule({"main": func})
-    with pytest.raises(Exception, match="not a multiple of 32"):
+    with pytest.raises(Exception, match="compile-time warp-uniform"):
         tilelang.transform.ThreadSync("shared")(mod)
 
 
@@ -921,7 +921,7 @@ def test_no_plain_sync_inside_divergent_symbolic_guard():
         assert sync_pos < if_pos, f"Barrier must be hoisted out of the divergent guard:\n{s}"
 
 
-def test_unorderable_hazard_in_divergent_guard_is_reported(capfd):
+def test_unorderable_hazard_in_divergent_guard_is_rejected():
     """A hazard confined to a divergent branch has no correct barrier placement.
 
     ``bx * 4 + tx // 32 < n`` mixes a thread variable with a runtime parameter, so
@@ -929,8 +929,7 @@ def test_unorderable_hazard_in_divergent_guard_is_reported(capfd):
     that branch. A barrier inside it hangs on the threads that skip the branch,
     while one in front of it is reached by everyone but no longer separates the
     accesses. Ordering this needs the branch split around the barrier, which the
-    pass cannot express, so reporting the program is the only thing it can get
-    right. Where the barrier ends up is deliberately not asserted.
+    pass cannot express, so compilation must reject the program.
     """
 
     @T.prim_func(private=True)
@@ -945,17 +944,18 @@ def test_unorderable_hazard_in_divergent_guard_is_reported(capfd):
             s[tx] = T.cast(tx, "float32")
             l[0] = s[(tx + 64) % 128]
 
-    run_passes_script(func)
-    warnings = capfd.readouterr().err
-    assert "no longer separates" in warnings, f"Expected the pass to report the hazard:\n{warnings}"
+    import pytest
+
+    with pytest.raises(Exception, match="compile-time warp-uniform"):
+        run_passes_script(func)
 
 
-def test_unorderable_hazard_in_divergent_else_branch_is_reported(capfd):
+def test_unorderable_hazard_in_divergent_else_branch_is_rejected():
     """The else branch needs the same treatment as the then branch.
 
     Syncs found in either arm are tracked separately, so a hazard placed only in
     the else arm exercises the second of the two paths. It is as unorderable as
-    the one above, so again only the report is asserted.
+    the one above, so compilation must reject it as well.
     """
 
     @T.prim_func(private=True)
@@ -972,14 +972,38 @@ def test_unorderable_hazard_in_divergent_else_branch_is_reported(capfd):
             s[tx] = T.cast(tx, "float32")
             l[0] = s[(tx + 64) % 128]
 
-    run_passes_script(func)
-    warnings = capfd.readouterr().err
-    assert "no longer separates" in warnings, f"Expected the pass to report the hazard:\n{warnings}"
+    import pytest
+
+    with pytest.raises(Exception, match="compile-time warp-uniform"):
+        run_passes_script(func)
 
 
-def test_safe_else_sync_survives_unsafe_then_condition(capfd):
-    """An unsafe then condition must not remove a valid else partial barrier."""
+def test_aligned_else_partial_sync_is_preserved():
+    """A branch containing one complete warp can use a partial barrier."""
     import re
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        if tx >= 32:
+            l[0] = T.float32(0)
+        else:
+            s[tx] = T.cast(tx, "float32")
+            l[0] = s[31 - tx]
+
+    s = run_passes_script(func)
+    assert re.search(r'tvm_storage_sync\("shared",\s*\d+,\s*32\)', s), f"Expected a 32-thread barrier:\n{s}"
+    assert s.index('T.tvm_storage_sync("shared"') > s.index("else:"), f"Barrier must stay in else branch:\n{s}"
+
+
+def test_misaligned_else_partial_sync_is_rejected():
+    """Consecutive threads spanning two partial warps cannot use bar.sync."""
+    import pytest
 
     @T.prim_func(private=True)
     def func():
@@ -995,11 +1019,8 @@ def test_safe_else_sync_survives_unsafe_then_condition(capfd):
             s[tx] = T.cast(tx, "float32")
             l[0] = s[33 - tx]
 
-    s = run_passes_script(func)
-    warnings = capfd.readouterr().err
-    assert re.search(r'tvm_storage_sync\("shared",\s*\d+,\s*32\)', s), f"Expected a 32-thread barrier:\n{s}"
-    assert s.index('T.tvm_storage_sync("shared"') > s.index("else:"), f"Barrier must stay in else branch:\n{s}"
-    assert "no longer separates" not in warnings, f"Safe else branch should not be hoisted:\n{warnings}"
+    with pytest.raises(Exception, match="compile-time warp-uniform"):
+        run_passes_script(func)
 
 
 def test_sync_stays_inside_guard_proven_uniform_by_premise(capfd):
@@ -1034,13 +1055,13 @@ def test_sync_stays_inside_guard_proven_uniform_by_premise(capfd):
     assert "no longer separates" not in warnings, f"A provably uniform guard should not be reported:\n{warnings}"
 
 
-def test_premise_weaker_than_the_block_is_not_taken_as_uniform(capfd):
+def test_premise_weaker_than_the_block_is_rejected():
     """The premise has to rule divergence out for the block size actually used.
 
     ``n % 64 == 0`` with a block of 128 threads still admits ``n == 64``, where
     half the block enters. This pins down the boundary of the check above: it must
     accept a premise only when the premise really excludes divergence. The guard
-    is therefore treated as divergent, which for this shape means reported.
+    is therefore unsupported and must be rejected.
     """
 
     @T.prim_func(private=True)
@@ -1056,9 +1077,10 @@ def test_premise_weaker_than_the_block_is_not_taken_as_uniform(capfd):
                 s[tx] = T.cast(tx, "float32")
                 l[0] = s[(tx + 64) % 128]
 
-    run_passes_script(func)
-    warnings = capfd.readouterr().err
-    assert "no longer separates" in warnings, f"A premise that still allows divergence must not be accepted:\n{warnings}"
+    import pytest
+
+    with pytest.raises(Exception, match="compile-time warp-uniform"):
+        run_passes_script(func)
 
 
 def test_premise_holds_across_an_enclosing_guard():

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -377,47 +377,6 @@ def test_sync_shared_dyn_stmatrix_loop_hoist():
     assert s.index('T.tvm_storage_sync("shared.dyn")') < s.index("for i in T.unroll(8)")
 
 
-def test_unrolled_inplace_vector_update_has_no_loop_carry_sync():
-    """展开循环中互不重叠的原地向量更新不需要跨线程 barrier。"""
-
-    @T.prim_func(private=True)
-    def func():
-        S_shared = T.alloc_buffer((4096,), scope="shared.dyn")
-        scores_max = T.alloc_buffer((2,), scope="local")
-        logsum = T.alloc_buffer((2,), scope="local")
-        bx = T.launch_thread("blockIdx.x", 1)
-        tx = T.launch_thread("threadIdx.x", 128)
-        ty = T.launch_thread("threadIdx.y", 1)
-        tz = T.launch_thread("threadIdx.z", 1)
-        if tx % 4 == 0:
-            for i in T.unroll(32):
-                S_shared[
-                    T.Ramp(
-                        tx // 32 * 1024 + i // 16 * 512 + tx % 32 // 4 * 64 + i % 16 * 4 - 4096,
-                        1,
-                        4,
-                    )
-                ] = T.exp2(
-                    S_shared[
-                        T.Ramp(
-                            tx // 32 * 1024 + i // 16 * 512 + tx % 32 // 4 * 64 + i % 16 * 4 - 4096,
-                            1,
-                            4,
-                        )
-                    ]
-                    - T.Broadcast(scores_max[i // 16], 4)
-                ) / T.Broadcast(logsum[i // 16], 4)
-
-    target = tvm.target.Target(
-        {"kind": "cuda", "arch": "sm_90", "thread_warp_size": 32, "max_num_threads": 1024},
-        host="llvm",
-    )
-    mod = tvm.IRModule({"main": func.with_attr({"global_symbol": "test", "target": target})})
-    mod = tilelang.transform.ThreadSync("shared.dyn")(mod)
-    s = str(mod.script())
-    assert 'T.tvm_storage_sync("shared.dyn")' not in s, f"Unexpected loop-carried sync:\n{s}"
-
-
 @tilelang.testing.requires_cuda
 def test_loop_carry_no_dependency_same_index():
     """Test that A[i] write followed by A[i] read in a loop does NOT need barrier.
@@ -837,7 +796,7 @@ def test_partial_sync_non_warp_multiple_rejected():
                 acc[0] += S[47 - tx]
 
     mod = tvm.IRModule({"main": func})
-    with pytest.raises(Exception, match="compile-time warp-uniform"):
+    with pytest.raises(Exception, match="not warp-uniform"):
         tilelang.transform.ThreadSync("shared")(mod)
 
 
@@ -866,89 +825,6 @@ def test_partial_sync_warp_multiple_still_lowered():
     mod = tilelang.transform.ThreadSync("shared")(mod)
     s = str(mod.script())
     assert re.search(r'tvm_storage_sync\("shared",\s*\d+,\s*32\)', s), f"Expected a partial barrier with thread_count=32:\n{s}"
-
-
-def test_masked_warp_sync_orders_only_intra_warp_hazards():
-    """ballot 掩码生成的 warp barrier 足以排序同一 warp 内的冲突。"""
-
-    @T.prim_func(private=True)
-    def func():
-        S = T.alloc_buffer((64,), dtype="float32", scope="shared")
-        acc = T.alloc_buffer((1,), dtype="float32", scope="local")
-        bx = T.launch_thread("blockIdx.x", 1)
-        tx = T.launch_thread("threadIdx.x", 64)
-        ty = T.launch_thread("threadIdx.y", 1)
-        tz = T.launch_thread("threadIdx.z", 1)
-        active_mask = T.bind(T.cast(T.call_intrin("uint64", tvm.tirx.op.Op.get("tl.activemask")), "uint32"))
-        participant_mask = T.bind(
-            T.cast(
-                T.call_intrin("uint64", tvm.tirx.op.Op.get("tl.ballot_sync"), active_mask, tx % 4 == 0),
-                "uint32",
-            )
-        )
-        if tx % 4 == 0:
-            acc[0] = S[tx // 32 * 32 + (tx + 4) % 32]
-            T.evaluate(T.call_intrin("void", tvm.tirx.op.Op.get("tl.sync_warp"), participant_mask))
-            S[tx] = acc[0]
-
-    s = run_passes_script(func)
-    assert "T.tvm_storage_sync" not in s, f"Masked warp sync should order the intra-warp hazard:\n{s}"
-
-
-def test_masked_warp_sync_does_not_order_cross_warp_hazards():
-    """warp barrier 不能掩盖跨 warp 的共享内存冲突。"""
-    import pytest
-
-    @T.prim_func(private=True)
-    def func():
-        S = T.alloc_buffer((64,), dtype="float32", scope="shared")
-        acc = T.alloc_buffer((1,), dtype="float32", scope="local")
-        bx = T.launch_thread("blockIdx.x", 1)
-        tx = T.launch_thread("threadIdx.x", 64)
-        ty = T.launch_thread("threadIdx.y", 1)
-        tz = T.launch_thread("threadIdx.z", 1)
-        active_mask = T.bind(T.cast(T.call_intrin("uint64", tvm.tirx.op.Op.get("tl.activemask")), "uint32"))
-        participant_mask = T.bind(
-            T.cast(
-                T.call_intrin("uint64", tvm.tirx.op.Op.get("tl.ballot_sync"), active_mask, tx % 4 == 0),
-                "uint32",
-            )
-        )
-        if tx % 4 == 0:
-            acc[0] = S[(tx + 32) % 64]
-            T.evaluate(T.call_intrin("void", tvm.tirx.op.Op.get("tl.sync_warp"), participant_mask))
-            S[tx] = acc[0]
-
-    with pytest.raises(Exception, match="compile-time warp-uniform"):
-        run_passes_script(func)
-
-
-def test_rocm_subwarp_allreduce_keeps_masked_warp_sync():
-    """ROCm 子 warp allreduce 不应被补入非法的 shared barrier。"""
-
-    @T.prim_func(private=True)
-    def func(A: T.Buffer((8,), "float32"), C: T.Buffer((1,), "float32")):
-        bx = T.launch_thread("blockIdx.x", 1)
-        tx = T.launch_thread("threadIdx.x", 8)
-        ty = T.launch_thread("threadIdx.y", 1)
-        tz = T.launch_thread("threadIdx.z", 1)
-        value = T.alloc_buffer((1,), "float32", scope="local")
-        result = T.alloc_buffer((1,), "float32", scope="local")
-        value[0] = A[tx]
-        with T.attr(
-            T.comm_reducer(lambda x, y: x + y, [T.float32(0)]),
-            "reduce_scope",
-            T.reinterpret(T.uint64(0), dtype="handle"),
-        ):
-            T.tvm_thread_allreduce(T.uint32(1), value[0], T.bool(True), result[0], tx)
-        C[0] = result[0]
-
-    target = tvm.target.Target({"kind": "rocm", "thread_warp_size": 64, "max_num_threads": 1024}, host="llvm")
-    mod = tvm.IRModule({"main": func.with_attr({"global_symbol": "test", "target": target})})
-    mod = tilelang.transform.LowerThreadAllreduce()(mod)
-    mod = tilelang.transform.ThreadSync("shared")(mod)
-    s = str(mod.script())
-    assert "T.sync_warp" in s, f"Expected the masked warp synchronization to remain:\n{s}"
 
 
 # =============================================================================
@@ -1045,7 +921,7 @@ def test_no_plain_sync_inside_divergent_symbolic_guard():
         assert sync_pos < if_pos, f"Barrier must be hoisted out of the divergent guard:\n{s}"
 
 
-def test_unorderable_hazard_in_divergent_guard_is_rejected():
+def test_unorderable_hazard_in_divergent_guard_is_reported(capfd):
     """A hazard confined to a divergent branch has no correct barrier placement.
 
     ``bx * 4 + tx // 32 < n`` mixes a thread variable with a runtime parameter, so
@@ -1053,7 +929,8 @@ def test_unorderable_hazard_in_divergent_guard_is_rejected():
     that branch. A barrier inside it hangs on the threads that skip the branch,
     while one in front of it is reached by everyone but no longer separates the
     accesses. Ordering this needs the branch split around the barrier, which the
-    pass cannot express, so compilation must reject the program.
+    pass cannot express, so reporting the program is the only thing it can get
+    right. Where the barrier ends up is deliberately not asserted.
     """
 
     @T.prim_func(private=True)
@@ -1068,18 +945,17 @@ def test_unorderable_hazard_in_divergent_guard_is_rejected():
             s[tx] = T.cast(tx, "float32")
             l[0] = s[(tx + 64) % 128]
 
-    import pytest
+    run_passes_script(func)
+    warnings = capfd.readouterr().err
+    assert "no longer separates" in warnings, f"Expected the pass to report the hazard:\n{warnings}"
 
-    with pytest.raises(Exception, match="compile-time warp-uniform"):
-        run_passes_script(func)
 
-
-def test_unorderable_hazard_in_divergent_else_branch_is_rejected():
+def test_unorderable_hazard_in_divergent_else_branch_is_reported(capfd):
     """The else branch needs the same treatment as the then branch.
 
     Syncs found in either arm are tracked separately, so a hazard placed only in
     the else arm exercises the second of the two paths. It is as unorderable as
-    the one above, so compilation must reject it as well.
+    the one above, so again only the report is asserted.
     """
 
     @T.prim_func(private=True)
@@ -1096,14 +972,13 @@ def test_unorderable_hazard_in_divergent_else_branch_is_rejected():
             s[tx] = T.cast(tx, "float32")
             l[0] = s[(tx + 64) % 128]
 
-    import pytest
-
-    with pytest.raises(Exception, match="compile-time warp-uniform"):
-        run_passes_script(func)
+    run_passes_script(func)
+    warnings = capfd.readouterr().err
+    assert "no longer separates" in warnings, f"Expected the pass to report the hazard:\n{warnings}"
 
 
 def test_aligned_else_partial_sync_is_preserved():
-    """A branch containing one complete warp can use a partial barrier."""
+    """An unsafe 16-thread then arm must not remove a valid else warp barrier."""
     import re
 
     @T.prim_func(private=True)
@@ -1111,7 +986,7 @@ def test_aligned_else_partial_sync_is_preserved():
         s = T.alloc_buffer((64,), dtype="float32", scope="shared")
         l = T.alloc_buffer((1,), dtype="float32", scope="local")
         bx = T.launch_thread("blockIdx.x", 1)
-        tx = T.launch_thread("threadIdx.x", 128)
+        tx = T.launch_thread("threadIdx.x", 48)
         ty = T.launch_thread("threadIdx.y", 1)
         tz = T.launch_thread("threadIdx.z", 1)
         if tx >= 32:
@@ -1143,30 +1018,7 @@ def test_misaligned_else_partial_sync_is_rejected():
             s[tx] = T.cast(tx, "float32")
             l[0] = s[33 - tx]
 
-    with pytest.raises(Exception, match="compile-time warp-uniform"):
-        run_passes_script(func)
-
-
-def test_explicit_misaligned_else_partial_sync_is_rejected():
-    """显式 barrier 也不能绕过非 warp 对齐参与集合的校验。"""
-    import pytest
-
-    @T.prim_func(private=True)
-    def func():
-        s = T.alloc_buffer((64,), dtype="float32", scope="shared")
-        l = T.alloc_buffer((1,), dtype="float32", scope="local")
-        bx = T.launch_thread("blockIdx.x", 1)
-        tx = T.launch_thread("threadIdx.x", 128)
-        ty = T.launch_thread("threadIdx.y", 1)
-        tz = T.launch_thread("threadIdx.z", 1)
-        if tx == 0 or tx >= 33:
-            l[0] = T.float32(0)
-        else:
-            s[tx] = T.cast(tx, "float32")
-            T.tvm_storage_sync("shared")
-            l[0] = s[33 - tx]
-
-    with pytest.raises(Exception, match="compile-time warp-uniform"):
+    with pytest.raises(Exception, match="not warp-uniform"):
         run_passes_script(func)
 
 
@@ -1202,13 +1054,13 @@ def test_sync_stays_inside_guard_proven_uniform_by_premise(capfd):
     assert "no longer separates" not in warnings, f"A provably uniform guard should not be reported:\n{warnings}"
 
 
-def test_premise_weaker_than_the_block_is_rejected():
+def test_premise_weaker_than_the_block_is_not_taken_as_uniform(capfd):
     """The premise has to rule divergence out for the block size actually used.
 
     ``n % 64 == 0`` with a block of 128 threads still admits ``n == 64``, where
     half the block enters. This pins down the boundary of the check above: it must
     accept a premise only when the premise really excludes divergence. The guard
-    is therefore unsupported and must be rejected.
+    is therefore treated as divergent, which for this shape means reported.
     """
 
     @T.prim_func(private=True)
@@ -1224,10 +1076,9 @@ def test_premise_weaker_than_the_block_is_rejected():
                 s[tx] = T.cast(tx, "float32")
                 l[0] = s[(tx + 64) % 128]
 
-    import pytest
-
-    with pytest.raises(Exception, match="compile-time warp-uniform"):
-        run_passes_script(func)
+    run_passes_script(func)
+    warnings = capfd.readouterr().err
+    assert "no longer separates" in warnings, f"A premise that still allows divergence must not be accepted:\n{warnings}"
 
 
 def test_premise_holds_across_an_enclosing_guard():

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -882,6 +882,34 @@ def test_masked_warp_sync_does_not_order_cross_warp_hazards():
         run_passes_script(func)
 
 
+def test_rocm_subwarp_allreduce_keeps_masked_warp_sync():
+    """ROCm 子 warp allreduce 不应被补入非法的 shared barrier。"""
+
+    @T.prim_func(private=True)
+    def func(A: T.Buffer((8,), "float32"), C: T.Buffer((1,), "float32")):
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 8)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        value = T.alloc_buffer((1,), "float32", scope="local")
+        result = T.alloc_buffer((1,), "float32", scope="local")
+        value[0] = A[tx]
+        with T.attr(
+            T.comm_reducer(lambda x, y: x + y, [T.float32(0)]),
+            "reduce_scope",
+            T.reinterpret(T.uint64(0), dtype="handle"),
+        ):
+            T.tvm_thread_allreduce(T.uint32(1), value[0], T.bool(True), result[0], tx)
+        C[0] = result[0]
+
+    target = tvm.target.Target({"kind": "rocm", "thread_warp_size": 64, "max_num_threads": 1024}, host="llvm")
+    mod = tvm.IRModule({"main": func.with_attr({"global_symbol": "test", "target": target})})
+    mod = tilelang.transform.LowerThreadAllreduce()(mod)
+    mod = tilelang.transform.ThreadSync("shared")(mod)
+    s = str(mod.script())
+    assert "T.sync_warp" in s, f"Expected the masked warp synchronization to remain:\n{s}"
+
+
 # =============================================================================
 # Tests for flat Bind definitions inside the recorded constraint sets
 #


### PR DESCRIPTION
Fixes #3042.

## What went wrong

`ThreadSync` was checking only the `then` condition when it decided if a barrier had to be moved out of an `if`. If that check said yes, it removed barriers from **both** the `then` and `else` branches.

That is not always right becuase the two branches can have different sets of participating threads. A barrier may be unsafe in `then`, but still be a perfectly valid partial barrier in `else`.

## Small repro

The test uses 128 threads and this branch:

```python
if tx == 0 or tx >= 33:
    l[0] = 0.0
else:
    s[tx] = T.cast(tx, "float32")
    l[0] = s[33 - tx]
```

Only threads `1..32` enter the `else`. They all write shared memory first, then read the value written by another thread (`1 <-> 32`, `2 <-> 31`, etc), so we need a 32-thread partial barrier between those two ops.

Before this fix the pass looked at the `then` condition, decided to hoist, and generated something like:

```python
T.tvm_storage_sync("shared")
if tx == 0 or tx >= 33:
    ...
else:
    s[tx] = ...
    l[0] = s[33 - tx]
```

The barrier is now before both accesses, so it doesnt order anything inside `else`. One warp can read before the other warp writes and get an old/uninitialized value.

## Fix

Check the branches seperately:

- use `op->condition` for `then`
- use `Not(op->condition)` for `else`
- only remove syncs from the branch that actually needs hoisting

After the fix the reprodcuer keeps this in the `else` branch:

```python
s[tx] = ...
T.tvm_storage_sync("shared", barrier_id, 32)
l[0] = s[33 - tx]
```

## When it triggers

It needs this combo:

1. `ThreadSync` finds a cross-thread shared-memory dependency inside one arm of an `IfThenElse`.
2. The two arms have different partial-barrier participation patterns.
3. The old decision based on the `then` condition gets applied to syncs from both arms.

## Tested

- rebuilt with cmake
- full `test_tilelang_transform_thread_sync.py`: `21 passed, 21 skipped` on my Mac
- pre-commit passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes `ThreadSync` barrier handling for `IfThenElse` branches.

- Analyzes each branch with its own condition.
- Removes synchronization only from the branch that requires hoisting.
- Preserves required partial barriers in the `else` branch.
- Prevents shared-memory read/write conflicts.
- Adds masked warp-sync handling for ballot-derived masks.
- Rejects non-warp-uniform synchronization conditions.
- Adds regression coverage for partial barriers, explicit synchronization, and masked warp synchronization.

## Validation

- 21 tests passed.
- 21 tests skipped.
- CMake rebuild passed.
- Pre-commit checks passed.

## C++ style / lint notes

The change touches C++ implementation code but does not modify rules in `docs/developer_guide/cpp_style.md`.

The C++ API Style Audit runs in warning-only mode. Any TLCPP003/TLCPP004 findings are advisory and separate from correctness, build, and test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->