### PR TITLE
[Bugfix] Fix wait parity for explicit mbarriers in pipelined loops

### DIFF
--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -117,8 +117,7 @@ struct LowerArgs {
   ffi::Map<tirx::Var, PrimExpr> bind_var_to_expr;
   // Fallback mbarrier parity for ops that do not carry an explicit
   // tl.pipeline_mbar_phase_expr annotation. LowerTileOp derives this from the
-  // nearest enclosing serial loop so non-pipelined TMA loops still alternate
-  // barrier phase correctly.
+  // zero-based epoch of the nearest enclosing serial loop.
   PrimExpr mbar_phase_expr = IntImm(DataType::Int(32), 0);
   // Pointer to the shared.barrier buffer for compiler-generated mbarriers.
   // Points to the LowerTileOpPass member so copy.cc sees the buffer

--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -334,11 +334,24 @@ private:
     return Call(call->dtype, call->op, call->args, annotations, call->span);
   }
 
+  // Ops that auto-emit a paired arrive+wait on an explicit (user-allocated)
+  // mbarrier: sync gemm with an mbar (isTcgen05_ marks the explicit-async
+  // T.tcgen05_gemm op, which never waits) and copies with an explicit
+  // "barrier". The paired wait assumes the slot flips once per op invocation,
+  // so the parity is the op's logical iteration parity. Pipeline-managed TMA
+  // copies (is_tma_copy) carry their ring parity in explicit waits, and
+  // compiler-generated copy/im2col barriers are allocated per emitted site,
+  // so LowerTileOp derives their phase from that site's enclosing loop.
   bool IsMbarPhaseConsumer(const Call &call) const {
     auto tile_op = ParseOperator(call);
-    return tile_op.defined() && (tile_op.as<CopyNode>() != nullptr ||
-                                 tile_op.as<Im2ColOpNode>() != nullptr ||
-                                 tile_op.as<GemmNode>() != nullptr);
+    if (const auto *gemm = tile_op.as<GemmNode>()) {
+      return gemm->mbar_.defined() && !gemm->isTcgen05_;
+    }
+    if (const auto *copy = tile_op.as<CopyNode>()) {
+      return !GetIsTmaCopy(*copy) &&
+             copy->annotations.Get("barrier").has_value();
+    }
+    return false;
   }
 
   PrimExpr phase_expr_;
@@ -1742,25 +1755,6 @@ private:
     const PipelineRewriter *rewriter_;
   };
 
-  Optional<PrimExpr>
-  ComputePipelineMbarPhaseExpr(const PrimExpr &normalized_access_index,
-                               const Optional<Integer> &pipeline_num_stages) {
-    if (!pipeline_num_stages) {
-      return Optional<PrimExpr>();
-    }
-    PrimExpr parity_expr;
-    if (pipeline_num_stages.value().IntValue() <= 1) {
-      parity_expr =
-          FloorMod(normalized_access_index, IntImm(DataType::Int(32), 2));
-    } else {
-      PrimExpr ns =
-          IntImm(DataType::Int(32), pipeline_num_stages.value().IntValue());
-      parity_expr = FloorMod(FloorDiv(normalized_access_index, ns),
-                             IntImm(DataType::Int(32), 2));
-    }
-    return analyzer_.Simplify(parity_expr);
-  }
-
   static bool IsAsyncCommitQueueScope(const AttrStmtNode *attr) {
     return attr && attr->attr_key == s_tir::attr::async_commit_queue_scope;
   }
@@ -2834,6 +2828,11 @@ private:
     PrimExpr extent = end - start;
     Optional<Integer> pipeline_num_stages =
         GetPipelineNumStages(pipeline_loop_.get());
+    // Written against the original loop var; the per-block Substitute below
+    // specializes it into each op's logical iteration parity.
+    PrimExpr mbar_phase = analyzer_.Simplify(
+        FloorMod(pipeline_loop_->loop_var - pipeline_loop_->min,
+                 make_const(pipeline_loop_->loop_var.dtype(), 2)));
     auto make_nop = []() {
       return SBlockRealize({}, Bool(true), MakeBlock(Evaluate(0), {}));
     };
@@ -2899,9 +2898,11 @@ private:
             pipeline_loop_->min <= skewed_loop_var,
             (skewed_loop_var < pipeline_loop_->min + pipeline_loop_->extent));
 
-      SBlock new_block = Downcast<SBlock>(
-          PipelineBodyRewriter(buffer_data_to_buffer_, buffer_remap_,
-                               pipeline_loop_, max_stage_ != 1)(block));
+      SBlock annotated_block =
+          Downcast<SBlock>(AnnotateTileOpMbarPhase(block, mbar_phase));
+      SBlock new_block = Downcast<SBlock>(PipelineBodyRewriter(
+          buffer_data_to_buffer_, buffer_remap_, pipeline_loop_,
+          max_stage_ != 1)(annotated_block));
 
       PrimExpr delta = start - pipeline_loop_->min;
       PrimExpr normalized_access_index =
@@ -2925,8 +2926,6 @@ private:
       new_block = ReplayScalarBindings(new_block, normalized_access_index);
 
       Stmt rewritten_stmt = SBlockRealize({}, inbound, new_block);
-      Optional<PrimExpr> pipeline_mbar_phase = ComputePipelineMbarPhaseExpr(
-          normalized_access_index, pipeline_num_stages);
 
       bool is_async = pipeline_anno.async;
       if (is_async) {
@@ -2974,11 +2973,6 @@ private:
         }
         rewritten_stmt = AnnotateSimtProducer(rewritten_stmt, target_);
       }
-      if (pipeline_mbar_phase) {
-        rewritten_stmt = AnnotateTileOpMbarPhase(rewritten_stmt,
-                                                 pipeline_mbar_phase.value());
-      }
-
       new_stmts.push_back({stage, inbound, new_block->reads, new_block->writes,
                            normalized_access_index, is_async, rewritten_stmt});
 

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -229,10 +229,9 @@ public:
     }
     fptr = f.CopyOnWrite();
 
-    // If any TMA copies allocated mbarriers, inject the barrier buffer
-    // into the tilelang_root block with a barrier_init annotation.
-    // Pipeline buffer versioning expands it for pipelining, and
-    // LowerSharedBarrier will process it into ptx_init_barrier_thread_count.
+    // If any tile ops allocated mbarriers, inject their barrier buffer into
+    // the tilelang_root block. Each lowered tile-op site owns one slot;
+    // LowerSharedBarrier emits the corresponding initialization.
     if (substituter.mbarrier_count_ > 0) {
       ICHECK(substituter.mbarrier_buffer_.defined())
           << "mbarrier_buffer_ must have been created by alloc_mbarrier "
@@ -1193,24 +1192,16 @@ private:
   Stmt VisitStmt_(const ForNode *op) final {
     bool pushed_loop_mbar_phase = false;
     if (op->kind == ForKind::kSerial) {
-      int num_stages = 1;
-      if (auto ns_anno = op->annotations.Get("num_stages")) {
-        if (const auto *ns_int = ns_anno.value().as<IntImmNode>()) {
-          if (ns_int->value > 1) {
-            num_stages = static_cast<int>(ns_int->value);
-          }
-        }
-      }
-      PrimExpr phase_expr;
+      // Compiler-generated barriers are allocated per lowered tile-op site, so
+      // their phase follows this loop's invocation count, not pipeline depth.
       DataType loop_dtype = op->loop_var.dtype();
-      PrimExpr two = make_const(loop_dtype, 2);
-      if (num_stages > 1) {
-        PrimExpr num_stages_expr = make_const(loop_dtype, num_stages);
-        phase_expr = FloorMod(FloorDiv(op->loop_var, num_stages_expr), two);
-      } else {
-        phase_expr = FloorMod(op->loop_var, two);
-      }
-      loop_mbar_phase_stack_.push_back(analyzer_->Simplify(phase_expr));
+      PrimExpr step = op->step.defined() ? op->step.value()
+                                         : PrimExpr(make_const(loop_dtype, 1));
+      PrimExpr loop_epoch =
+          analyzer_->Simplify(FloorDiv(op->loop_var - op->min, step));
+      PrimExpr phase =
+          analyzer_->Simplify(FloorMod(loop_epoch, make_const(loop_dtype, 2)));
+      loop_mbar_phase_stack_.push_back(phase);
       pushed_loop_mbar_phase = true;
     }
 
@@ -1485,7 +1476,7 @@ private:
   std::vector<int> mbarrier_arrive_counts_;
   // The shared.barrier scope buffer created lazily by alloc_mbarrier callback.
   Optional<Buffer> mbarrier_buffer_;
-  // Fallback mbarrier parity derived from the nearest enclosing serial loop.
+  // Fallback phase for a tile-op barrier local to the nearest serial loop.
   std::vector<PrimExpr> loop_mbar_phase_stack_;
   // For ptx Node, we need to remap the buffer and indices
   // By access CallNode instead of BufferLoad Node.

--- a/testing/python/language/test_tilelang_language_tcgen05_gemm.py
+++ b/testing/python/language/test_tilelang_language_tcgen05_gemm.py
@@ -808,3 +808,56 @@ def test_tcgen05_ts_gemm_tmem_a_correctness(M, K):
     b = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
     ref = a.float() @ b.float().T
     torch.testing.assert_close(kernel(a, b), ref, rtol=2e-2, atol=2e-2)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+@pytest.mark.parametrize("num_stages", [2, 3])
+def test_sync_tcgen05_gemm_pipelined_wait_parity(num_stages):
+    """A synchronous T.gemm(mbar=...) inside T.Pipelined uses a single user
+    barrier that flips once per iteration, so the auto-emitted wait parity is
+    k % 2 regardless of num_stages. The old ring parity was wrong for every
+    num_stages > 1 and could let a later copy overwrite shared memory while an
+    MMA was still reading it.
+    """
+    import torch
+
+    M = N = K = 2048
+    block_M = block_N = 128
+    block_K = 64
+    dtype, accum_dtype = T.bfloat16, T.float32
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), dtype),
+        B: T.Tensor((N, K), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(M, block_M), T.ceildiv(N, block_N), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), dtype)
+            B_shared = T.alloc_shared((block_N, block_K), dtype)
+            C_tmem = T.alloc_tmem([block_M, block_N], accum_dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            mbar = T.alloc_barrier(1)
+
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                T.copy(A[bx * block_M, k * block_K], A_shared)
+                T.copy(B[by * block_N, k * block_K], B_shared)
+                T.gemm(A_shared, B_shared, C_tmem, transpose_B=True, clear_accum=k == 0, mbar=mbar)
+
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, C[bx * block_M, by * block_N])
+
+    kernel = tilelang.compile(
+        main,
+        target="cuda",
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )
+    torch.manual_seed(0)
+    a = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
+    c = torch.zeros(M, N, device="cuda", dtype=torch.bfloat16)
+    kernel(a, b, c)
+    ref = a.float() @ b.float().T
+    torch.testing.assert_close(c.float(), ref, rtol=2e-2, atol=2e-2)

--- a/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
+++ b/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
@@ -59,6 +59,20 @@ def _collect_attr_value_nodes(func, attr_key):
     return values
 
 
+def _collect_call_annotation_values(root, op_name, annotation_key):
+    values = []
+
+    def _visit(node):
+        if not isinstance(node, tvm.tirx.Call) or not isinstance(node.op, tvm.ir.Op):
+            return
+        if str(node.op.name) != op_name or annotation_key not in node.annotations:
+            return
+        values.append(node.annotations[annotation_key])
+
+    post_order_visit(root.body if hasattr(root, "body") else root, _visit)
+    return values
+
+
 def _collect_wait_args(func):
     wait_args = []
     stmt = func.body if hasattr(func, "body") else func
@@ -338,6 +352,41 @@ def test_async_pipeline_marks_copy_ops_for_pipeline_managed_cp_async_sync():
     annotated, total = _count_copy_calls_with_annotation(mod["main"], "no_implicit_async_commit_wait")
     assert total > 0
     assert annotated == total
+
+
+@pytest.mark.parametrize("num_stages", [2, 3])
+def test_pipeline_explicit_gemm_mbar_uses_logical_epoch(num_stages):
+    @T.prim_func
+    def before(
+        A: T.Tensor((9, 16, 16), T.float16),
+        B: T.Tensor((9, 16, 16), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((16, 16), T.float16)
+            B_shared = T.alloc_shared((16, 16), T.float16)
+            C_local = T.alloc_fragment((16, 16), T.float32)
+            mbar = T.alloc_barrier(1)
+            for i in T.serial(
+                3,
+                9,
+                annotations={
+                    "software_pipeline_stage": [0, 0, num_stages - 1],
+                    "software_pipeline_order": [0, 1, 2],
+                    "tl_pipelined_num_stages": T.int32(num_stages),
+                },
+            ):
+                T.copy(A[i, 0:16, 0:16], A_shared)
+                T.copy(B[i, 0:16, 0:16], B_shared)
+                T.gemm(A_shared, B_shared, C_local, mbar=mbar)
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = tl.transform.InjectSoftwarePipeline()(mod)
+    loop = _find_pipelined_loop(mod["main"])
+    phases = _collect_call_annotation_values(loop, "tl.tileop.gemm", "tl.pipeline_mbar_phase_expr")
+
+    assert len(phases) == 1
+    expected = (loop.loop_var - loop.min) % 2
+    assert tvm.arith.Analyzer().can_prove_equal(phases[0], expected)
 
 
 def test_async_pipeline_does_not_mark_non_cp_async_compatible_copy():

--- a/testing/python/transform/test_tilelang_transform_lower_tile_op.py
+++ b/testing/python/transform/test_tilelang_transform_lower_tile_op.py
@@ -1,5 +1,6 @@
-"""Tests for TileLang `LowerTileOp` copy annotations affecting cp.async sync."""
+"""Tests for TileLang `LowerTileOp` synchronization and copy lowering."""
 
+import pytest
 import tilelang as tl
 import tilelang.language as T
 import tilelang.testing
@@ -17,6 +18,29 @@ def _count_calls(func: tvm.tirx.PrimFunc):
 
     post_order_visit(func.body, _visit)
     return counts
+
+
+def _collect_calls(root, op_name: str):
+    calls = []
+
+    def _visit(node):
+        if isinstance(node, tvm.tirx.Call) and isinstance(node.op, tvm.ir.Op) and str(node.op.name).endswith(op_name):
+            calls.append(node)
+
+    post_order_visit(root.body if hasattr(root, "body") else root, _visit)
+    return calls
+
+
+def _find_loop_with_annotation(func: tvm.tirx.PrimFunc, annotation: str):
+    loops = []
+
+    def _visit(node):
+        if isinstance(node, tvm.tirx.For) and annotation in node.annotations:
+            loops.append(node)
+
+    post_order_visit(func.body, _visit)
+    assert len(loops) == 1, f"Expected one loop with {annotation}, got {len(loops)}"
+    return loops[0]
 
 
 @tilelang.testing.requires_cuda
@@ -77,6 +101,108 @@ def test_lower_tile_op_respects_copy_annotation_for_explicit_async_copy():
     assert calls.get("tl.ptx_cp_async", 0) > 0
     assert calls.get("tirx.ptx_commit_group", 0) == 0
     assert calls.get("tirx.ptx_wait_group", 0) == 0
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("num_stages", [2, 3])
+def test_pipelined_tma_copy_compiler_generated_barrier_uses_emitted_loop_epoch(num_stages):
+    target = tvm.target.Target({"kind": "cuda", "arch": "sm_90a"})
+
+    @T.prim_func
+    def before(
+        A: T.Tensor((9, 16), T.float16),
+        B: T.Tensor((9, 16), T.float16),
+    ):
+        with T.Kernel(1, threads=32):
+            shared = T.alloc_shared((16,), T.float16)
+            for i in T.serial(
+                3,
+                9,
+                annotations={
+                    "software_pipeline_stage": [0, num_stages - 1],
+                    "software_pipeline_order": [0, 1],
+                    "tl_pipelined_num_stages": T.int32(num_stages),
+                },
+            ):
+                T.copy(A[i, 0:16], shared, prefer_instruction="tma")
+                T.copy(shared, B[i, 0:16], prefer_instruction="sync")
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = tvm.tirx.transform.BindTarget(target)(mod)
+    with target:
+        mod = tl.transform.InjectSoftwarePipeline()(mod)
+        copy_calls = _collect_calls(mod["main"], "tileop.copy")
+        assert all("tl.pipeline_mbar_phase_expr" not in call.annotations for call in copy_calls)
+        mod = tl.transform.LayoutInference()(mod)
+        mod = tl.transform.LowerTileOp()(mod)
+
+    func = mod["main"]
+    waits = _collect_calls(func, "mbarrier_wait_parity")
+    loop = _find_loop_with_annotation(func, "tl_pipelined_num_stages")
+    loop_waits = _collect_calls(loop, "mbarrier_wait_parity")
+
+    assert len(waits) == num_stages
+    assert len(loop_waits) == 1
+    barrier_indices = [int(wait.args[0].indices[0]) for wait in waits]
+    assert sorted(barrier_indices) == list(range(num_stages))
+    simplified_phases = [tvm.arith.Analyzer().simplify(wait.args[1]) for wait in waits]
+    constant_phases = [int(phase) for phase in simplified_phases if isinstance(phase, tvm.tirx.IntImm)]
+    assert constant_phases == [0] * (num_stages - 1)
+    expected = (loop.loop_var - loop.min) % 2
+    assert tvm.arith.Analyzer().can_prove_equal(loop_waits[0].args[1], expected)
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("num_stages", [2, 3])
+def test_pipelined_tma_copy_explicit_mbar_uses_logical_epoch(num_stages):
+    target = tvm.target.Target({"kind": "cuda", "arch": "sm_90a"})
+
+    @T.prim_func
+    def before(
+        A: T.Tensor((9, 16), T.float16),
+        B: T.Tensor((9, 16), T.float16),
+    ):
+        with T.Kernel(1, threads=32):
+            shared = T.alloc_shared((16,), T.float16)
+            mbar = T.alloc_barrier(1)
+            for i in T.serial(
+                3,
+                9,
+                annotations={
+                    "software_pipeline_stage": [0, num_stages - 1],
+                    "software_pipeline_order": [0, 1],
+                    "tl_pipelined_num_stages": T.int32(num_stages),
+                },
+            ):
+                T.copy(
+                    A[i, 0:16],
+                    shared,
+                    prefer_instruction="tma",
+                    annotations={"barrier": mbar[0]},
+                )
+                T.copy(shared, B[i, 0:16], prefer_instruction="sync")
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = tvm.tirx.transform.BindTarget(target)(mod)
+    with target:
+        mod = tl.transform.InjectSoftwarePipeline()(mod)
+        mod = tl.transform.LayoutInference()(mod)
+        mod = tl.transform.LowerTileOp()(mod)
+
+    func = mod["main"]
+    waits = _collect_calls(func, "mbarrier_wait_parity")
+    loop = _find_loop_with_annotation(func, "tl_pipelined_num_stages")
+    loop_waits = _collect_calls(loop, "mbarrier_wait_parity")
+
+    assert len(waits) == num_stages
+    assert len(loop_waits) == 1
+    barrier_indices = [int(wait.args[0].indices[0]) for wait in waits]
+    assert barrier_indices == [0] * num_stages
+    simplified_phases = [tvm.arith.Analyzer().simplify(wait.args[1]) for wait in waits]
+    constant_phases = [int(phase) for phase in simplified_phases if isinstance(phase, tvm.tirx.IntImm)]
+    assert constant_phases == [i % 2 for i in range(num_stages - 1)]
+    logical_epoch = loop.loop_var - loop.min + num_stages - 1
+    assert tvm.arith.Analyzer().can_prove_equal(loop_waits[0].args[1], logical_epoch % 2)
 
 
 def test_lower_tile_op_respects_parallel_loop_async_annotation_without_pipeline_context():


### PR DESCRIPTION
A synchronous T.gemm(mbar=...) inside T.Pipelined waited on the wrong mbarrier parity. InjectSoftwarePipeline annotated every copy/im2col/gemm call with the ring parity (k / num_stages) % 2, but that law belongs to the compiler-generated pipeline_mbar ring: an explicit mbarrier whose arrive happens inside a tile op is deliberately excluded from ExpandPipelineBarriers, so it remains a single slot that flips once per iteration. The auto-emitted wait asked for a parity that had already completed, returned immediately, and the next iteration's copies overwrote a shared-memory stage the still-running MMA was reading (wrong results observed at num_stages >= 3).

Annotate only the ops that consume the phase -- those that auto-emit a paired arrive+wait on an explicit mbarrier: sync gemm with an mbar, and copies carrying an explicit "barrier" that are not is_tma_copy -- and annotate them with the logical iteration parity (k - min) % 2, written against the original loop var. EmitImpl's existing per-block Substitute(loop_var -> normalized_access_index) specializes the expression for every prologue/body/epilogue clone, since the tirx mutators already rewrite PrimExprs inside call annotations. Pipeline-managed TMA copies keep their ring parity in the explicit waits the pass inserts, and the explicit-async T.tcgen05_gemm never auto-waits, so neither is annotated.

Drop the matching ring branch from LowerTileOp's fallback: it keyed on the "num_stages" annotation, which InjectSoftwarePipeline strips, so it was dead on pipelined loops and wrong on unpipelined ones -- a compiler-generated per-site barrier flips once per loop iteration regardless of pipeline depth. The fallback is now the zero-based epoch of the nearest enclosing serial loop.

Add transform-level tests asserting the annotated phase and the emitted wait parities on sm_90a, so the fix is covered without sm_100 hardware; the loops start at a nonzero min to pin the epoch normalization. Add a tcgen05 correctness test running the failing kernel at num_stages 2 and 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed wait-parity handling for explicit mbarriers in pipelined loops.
- Annotated synchronous `T.gemm` operations and eligible explicit-barrier copies with logical parity `(k - min) % 2`.
- Excluded pipeline-managed TMA copies and explicit-async `T.tcgen05_gemm` operations.
- Updated `LowerTileOp` to derive fallback parity from the nearest serial loop epoch.
- Added transform tests for barrier annotations and emitted wait parity on `sm_90a`.
- Added `tcgen05` GEMM correctness tests for two- and three-stage pipelines.

## C++ style / lint notes

- The PR changes C++ sources.
- No changes to `docs/developer_guide/cpp_style.md` are included.
- The C++ API Style Audit remains warning-only when applicable.
- No correctness or build issues are identified. Advisory style warnings should not block merge unless they indicate a new API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->