### PR TITLE
[Bugfix] Make TMA layouts region-aware to keep slices contiguous

### DIFF
--- a/src/cuda/op/atomic_add.cc
+++ b/src/cuda/op/atomic_add.cc
@@ -39,22 +39,6 @@ namespace cuda {
 
 namespace {
 
-Layout ComputeLinearLayout(const Buffer &shared_tensor) {
-  Array<PrimExpr> input_size = shared_tensor->shape;
-  Array<PrimExpr> forward_vars;
-  for (size_t i = 0; i < input_size.size(); i++) {
-    forward_vars.push_back(InputPlaceholder(i));
-  }
-  Array<PrimExpr> forward_index;
-  for (size_t i = 0; i < input_size.size(); i++) {
-    forward_index.push_back(FloorDiv(forward_vars[i], 256));
-  }
-  for (size_t i = 0; i < input_size.size(); i++) {
-    forward_index.push_back(FloorMod(forward_vars[i], 256));
-  }
-  return Layout(input_size, forward_index);
-}
-
 bool UseTMA(const AtomicAddNode &op) {
   if (auto val = op.annotations.Get("use_tma")) {
     if (auto int_val = val->as<IntImmNode>()) {
@@ -142,7 +126,8 @@ TMAAtomicAddAnalysis AnalyzeTMAAtomicAdd(const AtomicAddNode &op, Target target,
   return {std::move(plan), ""};
 }
 
-Layout MakeTMAAtomicAddSharedLayout(const Buffer &shared_tensor) {
+Layout MakeTMAAtomicAddSharedLayout(const Buffer &shared_tensor,
+                                    const Array<Range> &region) {
   ICHECK_GE(shared_tensor->shape.size(), 2U)
       << "TMA atomic add layout inference requires a rank-2+ shared buffer";
   int ndim = static_cast<int>(shared_tensor->shape.size());
@@ -153,7 +138,7 @@ Layout MakeTMAAtomicAddSharedLayout(const Buffer &shared_tensor) {
          "but got "
       << shared_tensor->shape;
 
-  Layout inferred_layout = ComputeLinearLayout(shared_tensor);
+  Layout inferred_layout = MakeTmaLinearLayout(shared_tensor->shape, region);
   int element_bits = shared_tensor->dtype.bits();
   if ((element_bits == 16 || element_bits == 32) && *mat_stride % 8 == 0) {
     int vector_size = 128 / element_bits;
@@ -382,7 +367,7 @@ struct AtomicAdd {
     if (level == InferLevel::kFree &&
         !layout_args.layout_map.count(shared_tensor)) {
       result_map.Set(shared_tensor,
-                     MakeTMAAtomicAddSharedLayout(shared_tensor));
+                     MakeTMAAtomicAddSharedLayout(shared_tensor, shared_range));
     }
 
     return result_map;
@@ -467,20 +452,13 @@ struct AtomicAdd {
         << " is not divisible by instruction_dim: " << instruction_dim;
     desc.smem_box.Set(0, PrimExpr(instruction_dim));
 
-    Array<PrimExpr> shared_indices;
-    for (auto r : shared_range) {
-      shared_indices.push_back(r->min);
-    }
-    std::vector<PrimExpr> shared_strides;
-    PrimExpr shared_stride = 1;
-    for (size_t i = 0; i < shared_tensor->shape.size(); i++) {
-      auto s = shared_tensor->shape[shared_tensor->shape.size() - i - 1];
-      shared_strides.insert(shared_strides.begin(), shared_stride);
-      shared_stride *= s;
-    }
+    // Physical offset of the region base under the shared layout.
+    Array<PrimExpr> shared_indices = shared_layout->Forward(
+        shared_range.Map([](const Range &r) { return r->min; }));
+    Array<PrimExpr> physical_shape = shared_layout->OutputShape();
     PrimExpr shared_offset = 0;
     for (size_t i = 0; i < shared_indices.size(); i++) {
-      shared_offset += shared_indices[i] * shared_strides[i];
+      shared_offset = shared_offset * physical_shape[i] + shared_indices[i];
     }
 
     Call create_descriptor = Call(DataType::Handle(), create_tma_descriptor(),

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -451,8 +451,6 @@ struct Copy {
                     arith::Analyzer *analyzer);
 
 private:
-  static Layout ComputeLinearLayout(const Buffer &shared_tensor);
-
   static void CollectFragmentLayouts(const PrimExpr &expr,
                                      const Map<Var, PrimExpr> &bind_var_to_expr,
                                      const LayoutMap &existing_layouts,
@@ -503,23 +501,6 @@ struct Im2Col {
   static Stmt Lower(const Im2ColOpNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer);
 };
-
-Layout Copy::ComputeLinearLayout(const Buffer &shared_tensor) {
-  Array<PrimExpr> input_size = shared_tensor->shape;
-  Array<PrimExpr> forward_vars;
-  for (size_t i = 0; i < input_size.size(); i++) {
-    forward_vars.push_back(InputPlaceholder(i));
-  }
-
-  Array<PrimExpr> forward_index;
-  for (size_t i = 0; i < input_size.size(); i++) {
-    forward_index.push_back(FloorDiv(forward_vars[i], 256));
-  }
-  for (size_t i = 0; i < input_size.size(); i++) {
-    forward_index.push_back(FloorMod(forward_vars[i], 256));
-  }
-  return Layout(input_size, forward_index);
-}
 
 void Copy::CollectFragmentLayouts(const PrimExpr &expr,
                                   const Map<Var, PrimExpr> &bind_var_to_expr,
@@ -779,13 +760,15 @@ LayoutMap Copy::InferBulkLayout(const CopyNode &op,
       if (StructuralEqual()(swizzle_layout_2d, MakeLinearLayout(Array<PrimExpr>{
                                                    Integer(mat_stride),
                                                    Integer(mat_continuous)}))) {
-        result_map.Set(shared_tensor, ComputeLinearLayout(shared_tensor));
+        result_map.Set(shared_tensor,
+                       MakeTmaLinearLayout(shared_tensor->shape, shared_range));
       } else {
         result_map.Set(shared_tensor, ExpandLayoutToMatchBuffer(
                                           swizzle_layout_2d, shared_tensor));
       }
     } else {
-      result_map.Set(shared_tensor, ComputeLinearLayout(shared_tensor));
+      result_map.Set(shared_tensor,
+                     MakeTmaLinearLayout(shared_tensor->shape, shared_range));
     }
   }
 
@@ -1873,13 +1856,11 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
       << " elements; try to use annotate_layout to make your SMEM tile "
          "contiguous";
 
-  // Each TMA box dim is at most 256.
-  const int64_t max_box_dim = 256;
-
   // physical shared (without swizzle) -> tile -> logical global mode
   // E.g, physical_shared_to_global_mode = (64,64,8):(1@2,1@1,64@2)
-  auto physical_shared_to_global_mode = cute::Coalesce(
-      cute::Composition(tile_to_global_mode, smem_plain_to_tile), max_box_dim);
+  auto physical_shared_to_global_mode =
+      cute::Coalesce(cute::Composition(tile_to_global_mode, smem_plain_to_tile),
+                     kTmaMaxBoxDim);
 
   // Truncate, because we do not want to start in the middle of a global mode.
   // E.g., smem_rank = 2
@@ -1919,7 +1900,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
   // meet some requirements if we need to. This is the modified tile_gbasis.
   Array<cute::IntTuple> box_shape, box_stride;
   for (int64_t i = 0; i < smem_rank; i++) {
-    int64_t cap = max_box_dim;
+    int64_t cap = kTmaMaxBoxDim;
     bool is_swizzle_inner = (i == 0 && sw->IsSwizzled());
     if (is_swizzle_inner) {
       int64_t span_bits = sw->Granularity() * 8;

--- a/src/cuda/op/tma_layout.cc
+++ b/src/cuda/op/tma_layout.cc
@@ -12,6 +12,8 @@ namespace tvm {
 namespace tl {
 namespace cuda {
 
+using namespace tirx;
+
 TMASharedLayoutAnalysis AnalyzeTMASharedLayout(const Layout &layout,
                                                DataType dtype) {
   ffi::Optional<cute::ComposedLayout> composed =
@@ -45,6 +47,34 @@ void RequireTMASmemAlignment(const LowerArgs &lower_args,
   }
   lower_args.require_smem_alignment(shared_tensor->data,
                                     swizzle_mode.SmemAlignment());
+}
+
+Layout MakeTmaLinearLayout(const ffi::Array<PrimExpr> &shape,
+                           const ffi::Array<Range> &region) {
+  ICHECK(region.empty() || region.size() == shape.size());
+
+  // Physical order is [fixed slice, repeated boxes, box contents]. A fixed
+  // pipeline version therefore owns one contiguous run of complete TMA boxes.
+  ffi::Array<PrimExpr> fixed, outer, inner;
+  for (size_t i = 0; i < shape.size(); i++) {
+    Var v = InputPlaceholder(i);
+    if (!region.empty() && is_one(region[i]->extent)) {
+      fixed.push_back(v);
+      continue;
+    }
+    const int64_t *s = as_const_int(shape[i]);
+    if (s != nullptr && *s > kTmaMaxBoxDim && *s % kTmaMaxBoxDim == 0) {
+      outer.push_back(FloorDiv(v, Integer(kTmaMaxBoxDim)));
+      inner.push_back(FloorMod(v, Integer(kTmaMaxBoxDim)));
+    } else {
+      inner.push_back(v);
+    }
+  }
+  ffi::Array<PrimExpr> forward;
+  forward.insert(forward.end(), fixed.begin(), fixed.end());
+  forward.insert(forward.end(), outer.begin(), outer.end());
+  forward.insert(forward.end(), inner.begin(), inner.end());
+  return Layout(shape, forward);
 }
 
 } // namespace cuda

--- a/src/cuda/op/tma_layout.h
+++ b/src/cuda/op/tma_layout.h
@@ -38,6 +38,15 @@ void RequireTMASmemAlignment(const LowerArgs &lower_args,
                              const tirx::Buffer &shared_tensor,
                              const SwizzleMode &swizzle_mode);
 
+// A TensorMap box dimension holds at most 256 elements.
+inline constexpr int64_t kTmaMaxBoxDim = 256;
+
+// Unswizzled shared-memory layout whose copied modes are tiled at the TMA box
+// cap. Dimensions fixed by `region` stay outermost so a versioned slice
+// remains contiguous.
+Layout MakeTmaLinearLayout(const ffi::Array<PrimExpr> &shape,
+                           const ffi::Array<Range> &region = {});
+
 } // namespace cuda
 } // namespace tl
 } // namespace tvm

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -376,6 +376,67 @@ def test_tma_atomic_add_uint64_runtime():
 
 
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_atomic_add_wide_linear_layout_runtime():
+    rows, global_width, tile_width, col_offset = 8, 520, 512, 8
+
+    @tilelang.jit
+    def kernel(out):
+        out: T.Tensor[(rows, global_width), T.uint64]
+
+        with T.Kernel(1):
+            out_shared = T.alloc_shared((rows, tile_width), dtype=T.uint64)
+            T.fill(out_shared, 1)
+            T.atomic_add(
+                out[:, col_offset : col_offset + tile_width],
+                out_shared,
+                use_tma=True,
+            )
+
+    compiled = kernel.compile(out=T.Tensor[(rows, global_width), T.uint64])
+    source = compiled.get_kernel_source()
+    assert re.search(
+        r"for \(int \w+ = 0; \w+ < 2; \+\+\w+\) \{\n\s*tl::tma_store_add\(",
+        source,
+    )
+
+    out = torch.zeros((rows, global_width), dtype=torch.uint64, device="cuda")
+    compiled(out)
+    torch.cuda.synchronize()
+    assert torch.all(out[:, :col_offset] == 0)
+    assert torch.all(out[:, col_offset:] == 1)
+
+
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_atomic_add_versioned_smem_slice_runtime():
+    """A version slice of a wide linear buffer must stay contiguous under the
+    inferred layout, or the second TMA box silently reads the other version."""
+    rows, width = 8, 512
+
+    @tilelang.jit
+    def kernel(out):
+        out: T.Tensor[(rows, width), T.uint64]
+
+        with T.Kernel(1):
+            smem = T.alloc_shared((2, rows, width), dtype=T.uint64)
+            T.fill(smem, 7)  # decoy in version 0
+            for i, j in T.Parallel(rows, width):
+                smem[1, i, j] = 1
+            T.atomic_add(out, smem[1, :, :], use_tma=True)
+
+    compiled = kernel.compile(out=T.Tensor[(rows, width), T.uint64])
+    source = compiled.get_kernel_source()
+    assert re.search(
+        r"for \(int \w+ = 0; \w+ < 2; \+\+\w+\) \{\n\s*tl::tma_store_add\(",
+        source,
+    )
+
+    out = torch.zeros((rows, width), dtype=torch.uint64, device="cuda")
+    compiled(out)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, torch.ones_like(out), rtol=0, atol=0)
+
+
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_tma_atomic_add_32b_swizzle_runtime():
     out = torch.zeros((16, 24), dtype=torch.float32, device="cuda")
     tma_atomic_add_32b_swizzle_program(out)

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -12,6 +12,8 @@ For TMA stores (shared -> global):
   No barrier argument is needed for stores.
 """
 
+import re
+
 import pytest
 
 from tilelang import tvm as tvm
@@ -253,6 +255,155 @@ def test_tma_copy_uses_descriptor_for_padded_multirow_region():
     torch.testing.assert_close(padded_destination[:, cols:], torch.full_like(padded_destination[:, cols:], -1.0))
 
 
+def _assert_two_box_tma_loop(source, instruction):
+    assert re.search(
+        rf"for \(int \w+ = 0; \w+ < 2; \+\+\w+\) \{{\n\s*tl::{instruction}\(",
+        source,
+    )
+
+
+def _tma_descriptor_init_block(host_source, desc_name):
+    marker = f"[0].v_ptr) = {desc_name};"
+    start = host_source.find(marker)
+    assert start >= 0, f"Missing {desc_name} TensorMap initialization"
+    end = host_source.find("TVMFFIFunctionCall(__tvm_tensormap_create_tiled_packed", start)
+    assert end >= 0, f"Missing {desc_name} TensorMap creation call"
+    return host_source[start:end]
+
+
+def _tma_stack_int(block, index):
+    match = re.search(rf"\[{index}\]\.v_int64\)\s*=\s*\(\(int64_t\)(-?\d+)\);", block)
+    assert match, f"Missing stack[{index}] integer assignment in:\n{block}"
+    return int(match.group(1))
+
+
+def _assert_2d_f32_tma_descriptor(kernel, desc_name, rows, global_width):
+    block = _tma_descriptor_init_block(kernel.get_host_source(), desc_name)
+    assert _tma_stack_int(block, 2) == 2
+    assert _tma_stack_int(block, 4) == global_width
+    assert _tma_stack_int(block, 5) == rows
+    assert _tma_stack_int(block, 6) == 4
+    assert _tma_stack_int(block, 7) == global_width * 4
+    assert _tma_stack_int(block, 8) == 256
+    assert _tma_stack_int(block, 9) == rows
+
+
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_load_wide_linear_fixed_slice_with_unaligned_global_shape():
+    # The extent and coordinate are not 256-aligned; the byte stride and
+    # starting address still satisfy CUDA's 16-byte requirements.
+    rows, global_width, tile_width, col_offset = 16, 516, 512, 4
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((rows, global_width), T.float32),
+        B: T.Tensor((rows, tile_width), T.float32),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((2, rows, tile_width), T.float32)
+            mbar = T.alloc_barrier(128)
+            T.tma_copy(
+                A[:, col_offset : col_offset + tile_width],
+                A_shared[1, :, :],
+                barrier=mbar,
+            )
+            T.barrier_arrive(mbar)
+            T.barrier_wait(mbar, 0)
+            T.copy(A_shared[1, :, :], B, prefer_instruction="sync")
+
+    kernel = tilelang.compile(
+        main,
+        out_idx=[1],
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )
+    source = kernel.get_kernel_source()
+    assert "CUtensorMap" in source
+    _assert_two_box_tma_loop(source, "tma_load")
+    _assert_2d_f32_tma_descriptor(kernel, "A_desc", rows, global_width)
+
+    import torch
+
+    A = torch.arange(rows * global_width, dtype=torch.float32, device="cuda").reshape(rows, global_width)
+    B = kernel(A)
+    torch.testing.assert_close(B, A[:, col_offset : col_offset + tile_width])
+
+
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_store_wide_linear_fixed_slice_with_unaligned_global_shape():
+    # Fifteen rows select the unswizzled layout; 516 and 4 satisfy byte
+    # alignment without being aligned to the 256-element box.
+    rows, global_width, tile_width, col_offset = 15, 516, 512, 4
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((rows, tile_width), T.float32),
+        B: T.Tensor((rows, global_width), T.float32),
+    ):
+        with T.Kernel(1, threads=128):
+            B_shared = T.alloc_shared((2, rows, tile_width), T.float32)
+            T.copy(A, B_shared[1, :, :], prefer_instruction="sync")
+            T.tma_copy(
+                B_shared[1, :, :],
+                B[:, col_offset : col_offset + tile_width],
+            )
+            T.tma_store_wait(read=False)
+
+    kernel = tilelang.compile(
+        main,
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )
+    source = kernel.get_kernel_source()
+    assert "CUtensorMap" in source
+    _assert_two_box_tma_loop(source, "tma_store")
+    _assert_2d_f32_tma_descriptor(kernel, "B_desc", rows, global_width)
+
+    import torch
+
+    A = torch.arange(rows * tile_width, dtype=torch.float32, device="cuda").reshape(rows, tile_width)
+    B = torch.full((rows, global_width), -1.0, dtype=torch.float32, device="cuda")
+    kernel(A, B)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(B[:, col_offset : col_offset + tile_width], A)
+    assert torch.all(B[:, :col_offset] == -1)
+
+
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_load_oob_fill_with_non_aligned_global_extent():
+    rows, global_width, row_stride, tile_width, col_offset = 2, 515, 516, 256, 512
+
+    @T.prim_func
+    def main(
+        A: T.StridedTensor((rows, global_width), (row_stride, 1), T.float32),
+        B: T.Tensor((rows, tile_width), T.float32),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((rows, tile_width), T.float32)
+            mbar = T.alloc_barrier(128)
+            T.tma_copy(A[:, col_offset : col_offset + tile_width], A_shared, barrier=mbar)
+            T.barrier_arrive(mbar)
+            T.barrier_wait(mbar, 0)
+            T.copy(A_shared, B, prefer_instruction="sync")
+
+    kernel = tilelang.compile(
+        main,
+        out_idx=[1],
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )
+    assert "tl::tma_load" in kernel.get_kernel_source()
+    block = _tma_descriptor_init_block(kernel.get_host_source(), "A_desc")
+    assert _tma_stack_int(block, 4) == global_width
+    assert _tma_stack_int(block, 7) == row_stride * 4
+
+    import torch
+
+    backing = torch.arange(rows * row_stride, dtype=torch.float32, device="cuda").reshape(rows, row_stride)
+    A = backing[:, :global_width]
+    B = kernel(A)
+    expected = torch.zeros_like(B)
+    expected[:, : global_width - col_offset] = A[:, col_offset:]
+    torch.testing.assert_close(B, expected)
+
+
 def matmul_tma_copy_store(
     M,
     N,
@@ -401,23 +552,6 @@ def fp4_tma_copy_unpacked_smem_store(M=128, N=256, block_M=64, block_N=128):
     return main
 
 
-def _fp4_tma_descriptor_init_block(host_source, desc_name):
-    marker = f"[0].v_ptr) = {desc_name};"
-    start = host_source.find(marker)
-    assert start >= 0, f"Missing {desc_name} TensorMap initialization"
-    end = host_source.find("TVMFFIFunctionCall(__tvm_tensormap_create_tiled_packed", start)
-    assert end >= 0, f"Missing {desc_name} TensorMap creation call"
-    return host_source[start:end]
-
-
-def _fp4_tma_stack_int(block, index):
-    import re
-
-    match = re.search(rf"\[{index}\]\.v_int64\)\s*=\s*\(\(int64_t\)(-?\d+)\);", block)
-    assert match, f"Missing stack[{index}] integer assignment in:\n{block}"
-    return int(match.group(1))
-
-
 def _assert_fp4_packed_tma_descriptor(host_source, desc_name):
     expected_tma_args = {
         1: 13,  # CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B
@@ -435,17 +569,17 @@ def _assert_fp4_packed_tma_descriptor(host_source, desc_name):
         14: 2,
         15: 0,
     }
-    block = _fp4_tma_descriptor_init_block(host_source, desc_name)
+    block = _tma_descriptor_init_block(host_source, desc_name)
     for index, expected in expected_tma_args.items():
-        assert _fp4_tma_stack_int(block, index) == expected
+        assert _tma_stack_int(block, index) == expected
 
 
 def _assert_fp4_unpacked_tma_descriptor(host_source, desc_name, *, expect_swizzle=None):
-    block = _fp4_tma_descriptor_init_block(host_source, desc_name)
-    assert _fp4_tma_stack_int(block, 1) == 14  # CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B
-    assert _fp4_tma_stack_int(block, 8) == 128  # 128-element inner box for 8-bit storage
+    block = _tma_descriptor_init_block(host_source, desc_name)
+    assert _tma_stack_int(block, 1) == 14  # CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B
+    assert _tma_stack_int(block, 8) == 128  # 128-element inner box for 8-bit storage
     if expect_swizzle is not None:
-        assert _fp4_tma_stack_int(block, 13) == expect_swizzle
+        assert _tma_stack_int(block, 13) == expect_swizzle
 
 
 def run_fp4_tma_copy_roundtrip():

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -1,5 +1,7 @@
 """Tests for the warp-specialized producer/consumer pass."""
 
+import re
+
 import tilelang
 import tilelang.language as T
 import tilelang.testing
@@ -839,6 +841,80 @@ def test_tiled_ws_does_not_clone_local_var_into_producer_branch():
     _run_grouped_gemm_ws(kernel, batch_sizes)
 
 
+def _wide_linear_reduce_kernel(rows, mids, width, batches, rows_per_batch, dtype, num_stages=2):
+    """A grad_w-style batched reduction: each pipelined iteration TMA-loads a
+    (rows_per_batch, width) slice (fixed middle index, strided rows) into a
+    linear-layout shared buffer and accumulates it into a fragment."""
+
+    @T.prim_func
+    def main(
+        src: T.Tensor((rows, mids, width), dtype),
+        out: T.Tensor((mids, width), "float32"),
+    ):
+        with T.Kernel(mids, threads=128) as bx:
+            smem = T.alloc_shared((rows_per_batch, width), dtype)
+            acc = T.alloc_fragment((width,), "float32")
+            T.clear(acc)
+            for k in T.Pipelined(batches, num_stages=num_stages):
+                T.copy(src[k * rows_per_batch : (k + 1) * rows_per_batch, bx, :], smem)
+                for i in T.Serial(rows_per_batch):
+                    for j in T.Parallel(width):
+                        acc[j] += smem[i, j]
+            T.copy(acc, out[bx, :])
+
+    return main
+
+
+def _run_wide_linear_reduce(kernel, rows, mids, width, dtype):
+    import torch
+
+    torch_dtype = {"float32": torch.float32, "bfloat16": torch.bfloat16}[dtype]
+    src = torch.randn(rows, mids, width, device="cuda", dtype=torch_dtype)
+    out = torch.zeros(mids, width, device="cuda", dtype=torch.float32)
+    kernel(src, out)
+    ref = src.float().sum(dim=0)
+    torch.testing.assert_close(out, ref, rtol=1e-3, atol=1e-3)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_tiled_ws_multi_versioned_wide_linear_smem_keeps_tma():
+    """A multi-versioned linear shared buffer with a >256-element row must
+    stay a TMA producer: the version axis stays outside the per-copy TMA tile,
+    while the width quotient stays outside its 256-element box. Pins the fix
+    for the gapped-slice bijection ICHECK."""
+    func = _wide_linear_reduce_kernel(rows=128, mids=4, width=512, batches=4, rows_per_batch=32, dtype="float32")
+    kernel = tilelang.compile(func, target="cuda")
+    src = kernel.get_kernel_source()
+    assert "tl::tma_load(" in src
+    assert "cp_async" not in src
+    assert re.search(r"for \(int \w+ = 0; \w+ < 2; \+\+\w+\) \{\n\s*tl::tma_load\(", src)
+    _run_wide_linear_reduce(kernel, 128, 4, 512, "float32")
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_tiled_ws_wide_linear_smem_multi_way_box_split():
+    """1024 bf16 columns force a (256, 4) split of the contiguous box mode."""
+    func = _wide_linear_reduce_kernel(rows=64, mids=2, width=1024, batches=4, rows_per_batch=16, dtype="bfloat16")
+    kernel = tilelang.compile(func, target="cuda")
+    src = kernel.get_kernel_source()
+    assert "tl::tma_load(" in src
+    _run_wide_linear_reduce(kernel, 64, 2, 1024, "bfloat16")
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_tiled_ws_wide_linear_smem_three_stages():
+    """Three versions interleave the ring dimension above the 256-splits."""
+    func = _wide_linear_reduce_kernel(rows=48, mids=2, width=768, batches=3, rows_per_batch=16, dtype="float32", num_stages=3)
+    kernel = tilelang.compile(func, target="cuda")
+    src = kernel.get_kernel_source()
+    assert "cp_async" not in src
+    assert re.search(r"for \(int \w+ = 0; \w+ < 3; \+\+\w+\) \{\n\s*tl::tma_load\(", src)
+    _run_wide_linear_reduce(kernel, 48, 2, 768, "float32")
+
+
 if __name__ == "__main__":
     test_tiled_ws_skips_device_bound_tma_descriptor_base()
     test_tiled_ws_places_producer_in_first_warp_group()
@@ -854,3 +930,6 @@ if __name__ == "__main__":
     test_tiled_ws_explicit_cp_async_wait_precedes_first_consumer_read()
     test_tiled_ws_keeps_shared_prelude_local_vars_for_grouped_gemm()
     test_tiled_ws_does_not_clone_local_var_into_producer_branch()
+    test_tiled_ws_multi_versioned_wide_linear_smem_keeps_tma()
+    test_tiled_ws_wide_linear_smem_multi_way_box_split()
+    test_tiled_ws_wide_linear_smem_three_stages()


### PR DESCRIPTION
The inferred "linear" shared layout hoisted every 256-split quotient above all dims, so a pipeline-versioned slice became two gapped chunks: LowerBulk's bijection check fired on warp-specialized wide reductions, and the TMA atomic-add path (which has no such check) silently read the other version.

MakeTmaLinearLayout now takes the copied region and orders modes as [region-fixed dims, box quotients, box contents], so a fixed slice owns one contiguous run of whole TMA boxes and the existing rest-loop machinery emits one instruction per box over the true (unaligned) global shape. The atomic-add path shares the helper and computes the region base offset through the layout instead of hand-rolled row-major strides over the physical shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added region-aware `MakeTmaLinearLayout` inference for TMA operations.
- Ordered layout dimensions as region-fixed dimensions, box quotients, and box contents.
- Preserved contiguous TMA boxes for pipeline-versioned slices.
- Reused the layout for TMA atomic-add region offsets.
- Added wide, unaligned, multi-version, multi-stage, and out-of-bounds TMA tests.
- Added the shared `kTmaMaxBoxDim` constant and removed obsolete linear-layout code.

## C++ style / lint notes

- The PR changes C++ headers and implementations.
- It touches API and namespace rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step applies.
- Any TLCPP003/TLCPP004 findings are advisory unless they indicate a clear API, FFI, or maintainability risk.
- No correctness, build, or test issue is identified from the provided changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->