### PR TITLE
[Bugfix][CUDA] Fix UB in packed 8-bit vector stores

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -1465,7 +1465,7 @@ void CodeGenTileLangCUDA::PrintVecElemStore(const std::string &vec, DataType t,
       std::string ac = t.lanes() == 4 ? vec : (vec + "." + access[i / 4]);
       stream << ac << "=";
       // Do not read the first undef lane.
-      if (i != 0) {
+      if (i % 4 != 0) {
         stream << ac << " & ~(0x000000ff << " << i % 4 * 8 << ") |";
       }
       stream << "(" << value << " << " << i % 4 * 8 << ");\n";
@@ -1474,10 +1474,12 @@ void CodeGenTileLangCUDA::PrintVecElemStore(const std::string &vec, DataType t,
       std::string ac = vec + "." + access[i / 8];
       stream << ac << "=";
       // Do not read the first undef lane.
-      if (i != 0) {
-        stream << ac << " & ~(0x000000ff << " << i % 8 * 8 << ") |";
+      if (i % 8 != 0) {
+        stream << ac << " & ~(static_cast<unsigned long long>(0x000000ffu) << "
+               << i % 8 * 8 << ") |";
       }
-      stream << "(" << value << " << " << i % 8 * 8 << ");\n";
+      stream << "((static_cast<unsigned long long>(" << value
+             << ") & 0xffULL) << " << i % 8 * 8 << ");\n";
     }
   } else if (t.is_float16()) {
     if (t.lanes() <= 8) {

--- a/testing/python/issue/test_tilelang_int8x32_shift_ub.py
+++ b/testing/python/issue/test_tilelang_int8x32_shift_ub.py
@@ -62,7 +62,13 @@ def test_non_broadcast_8bit_small_vector_add_is_packed(lanes, dtype, torch_dtype
 )
 def test_non_broadcast_8bit_wide_vector_add_is_packed(dtype, torch_dtype, expected_vector_type):
     source = _run_non_broadcast_8bit_vector_add(32, dtype, torch_dtype)
-    assert expected_vector_type in source
+    packed = re.search(rf"\b{expected_vector_type}\s+(__\w+);", source)
+    assert packed is not None
+    vector = packed.group(1)
+    for field in "xyzw":
+        writes = [line for line in source.splitlines() if f"{vector}.{field}=" in line]
+        assert writes
+        assert not re.search(rf"=\s*{re.escape(vector)}\.{field}\s*&", writes[0])
     for shift in range(8, 64, 8):
         assert f"static_cast<unsigned long long>(0x000000ffu) << {shift}" in source
         assert f"& 0xffULL) << {shift}" in source

--- a/testing/python/issue/test_tilelang_int8x32_shift_ub.py
+++ b/testing/python/issue/test_tilelang_int8x32_shift_ub.py
@@ -1,0 +1,68 @@
+import re
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+def _run_non_broadcast_8bit_vector_add(lanes, dtype, torch_dtype):
+    n = lanes
+
+    @T.prim_func
+    def main(
+        a: T.Tensor((n,), dtype),
+        b: T.Tensor((n,), dtype),
+        c: T.Tensor((n,), dtype),
+    ):
+        with T.Kernel(1, threads=1):
+            for i in T.vectorized(n):
+                c[i] = a[i] + b[i]
+
+    kernel = tilelang.compile(main, target="cuda")
+    source = kernel.get_kernel_source()
+
+    if torch_dtype is torch.int8:
+        a = torch.arange(-(lanes // 2), lanes // 2, dtype=torch_dtype, device="cuda")
+    else:
+        a = torch.arange(128, 128 + n, dtype=torch_dtype, device="cuda")
+    b = torch.full((n,), 3, dtype=torch_dtype, device="cuda")
+    c = torch.empty_like(a)
+    kernel(a, b, c)
+    torch.cuda.synchronize()
+
+    expected = (a.to(torch.int16) + b.to(torch.int16)).to(torch_dtype)
+    torch.testing.assert_close(c, expected, rtol=0, atol=0)
+    return source
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    ("lanes", "dtype", "torch_dtype"),
+    [(lanes, dtype, torch_dtype) for lanes in [8, 16] for dtype, torch_dtype in [("int8", torch.int8), ("uint8", torch.uint8)]],
+)
+def test_non_broadcast_8bit_small_vector_add_is_packed(lanes, dtype, torch_dtype):
+    source = _run_non_broadcast_8bit_vector_add(lanes, dtype, torch_dtype)
+    packed = re.search(r"\b(?:u?int|u?char)(?:2|4)\s+(__\w+);", source)
+    assert packed is not None
+    vector = packed.group(1)
+    for field in "xyzw"[: lanes // 4]:
+        writes = [line for line in source.splitlines() if f"{vector}.{field}=" in line]
+        assert writes
+        assert not re.search(rf"=\s*{re.escape(vector)}\.{field}\s*&", writes[0])
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@pytest.mark.parametrize(
+    ("dtype", "torch_dtype", "expected_vector_type"),
+    [("int8", torch.int8, "longlong4"), ("uint8", torch.uint8, "ulonglong4")],
+)
+def test_non_broadcast_8bit_wide_vector_add_is_packed(dtype, torch_dtype, expected_vector_type):
+    source = _run_non_broadcast_8bit_vector_add(32, dtype, torch_dtype)
+    assert expected_vector_type in source
+    for shift in range(8, 64, 8):
+        assert f"static_cast<unsigned long long>(0x000000ffu) << {shift}" in source
+        assert f"& 0xffULL) << {shift}" in source


### PR DESCRIPTION
## Summary

Non-broadcast 8-bit vector stores are packed into CUDA vector fields. The `int8x32` and `uint8x32` paths use 64-bit fields (`longlong4` or `ulonglong4`), but the generated code performs shifts of up to 56 bits on 32-bit values. This is undefined behavior in CUDA C++ and can silently corrupt the upper four lanes of each 64-bit field.

The smaller `int8x8`/`uint8x8` and `int8x16`/`uint8x16` paths also read an uninitialized packed field when writing the first lane of each field.

The 32-lane path becomes reachable through automatic vectorization on `sm_100+`, where global-only memory operations may use 256-bit accesses. The 8- and 16-lane initialization issue is not architecture-specific.

## Root cause

`CodeGenTileLangCUDA::PrintVecElemStore` packs eight 8-bit lanes into each 64-bit field of a 32-lane vector. Both the packing mask and the lane value are 32-bit expressions, but lanes 4 through 7 require shift amounts of 32, 40, 48, and 56 bits.

The out-of-range shifts affect non-broadcast vector construction paths, including vector arithmetic, cast fallbacks, and vector-returning external calls scalarized per lane.

## Fix

- Promote the packing mask and value to `unsigned long long` before shifting.
- Mask each value to 8 bits before inserting it into the 64-bit packed field.
- Skip reads when writing the first lane of every packed field.
- Add regression coverage for `int8` and `uint8` vector addition at 8, 16, and 32 lanes.
- Use the active CUDA target so the test can run on both `sm_100` and `sm_120` devices.

## Tests

Verified on an NVIDIA RTX 5090 (`sm_120`) with CUDA 13.0:

- Regression test: 6 passed (8/16/32 lanes for both `int8` and `uint8`).
- All runtime results matched the PyTorch references.
- Generated CUDA no longer contains the 32-bit shift pattern.
- CMake build completed successfully with `-j16`.
- Repository pre-commit checks passed for the modified C++ and Python files.
- `git diff --check` passed.

Test command:

```bash
TILELANG_DISABLE_CACHE=1 \
PYTHONPATH=$PWD \
python -m pytest testing/python/issue/test_tilelang_int8x32_shift_ub.py -q -s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes undefined behavior in CUDA packed 8-bit vector stores for non-broadcast `int8x32` and `uint8x32` vectors.

The fix:
- Promotes packing operands to `unsigned long long`.
- Masks values to 8 bits before shifting.
- Preserves existing bytes in each 64-bit CUDA vector field.
- Avoids reading uninitialized packed fields when writing the first lane of 8-, 16-, and 32-lane vectors.

## Tests

Adds regression coverage for non-broadcast signed and unsigned 8-bit vector addition with 8, 16, and 32 lanes.

Validation passed on an NVIDIA RTX 5090 with CUDA 13.0, including:
- CUDA regression tests.
- CMake build.
- Pre-commit checks.
- `git diff --check`.

## C++ style / lint notes

The change touches C++ implementation code but does not change rules documented in `docs/developer_guide/cpp_style.md`.

The C++ API Style Audit is warning-only when applicable. No new API, FFI, or maintainability risk is identified. No correctness or build issues are reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->