### PR TITLE
[Bugfix] Validate T.gemm k_pack arguments

### DIFF
--- a/testing/python/issue/test_tilelang_issue_3035.py
+++ b/testing/python/issue/test_tilelang_issue_3035.py
@@ -1,0 +1,43 @@
+"""Regression tests for T.gemm k_pack validation (issue #3035)."""
+
+import pytest
+
+import tilelang.language as T
+import tilelang.testing
+
+
+def _make_gemm(k_pack):
+    @T.prim_func
+    def main(
+        A: T.Tensor((128, 128), "float16"),
+        B: T.Tensor((128, 128), "float16"),
+        C: T.Tensor((128, 128), "float16"),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128, 128), "float16")
+            B_shared = T.alloc_shared((128, 128), "float16")
+            C_local = T.alloc_fragment((128, 128), "float16")
+            T.gemm(A_shared, B_shared, C_local, k_pack=k_pack)
+
+    return main
+
+
+@pytest.mark.parametrize("k_pack", [1, 2])
+def test_gemm_accepts_supported_k_pack(k_pack):
+    assert _make_gemm(k_pack) is not None
+
+
+@pytest.mark.parametrize("k_pack", [0, -1, 3, 4, 8, 16])
+def test_gemm_rejects_unsupported_k_pack(k_pack):
+    with pytest.raises(ValueError, match=rf"T\.gemm k_pack must be 1 or 2, got {k_pack}"):
+        _make_gemm(k_pack)
+
+
+@pytest.mark.parametrize("k_pack", [True, 2.0, "2", None])
+def test_gemm_rejects_non_integer_k_pack(k_pack):
+    with pytest.raises(TypeError, match=r"T\.gemm k_pack must be an int"):
+        _make_gemm(k_pack)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/issue/test_tilelang_issue_3035.py
+++ b/testing/python/issue/test_tilelang_issue_3035.py
@@ -1,6 +1,5 @@
 """Regression tests for T.gemm k_pack validation (issue #3035)."""
 
-import numpy as np
 import pytest
 
 import tilelang.language as T
@@ -23,22 +22,22 @@ def _make_gemm(k_pack):
     return main
 
 
-@pytest.mark.parametrize("k_pack", [1, 2, np.int64(1), np.int64(2)])
+@pytest.mark.parametrize("k_pack", [1, 2])
 def test_gemm_accepts_supported_k_pack(k_pack):
     assert _make_gemm(k_pack) is not None
 
 
 @pytest.mark.parametrize("k_pack", [0, -1, 3, 4, 8, 16])
 def test_gemm_rejects_unsupported_k_pack(k_pack):
-    with pytest.raises(ValueError, match=rf"T\.gemm k_pack must be 1 or 2, got {k_pack}"):
+    with pytest.raises(ValueError, match=rf"T\.gemm k_pack must be an int equal to 1 or 2, got {k_pack}"):
         _make_gemm(k_pack)
 
 
 @pytest.mark.parametrize("k_pack", [True, 2.0, "2", None])
 def test_gemm_rejects_non_integer_k_pack(k_pack):
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(ValueError) as exc_info:
         _make_gemm(k_pack)
-    assert str(exc_info.value) == (f"T.gemm k_pack must be an int equal to 1 or 2, got {k_pack!r} ({type(k_pack).__name__})")
+    assert str(exc_info.value) == f"T.gemm k_pack must be an int equal to 1 or 2, got {k_pack!r}"
 
 
 if __name__ == "__main__":

--- a/testing/python/issue/test_tilelang_issue_3035.py
+++ b/testing/python/issue/test_tilelang_issue_3035.py
@@ -1,5 +1,6 @@
 """Regression tests for T.gemm k_pack validation (issue #3035)."""
 
+import numpy as np
 import pytest
 
 import tilelang.language as T
@@ -22,7 +23,7 @@ def _make_gemm(k_pack):
     return main
 
 
-@pytest.mark.parametrize("k_pack", [1, 2])
+@pytest.mark.parametrize("k_pack", [1, 2, np.int64(1), np.int64(2)])
 def test_gemm_accepts_supported_k_pack(k_pack):
     assert _make_gemm(k_pack) is not None
 

--- a/testing/python/issue/test_tilelang_issue_3035.py
+++ b/testing/python/issue/test_tilelang_issue_3035.py
@@ -35,8 +35,9 @@ def test_gemm_rejects_unsupported_k_pack(k_pack):
 
 @pytest.mark.parametrize("k_pack", [True, 2.0, "2", None])
 def test_gemm_rejects_non_integer_k_pack(k_pack):
-    with pytest.raises(TypeError, match=r"T\.gemm k_pack must be an int"):
+    with pytest.raises(TypeError) as exc_info:
         _make_gemm(k_pack)
+    assert str(exc_info.value) == (f"T.gemm k_pack must be an int equal to 1 or 2, got {k_pack!r} ({type(k_pack).__name__})")
 
 
 if __name__ == "__main__":

--- a/tilelang/language/gemm_op.py
+++ b/tilelang/language/gemm_op.py
@@ -38,6 +38,10 @@ def _gemm_impl(
 
     Returns a call_intrin handle for the given op key.
     """
+    if not isinstance(k_pack, int) or isinstance(k_pack, bool):
+        raise TypeError(f"T.gemm k_pack must be an int, got {type(k_pack).__name__}")
+    if k_pack not in (1, 2):
+        raise ValueError(f"T.gemm k_pack must be 1 or 2, got {k_pack}")
 
     def legalize_arguments(arg: BufferLikeType | tirx.Var) -> BufferLikeType:
         """Convert let-bound variables to their corresponding buffers.
@@ -176,7 +180,7 @@ def gemm(
         transpose_B (bool): Whether to transpose B. Defaults to False.
         policy (GemmWarpPolicy): GEMM warp partition policy.
         clear_accum (bool): Whether to clear the accumulator.
-        k_pack (int): Numbers of packed matrix cores, for ROCm only. Defaults to 1.
+        k_pack (int): Number of packed matrix cores, for ROCm only. Must be 1 or 2. Defaults to 1.
         mbar (BarrierType, i.e. Buffer | BufferLoad, or Var, optional): Mbarrier in Blackwell.
             Required when this GEMM lowers to TCGEN5MMA. Defaults to None.
         annotations (Optional[dict]): Additional annotations.

--- a/tilelang/language/gemm_op.py
+++ b/tilelang/language/gemm_op.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from numbers import Integral
-
 from tilelang._typing import BufferLikeType, BarrierType
 from tilelang.tileop.base import GemmWarpPolicy
 import tilelang.language as T
@@ -40,11 +38,8 @@ def _gemm_impl(
 
     Returns a call_intrin handle for the given op key.
     """
-    if isinstance(k_pack, bool) or not isinstance(k_pack, Integral):
-        raise TypeError(f"T.gemm k_pack must be an int equal to 1 or 2, got {k_pack!r} ({type(k_pack).__name__})")
-    k_pack = int(k_pack)
-    if k_pack not in (1, 2):
-        raise ValueError(f"T.gemm k_pack must be 1 or 2, got {k_pack}")
+    if not (isinstance(k_pack, int) and not isinstance(k_pack, bool) and k_pack in (1, 2)):
+        raise ValueError(f"T.gemm k_pack must be an int equal to 1 or 2, got {k_pack!r}")
 
     def legalize_arguments(arg: BufferLikeType | tirx.Var) -> BufferLikeType:
         """Convert let-bound variables to their corresponding buffers.

--- a/tilelang/language/gemm_op.py
+++ b/tilelang/language/gemm_op.py
@@ -39,7 +39,7 @@ def _gemm_impl(
     Returns a call_intrin handle for the given op key.
     """
     if not isinstance(k_pack, int) or isinstance(k_pack, bool):
-        raise TypeError(f"T.gemm k_pack must be an int, got {type(k_pack).__name__}")
+        raise TypeError(f"T.gemm k_pack must be an int equal to 1 or 2, got {k_pack!r} ({type(k_pack).__name__})")
     if k_pack not in (1, 2):
         raise ValueError(f"T.gemm k_pack must be 1 or 2, got {k_pack}")
 

--- a/tilelang/language/gemm_op.py
+++ b/tilelang/language/gemm_op.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from numbers import Integral
+
 from tilelang._typing import BufferLikeType, BarrierType
 from tilelang.tileop.base import GemmWarpPolicy
 import tilelang.language as T
@@ -38,8 +40,9 @@ def _gemm_impl(
 
     Returns a call_intrin handle for the given op key.
     """
-    if not isinstance(k_pack, int) or isinstance(k_pack, bool):
+    if isinstance(k_pack, bool) or not isinstance(k_pack, Integral):
         raise TypeError(f"T.gemm k_pack must be an int equal to 1 or 2, got {k_pack!r} ({type(k_pack).__name__})")
+    k_pack = int(k_pack)
     if k_pack not in (1, 2):
         raise ValueError(f"T.gemm k_pack must be 1 or 2, got {k_pack}")
 


### PR DESCRIPTION
## Summary

- validate `T.gemm` `k_pack` type and `{1, 2}` domain before constructing TIR
- preserve the native C++ check as a defensive backstop
- add portable frontend regression coverage for valid, out-of-range, and non-integer inputs

Fixes #3035.

## Validation

- editable macOS arm64 build with Python 3.12: passed
- `python -m pytest -q testing/python/issue/test_tilelang_issue_3035.py`: 12 passed
- `python -m pytest -q testing/python/language/test_tilelang_language_span.py`: 19 passed, 2 skipped
- `python -m compileall -q tilelang testing/python/issue/test_tilelang_issue_3035.py`: passed
- `python -m pre_commit run --all-files`: passed
- `git diff --check`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added frontend validation for `T.gemm`’s `k_pack` argument.
- Accepts only Python integer values `1` and `2`.
- Rejects booleans, floats, `None`, and other unsupported values before TIR construction.
- Raises a clear `ValueError` that identifies `k_pack` and the allowed values.
- Updated the `k_pack` documentation.
- Added regression tests for supported, out-of-range, and non-integer inputs.
- Preserved the native C++ check as a defensive backstop.
- Validation passed on macOS arm64 with Python 3.12, including targeted tests, language tests, compilation checks, pre-commit checks, and `git diff --check`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->