### PR TITLE
[BugFix] Bind symbolic coordinate ranges in FragmentThreadIndexProbe

### DIFF
--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -1202,9 +1202,25 @@ FragmentThreadIndexProbe::FragmentThreadIndexProbe(
   }
   Array<PrimExpr> partition_vars;
   for (size_t i = 0; i < loop_layout->OutputDim(); ++i) {
-    partition_vars.push_back(Var("__tl_candidate_i" + std::to_string(i)));
+    Var coord("__tl_candidate_i" + std::to_string(i));
+    // Bind every symbolic coordinate's range: the thread-cancellation proofs
+    // below are range-dependent (e.g. `(o0*512 + t*4 + o1) // 512 -> o0`
+    // only holds for t*4 + o1 < 512), and an unbound var makes Simplify
+    // keep the thread term, flagging clean strided layouts as spilling.
+    analyzer->Bind(coord, Range::FromMinExtent(make_zero(DataType::Int(32)),
+                                               loop_layout->OutputShape()[i]));
+    partition_vars.push_back(coord);
   }
   partition_vars.push_back(thread_var_);
+  if (loop_layout->ThreadRange().defined()) {
+    analyzer->Bind(thread_var_,
+                   Range::FromMinExtent(loop_layout->ThreadRange()->min,
+                                        loop_layout->ThreadRange()->extent));
+  } else {
+    analyzer->Bind(thread_var_,
+                   Range::FromMinExtent(make_zero(DataType::Int(32)),
+                                        loop_layout->ThreadExtent()));
+  }
 
   Array<PrimExpr> recovered_indices;
   try {

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -272,5 +272,100 @@ def test_column_broadcast_fragment_values(block_n):
     assert torch.equal(out, expected)
 
 
+def test_spill_pricing_no_false_positive_on_strided_fragment_layouts():
+    """Distilled from hai-llm's kl_div_with_mask large-d kernel (a 1.23-1.29x
+    production regression): a pipelined scan staging fp32/int8 chunks through
+    shared memory into fragments, reduced by per-iteration scalar reducers.
+
+    The canonical strided fragment distribution (thread = (i // vec) % threads,
+    conflict-free shared loads at `smem[k*512 + tid*4]`) proves its physical
+    index thread-free only RANGE-DEPENDENTLY: `(o0*512 + t*4 + o1) // 512 ->
+    o0` needs `t*4 + o1 < 512`. If FragmentThreadIndexProbe does not bind the
+    symbolic coordinate ranges, that cancellation fails, the identity access
+    is falsely charged as a register spill, and the pricing steers the solver
+    to the chunk-contiguous layout (`smem[tid*16 + k*4]`, a 16-word stride
+    that bank-conflicts on every shared load)."""
+    d_blk, n_chunk, threads = 2048, 4, 128
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((n_chunk * d_blk,), T.float32),
+        Bt: T.Tensor((n_chunk * d_blk,), T.float32),
+        Mk: T.Tensor((n_chunk * d_blk,), T.int8),
+        Out: T.Tensor((1,), T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            run_sum = T.alloc_fragment(1, T.float32)
+            run_max = T.alloc_fragment(1, T.float32)
+            num_ninf = T.alloc_reducer(1, T.int32, op="sum")
+            T.fill(run_sum, 0)
+            T.fill(run_max, -T.infinity(T.float32))
+            T.reducer_init(num_ninf)
+            a_smem = T.alloc_shared((d_blk,), T.float32)
+            t_smem = T.alloc_shared((d_blk,), T.float32)
+            m_smem = T.alloc_shared((d_blk,), T.int8)
+            a_frag = T.alloc_fragment((d_blk,), T.float32)
+            t_frag = T.alloc_fragment((d_blk,), T.float32)
+            m_frag = T.alloc_fragment((d_blk,), T.int32)
+            for i0 in T.Pipelined(n_chunk, num_stages=2):
+                T.copy(A[i0 * d_blk], a_smem)
+                T.copy(Bt[i0 * d_blk], t_smem)
+                T.copy(a_smem, a_frag)
+                T.copy(t_smem, t_frag)
+                T.copy(Mk[i0 * d_blk], m_smem)
+                T.copy(m_smem, m_frag)
+                new_sum = T.alloc_reducer(1, T.float32, op="sum")
+                new_max = T.alloc_reducer(1, T.float32, op="max")
+                T.reducer_init(new_sum)
+                T.reducer_init(new_max, run_max[0])
+                for i1 in T.Parallel(d_blk):
+                    t_frag[i1] = t_frag[i1] * 0.5
+                    if m_frag[i1] == 0:
+                        t_frag[i1] = 0
+                        a_frag[i1] = -T.infinity(T.float32)
+                    T.reducer_update(new_sum[0], t_frag[i1])
+                    T.reducer_update(new_max[0], a_frag[i1])
+                    T.reducer_update(num_ninf[0], T.cast(a_frag[i1] == -T.infinity(T.float32), T.int32))
+                new_sum_out = T.alloc_fragment(1, T.float32)
+                new_max_out = T.alloc_fragment(1, T.float32)
+                T.finalize_reducer(new_sum, new_sum_out)
+                T.finalize_reducer(new_max, new_max_out)
+                run_sum[0] = run_sum[0] + new_sum_out[0]
+                run_max[0] = new_max_out[0]
+            num_ninf_out = T.alloc_fragment(1, T.int32)
+            T.finalize_reducer(num_ninf, num_ninf_out)
+            if T.get_thread_binding() == 0:
+                Out[0] = run_sum[0] + run_max[0] + T.Cast(T.float32, num_ninf_out[0])
+
+    kern = tl.compile(
+        kernel,
+        out_idx=-1,
+        pass_configs={
+            # Pin 128-bit vectorization so the asserted distribution (float4,
+            # thread stride 4) is architecture-independent.
+            tl.PassConfigKey.TL_DISABLE_VECTORIZE_256: True,
+            tl.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+            tl.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        },
+    )
+    src = kern.get_kernel_source()
+    frag_loads = [line for line in src.splitlines() if ("a_frag" in line or "t_frag" in line) and "smem" in line]
+    assert frag_loads, src
+    for line in frag_loads:
+        # Strided distribution: each thread holds float4 vectors 512 apart.
+        assert "(((int)threadIdx.x) * 4)" in line, (line, src)
+        # Chunk-contiguous distribution (bank-conflicting) must not be chosen.
+        assert "(((int)threadIdx.x) * 16)" not in line, (line, src)
+
+    a = torch.randn(n_chunk * d_blk, dtype=torch.float32, device="cuda")
+    bt = torch.randn(n_chunk * d_blk, dtype=torch.float32, device="cuda")
+    mk = torch.randint(0, 2, (n_chunk * d_blk,), dtype=torch.int8, device="cuda")
+    out = kern(a, bt, mk)
+    t = torch.where(mk == 0, torch.zeros_like(bt), bt * 0.5)
+    am = torch.where(mk == 0, torch.full_like(a, float("-inf")), a)
+    ref = t.sum() + am.max() + (am == float("-inf")).sum().float()
+    torch.testing.assert_close(out, ref.reshape(1), rtol=1e-5, atol=1e-5)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

Fixes a performance regression introduced by #3093: the spill-pricing probe (`FragmentThreadIndexProbe`) produced false positives on strided fragment layouts, steering layout inference toward shared-memory bank-conflicting chunk-contiguous layouts. Observed as a 1.23x/1.29x latency regression (8.8ms vs 6.8ms, H800) on a production KL-divergence kernel (n=8192, d=262144).

## Root cause

The probe inverts a candidate loop layout into symbolic per-thread coordinates plus a symbolic thread variable, and flags an access as spilling if any fragment physical index still contains the thread variable after simplification. Proving a strided distribution thread-free is **range-dependent**:

```
(o0*512 + t*4 + o1) // 512  ->  o0     (only holds for t*4 + o1 < 512)
```

The symbolic vars were never bound in the analyzer, so this cancellation failed and even an **identity access** (loop layout == fragment layout) was charged as a full register-array spill. Chunk-contiguous layouts cancel unconditionally (`(t*16 + o) % 16 -> o`), so the pricing systematically penalized exactly the conflict-free strided layouts:

- strided (previous choice): `frag[k*4] = smem[k*512 + tid*4]` — conflict-free
- after the false charge: `frag[k*4] = smem[tid*16 + k*4]` — 16-word stride, bank conflicts on every shared load

The missing binding predates #3093 (the same unbound simplification existed in `HasThreadDependentFragmentIndex`), but was harmless there: it was consulted only behind the shared/global-store gate, compared two candidates symmetrically, and had no cross-attempt pricing power. #3093 promoted the probe into a fleet-wide pricing signal, where the asymmetric false positive flips attempt winners.

## Fix

Bind every per-thread output coordinate to its output-shape range and the thread variable to the loop's thread range/extent in the probe constructor. Range information only enables valid cancellations — genuine thread dependence (the real spill shapes the pricing exists for) is unaffected.

## Testing

- New regression test distilled from the affected production kernel: fails before the fix (chunk-contiguous layout chosen), passes after (strided layout restored). Codegen verified byte-equivalent (modulo buffer numbering) to pre-#3093 output on the original kernel.
- `testing/python/transform/test_tilelang_transform_layout_inference.py`: 16 passed
- `testing/python/language/test_tilelang_language_reducer_v2.py`: 75 passed (includes the staged-chain publication test guarding the genuine-spill path)
- `testing/python/language/test_tilelang_language_reduce.py`: 93 passed (3 pre-existing arch-dependent failures, unrelated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Bind symbolic fragment coordinates and thread variables to valid ranges.
- Restore strided fragment layout inference.
- Prevent false spill detection and bank-conflicting layout selection.
- Add a KL-divergence regression test for layout generation and numerical correctness.
- Preserve detection of genuine thread-dependent spills.

## Testing

- Ran layout inference and reducer test suites.
- Three unrelated architecture-dependent failures remain.

## C++ style / lint notes

- The PR does not change rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step applies.
- No warning-only findings were reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->