### PR TITLE
[CUDA] Add 16-bit overloads for CUTLASS fast-math functions

### DIFF
--- a/src/tl_templates/cuda/math.h
+++ b/src/tl_templates/cuda/math.h
@@ -13,9 +13,36 @@
 #define hpow powf
 
 namespace cutlass {
-// Mirror cutlass's own half_t fast_exp (fast_math.h): route through float.
-// A direct `return ::hexp(x)` recurses, since `hexp` is #define'd to this
-// same cutlass::fast_exp and x is already bfloat16_t.
+// CUTLASS lacks 16-bit overloads for these functions except fast_exp and
+// fast_tanh on half_t. Evaluate through float and convert back, matching its
+// fast_exp fallback. Use fast_* here because the h* aliases would recurse.
 TL_DEVICE
 bfloat16_t fast_exp(bfloat16_t x) { return bfloat16_t(fast_exp(float(x))); }
+
+TL_DEVICE
+half_t fast_log(half_t x) { return half_t(fast_log(float(x))); }
+
+TL_DEVICE
+bfloat16_t fast_log(bfloat16_t x) { return bfloat16_t(fast_log(float(x))); }
+
+TL_DEVICE
+half_t fast_sqrt(half_t x) { return half_t(fast_sqrt(float(x))); }
+
+TL_DEVICE
+bfloat16_t fast_sqrt(bfloat16_t x) { return bfloat16_t(fast_sqrt(float(x))); }
+
+TL_DEVICE
+half_t fast_sin(half_t x) { return half_t(fast_sin(float(x))); }
+
+TL_DEVICE
+bfloat16_t fast_sin(bfloat16_t x) { return bfloat16_t(fast_sin(float(x))); }
+
+TL_DEVICE
+half_t fast_cos(half_t x) { return half_t(fast_cos(float(x))); }
+
+TL_DEVICE
+bfloat16_t fast_cos(bfloat16_t x) { return bfloat16_t(fast_cos(float(x))); }
+
+TL_DEVICE
+bfloat16_t fast_tanh(bfloat16_t x) { return bfloat16_t(fast_tanh(float(x))); }
 } // namespace cutlass

--- a/testing/python/language/test_tilelang_language_fastmath.py
+++ b/testing/python/language/test_tilelang_language_fastmath.py
@@ -1,8 +1,11 @@
 import re
 
 import pytest
+import torch
 
+import tilelang
 import tilelang.language as T
+import tilelang.testing
 from tvm import tirx
 
 
@@ -54,3 +57,120 @@ def test_fastmath_accepts_float_dtype_at_frontend(intrinsic, dtype):
 
     assert isinstance(result, tirx.Call)
     assert result.dtype == dtype
+
+
+# Rows written by the kernels below, in order. The "pos" domain keeps the log
+# family defined and exp10 finite in float16; "sym" is mixed-sign and stays
+# clear of tan's pole.
+FASTMATH_ROWS = (
+    ("__exp", torch.exp, "pos"),
+    ("__exp10", lambda x: torch.pow(10.0, x), "pos"),
+    ("__log", torch.log, "pos"),
+    ("__log2", torch.log2, "pos"),
+    ("__log10", torch.log10, "pos"),
+    ("__sin", torch.sin, "sym"),
+    ("__cos", torch.cos, "sym"),
+    ("__tan", torch.tan, "sym"),
+)
+
+MIXED_ROWS = (
+    ("log", torch.log, "pos"),
+    ("sqrt", torch.sqrt, "pos"),
+    ("sin", torch.sin, "sym"),
+    ("cos", torch.cos, "sym"),
+    ("tanh", torch.tanh, "sym"),
+    ("__exp", torch.exp, "pos"),
+)
+
+TOLERANCE = 2e-2
+
+
+def _fastmath_kernel(dtype, N):
+    @T.prim_func
+    def main(
+        P: T.Tensor((N,), dtype),
+        S: T.Tensor((N,), dtype),
+        B: T.Tensor((len(FASTMATH_ROWS), N), dtype),
+    ):
+        with T.Kernel(1, threads=N):
+            i = T.get_thread_binding()
+            # Materialize each result: copy-initialization rejects a
+            # float-returning call, while a store only needs an assignment.
+            exp_value = T.__exp(P[i])
+            exp10_value = T.__exp10(P[i])
+            log_value = T.__log(P[i])
+            log2_value = T.__log2(P[i])
+            log10_value = T.__log10(P[i])
+            sin_value = T.__sin(S[i])
+            cos_value = T.__cos(S[i])
+            tan_value = T.__tan(S[i])
+            B[0, i] = exp_value
+            B[1, i] = exp10_value
+            B[2, i] = log_value
+            B[3, i] = log2_value
+            B[4, i] = log10_value
+            B[5, i] = sin_value
+            B[6, i] = cos_value
+            B[7, i] = tan_value
+
+    return main
+
+
+def _mixed_kernel(dtype, N):
+    @T.prim_func
+    def main(
+        P: T.Tensor((N,), dtype),
+        S: T.Tensor((N,), dtype),
+        B: T.Tensor((len(MIXED_ROWS), N), dtype),
+    ):
+        with T.Kernel(1, threads=N):
+            i = T.get_thread_binding()
+            log_value = T.log(P[i])
+            sqrt_value = T.sqrt(P[i])
+            sin_value = T.sin(S[i])
+            cos_value = T.cos(S[i])
+            tanh_value = T.tanh(S[i])
+            # This single fast-math op pulls math.h into the whole kernel,
+            # rebinding every half-style name above to a cutlass::fast_* macro.
+            exp_value = T.__exp(P[i])
+            B[0, i] = log_value
+            B[1, i] = sqrt_value
+            B[2, i] = sin_value
+            B[3, i] = cos_value
+            B[4, i] = tanh_value
+            B[5, i] = exp_value
+
+    return main
+
+
+def _run(kernel_fn, rows, dtype):
+    N = 128
+    kernel = tilelang.compile(kernel_fn(dtype, N), target="cuda")
+    torch_dtype = getattr(torch, dtype)
+    p = (torch.arange(N, device="cuda") * 0.03125 + 0.3).to(torch_dtype)
+    s = ((torch.arange(N, device="cuda") - 63.5) * 0.02).to(torch_dtype)
+    b = torch.empty(len(rows), N, device="cuda", dtype=torch_dtype)
+    kernel(p, s, b)
+
+    inputs = {"pos": p, "sym": s}
+    for row, (name, ref_fn, domain) in enumerate(rows):
+        ref = ref_fn(inputs[domain].float())
+        torch.testing.assert_close(
+            b[row].float(),
+            ref.to(torch_dtype).float(),
+            atol=TOLERANCE,
+            rtol=TOLERANCE,
+            msg=lambda base, name=name: f"T.{name} mismatch\n{base}",
+        )
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_fastmath_16bit_intrinsics(dtype):
+    _run(_fastmath_kernel, FASTMATH_ROWS, dtype)
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_plain_math_alongside_fastmath(dtype):
+    _run(_mixed_kernel, MIXED_ROWS, dtype)


### PR DESCRIPTION
## Summary

`math.h` aliases several half-style names to `cutlass::fast_*` when a kernel uses selected fast-math intrinsics. CUTLASS provides only `float` and `double` overloads for `fast_log`, `fast_sqrt`, `fast_sin`, and `fast_cos`, and adds `half_t` overloads only for `fast_exp` and `fast_tanh`.

A 16-bit call can therefore resolve through a `float` overload and leave a `float` result that cannot copy-initialize the CUTLASS wrapper. Because `math.h` is included per kernel, a fast-math intrinsic such as `T.__exp` also affects matching plain calls in the same kernel:

```python
with T.Kernel(1, threads=N):  # A and B are float16
    i = T.get_thread_binding()
    fast_value = T.__exp(A[i])
    plain_value = T.log(A[i])
    B[i] = fast_value + plain_value
```

```text
error: no suitable constructor exists to convert from "float" to "cutlass::half_t"
```

For float16, the same materialized-result failure affects `T.sqrt`, `T.sin`, and `T.cos`. For bfloat16, the aliased calls can also fail when stored directly, and `T.tanh` lacks the corresponding `fast_tanh` overload.

## Fix

Add `half_t` and `bfloat16_t` overloads for `fast_log`, `fast_sqrt`, `fast_sin`, and `fast_cos`, plus a `bfloat16_t` overload for `fast_tanh`.

Each overload evaluates in float32 and converts the result back, following the existing `fast_exp(bfloat16_t)` bridge. Calls that already compiled retain the same numerical path. The alias list is unchanged.

## Tests

Added one kernel per dtype: all eight fast-math operations with materialized results, and five plain operations alongside a single `T.__exp` to cover the per-kernel aliasing. Positive and mixed-sign input domains, compared against float32 PyTorch references.

Verified locally on `sm_75` / CUDA 12.4 with the kernel cache disabled:

* Touched test file: 124 passed.
* Negative control: 4 failed, 120 passed.
* Related fast-math and intrinsic suites: 199 passed.

## Scope

This change is limited to `cutlass::fast_*` functions whose 16-bit overloads are missing. It does not cover:

* plain half-style operations without a native CUDA 16-bit intrinsic, such as `sinh`, `cosh`, `tanh`, `atan`, and `erf`, which require a separate float32 fallback decision;
* `hpow`, which aliases `powf` rather than a CUTLASS function: bfloat16 is rejected by the frontend, while float16 requires separate wrapper handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added CUDA 16-bit overloads for CUTLASS `fast_log`, `fast_sqrt`, `fast_sin`, `fast_cos`, and `fast_tanh`.
- Routed supported 16-bit operations through `float32`.
- Added CUDA tests for `float16` and `bfloat16` fast-math operations and per-kernel aliasing.

## Testing

- Compared results with `float32` PyTorch references.
- Covered positive and mixed-sign inputs.
- Verified locally on `sm_75` with CUDA 12.4.

## C++ style / lint notes

- The change touches C++ code in `src/`, which is covered by `docs/developer_guide/cpp_style.md`.
- It does not change the documented style rules.
- The `C++ API Style Audit (warning only)` CI step remains advisory.
- No correctness or build issues are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->