### PR TITLE
[Cleanup] Remove obsolete disable-fast-math pass config

### DIFF
--- a/examples/deepseek_v32/inference/kernel.py
+++ b/examples/deepseek_v32/inference/kernel.py
@@ -7,7 +7,7 @@ tilelang.set_log_level("WARNING")
 
 pass_configs = {
     tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-    tilelang.PassConfigKey.TL_DISABLE_FAST_MATH: True}
+}
 
 FP8 = T.float8_e4m3fn
 BF16 = T.bfloat16

--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -21,7 +21,6 @@ TVM_REGISTER_PASS_CONFIG_OPTION(kConfigIndexBitwidth, Integer);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableAggressiveSharedMemoryMerge, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableSharedMemoryReuse, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kForceLetInline, Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION(kDisableFastMath, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableFastMath, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableAsyncCopy, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kReducerForceBaseline, Bool);

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -59,7 +59,6 @@ static constexpr const char *kEnableAggressiveSharedMemoryMerge =
     "tl.enable_aggressive_shared_memory_merge";
 static constexpr const char *kDisableSharedMemoryReuse =
     "tl.disable_shared_memory_reuse";
-static constexpr const char *kDisableFastMath = "tl.disable_fast_math";
 static constexpr const char *kEnableFastMath = "tl.enable_fast_math";
 static constexpr const char *kEnableAsyncCopy = "tl.enable_async_copy";
 // Force the canonical FullParticipant baseline for every reducer epoch,

--- a/testing/python/components/test_tilelang_pass_config_fast_math.py
+++ b/testing/python/components/test_tilelang_pass_config_fast_math.py
@@ -1,0 +1,8 @@
+from tilelang import tvm
+
+
+def test_disable_fast_math_pass_config_is_removed():
+    configs = tvm.transform.PassContext.list_configs()
+
+    assert "tl.disable_fast_math" not in configs
+    assert "tl.enable_fast_math" in configs


### PR DESCRIPTION
## Summary

- remove the unused native registration for `tl.disable_fast_math`
- remove a stale `TL_DISABLE_FAST_MATH` reference from the DeepSeek V3.2 inference example; fast math remains disabled by default
- add a portable regression test that keeps the obsolete key unregistered while preserving `tl.enable_fast_math`

The Python enum and behavior for the old disable flag were removed in v0.1.7.post1, so the remaining native registration only accepted a configuration that had no effect.

## Validation

- `cmake --build build -j$(nproc)`
- `PYTHONPATH=$(pwd) python -m pytest testing/python/components -x -q` (30 passed)
- `PYTHONPATH=$(pwd) python -m pytest testing/python/math/test_math_fast_math.py -x -q` (38 passed)
- `PYTHONPATH=$(pwd) python -m pytest testing/python/fastmath/test_mathops_fastmath.py -x -q` (32 passed)
- import smoke for `examples/deepseek_v32/inference/kernel.py`
- `bash format.sh --files src/op/builtin.h src/op/builtin.cc examples/deepseek_v32/inference/kernel.py testing/python/components/test_tilelang_pass_config_fast_math.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed the obsolete `tl.disable_fast_math` registration and `kDisableFastMath` constant.
- Removed the stale `TL_DISABLE_FAST_MATH` setting from the DeepSeek V3.2 inference example.
- Added a regression test that confirms `tl.disable_fast_math` is unregistered and `tl.enable_fast_math` remains available.
- Fast math remains disabled by default.

## Validation

- Builds completed successfully.
- Targeted tests, import smoke tests, formatting, and diff checks passed.

## C++ style / lint notes

- The PR changes C++ files but does not touch rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step applies.
- No correctness or build issues are reported. Any audit findings are advisory only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->