### PR TITLE
[SM120] kind::mxf8f6f4 block-scaled MMA: full f8f6f4 operand family, sub-byte TMA producers, and official examples

### DIFF
--- a/examples/dequantize_gemm/quantize/__init__.py
+++ b/examples/dequantize_gemm/quantize/__init__.py
@@ -28,3 +28,4 @@ from .mxfp4 import (  # noqa: F401
     pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes,
     quantize_bf16_to_mxfp4_blockscaled,
 )
+from .mxfp8 import quantize_bf16_to_mxfp8_blockscaled  # noqa: F401

--- a/examples/dequantize_gemm/quantize/__init__.py
+++ b/examples/dequantize_gemm/quantize/__init__.py
@@ -29,3 +29,10 @@ from .mxfp4 import (  # noqa: F401
     quantize_bf16_to_mxfp4_blockscaled,
 )
 from .mxfp8 import quantize_bf16_to_mxfp8_blockscaled  # noqa: F401
+from .mxfp6 import (  # noqa: F401
+    decode_fp6_values,
+    encode_fp6_values,
+    pack_fp6_codes,
+    quantize_bf16_to_mxfp6_blockscaled,
+    unpack_fp6_bytes,
+)

--- a/examples/dequantize_gemm/quantize/__init__.py
+++ b/examples/dequantize_gemm/quantize/__init__.py
@@ -22,3 +22,9 @@ from .nvfp4 import (  # noqa: F401
     swizzle_blockscaled_chunk_kmajor_scale_words,
     unswizzle_blockscaled_chunk_kmajor_scale_words,
 )
+from .mxfp4 import (  # noqa: F401
+    decode_ue8m0_scale_bytes,
+    encode_ue8m0_scale_bytes,
+    pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes,
+    quantize_bf16_to_mxfp4_blockscaled,
+)

--- a/examples/dequantize_gemm/quantize/mxfp4.py
+++ b/examples/dequantize_gemm/quantize/mxfp4.py
@@ -1,0 +1,139 @@
+"""MXFP4 (E2M1 data + UE8M0 scales) quantization and scale layout utilities.
+
+The SM120 ``blockscaled_chunk_kmajor`` scale layout is shared with NVFP4: the
+physical word order is the same 128-row BlockScaledBasicChunk stack, only the
+per-byte coverage changes (32 K elements per UE8M0 byte, so one uint32 word
+covers K=128 and a ``block_K`` stage holds ``block_K // 128`` words).
+"""
+
+from __future__ import annotations
+
+from .nvfp4 import (
+    _check_block_shape,
+    _import_torch,
+    _pack_scale_bytes_to_words,
+    _FP4_E2M1_MAX,
+    encode_fp4_e2m1_values,
+    pack_fp4_e2m1_codes,
+    swizzle_blockscaled_chunk_kmajor_scale_words,
+)
+
+_MXFP4_SCALE_BLOCK_K = 32
+_SCALE_BYTES_PER_WORD = 4
+
+
+def decode_ue8m0_scale_bytes(scale_bytes):
+    """Decode UE8M0 scale bytes (biased power-of-two exponents) to float32."""
+
+    torch = _import_torch()
+    if not isinstance(scale_bytes, torch.Tensor):
+        raise TypeError(f"scale_bytes must be a torch.Tensor, got {type(scale_bytes)!r}")
+    if scale_bytes.dtype != torch.uint8:
+        raise TypeError(f"scale_bytes must have dtype torch.uint8, got {scale_bytes.dtype}")
+
+    u = scale_bytes.to(torch.int32)
+    value = torch.pow(torch.tensor(2.0, device=scale_bytes.device), (u - 127).to(torch.float32))
+    return torch.where(u == 0xFF, torch.full_like(value, float("nan")), value)
+
+
+def encode_ue8m0_scale_bytes(values, *, rounding: str = "ceil"):
+    """Encode non-negative floats as UE8M0 bytes (power-of-two scales).
+
+    ``rounding="ceil"`` rounds up to the next power of two so values divided
+    by the scale stay within the FP4 range; zero maps to byte ``0x00``.
+    """
+
+    torch = _import_torch()
+    if rounding != "ceil":
+        raise ValueError(f"rounding must be 'ceil', got {rounding!r}")
+    if not isinstance(values, torch.Tensor):
+        raise TypeError(f"values must be a torch.Tensor, got {type(values)!r}")
+
+    x = torch.nan_to_num(values.to(torch.float32), nan=0.0, posinf=2.0**127, neginf=0.0).clamp(min=0.0).contiguous()
+    bits = x.view(torch.int32)
+    exponent = (bits >> 23) & 0xFF
+    mantissa = bits & 0x7FFFFF
+    code = (exponent + (mantissa != 0).to(torch.int32)).clamp(1, 254)
+    code = torch.where(x == 0, torch.zeros_like(code), code)
+    return code.to(torch.uint8)
+
+
+def pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes(scale_bytes, block_rows: int = 128, block_words: int = 2):
+    """Pack UE8M0 scale bytes into SM120 BlockScaledBasicChunk K-major words.
+
+    ``scale_bytes`` carries semantic row-major UE8M0 bytes with shape
+    ``[rows, K / 32]``. The result is
+    ``torch.uint32[ceil(rows / 128) * 128, K // 128]`` in the same physical
+    word order as the NVFP4 packer; ``block_words`` is the per-``block_K``
+    word count (``block_K // 128``).
+    """
+
+    torch = _import_torch()
+    _check_block_shape(block_rows, block_words)
+    if not isinstance(scale_bytes, torch.Tensor):
+        raise TypeError(f"scale_bytes must be a torch.Tensor, got {type(scale_bytes)!r}")
+    if scale_bytes.dtype != torch.uint8:
+        raise TypeError(f"scale_bytes must have dtype torch.uint8, got {scale_bytes.dtype}")
+    if scale_bytes.ndim != 2:
+        raise ValueError(f"scale_bytes must be a 2D tensor, got shape {tuple(scale_bytes.shape)}")
+
+    scale_cols = scale_bytes.shape[1]
+    scale_cols_per_tile = block_words * _SCALE_BYTES_PER_WORD
+    if scale_cols % scale_cols_per_tile != 0:
+        raise ValueError(
+            f"blockscaled_chunk_kmajor UE8M0 scale bytes require K/32 columns multiple of "
+            f"{scale_cols_per_tile}, got {tuple(scale_bytes.shape)}"
+        )
+
+    words = _pack_scale_bytes_to_words(scale_bytes)
+    return swizzle_blockscaled_chunk_kmajor_scale_words(words, block_rows, block_words)
+
+
+def quantize_bf16_to_mxfp4_blockscaled(
+    x,
+    *,
+    block_rows: int = 128,
+    block_words: int = 2,
+    scale_block_k: int = 32,
+    return_scale_bytes: bool = False,
+):
+    """Quantize a BF16 activation tensor to SM120 MXFP4 blockscaled storage.
+
+    Every ``scale_block_k = 32`` consecutive K elements share one UE8M0
+    (power-of-two, ceil-rounded) scale. Returns ``(packed_fp4,
+    scale_source)`` — ``torch.int8[rows, K/2]`` FP4 data and the packed
+    ``torch.uint32[rows_pad, K/128]`` K-major scale source — plus the
+    semantic ``[rows, K/32]`` scale bytes when ``return_scale_bytes`` is set.
+    """
+
+    torch = _import_torch()
+    _check_block_shape(block_rows, block_words)
+    if scale_block_k != _MXFP4_SCALE_BLOCK_K:
+        raise ValueError(f"SM120 MXFP4 scale_block_k must be 32, got {scale_block_k}")
+    if not isinstance(x, torch.Tensor):
+        raise TypeError(f"x must be a torch.Tensor, got {type(x)!r}")
+    if x.ndim != 2:
+        raise ValueError(f"x must be a 2D tensor, got shape {tuple(x.shape)}")
+    if not x.dtype.is_floating_point:
+        raise TypeError(f"x must be a floating-point tensor, got {x.dtype}")
+
+    rows, cols = x.shape
+    scale_cols_per_tile = block_words * _SCALE_BYTES_PER_WORD
+    if rows % block_rows != 0 or cols % (scale_block_k * scale_cols_per_tile) != 0:
+        raise ValueError(
+            f"SM120 MXFP4 quantization requires rows multiple of {block_rows} and K multiple of "
+            f"{scale_block_k * scale_cols_per_tile}, got {tuple(x.shape)}"
+        )
+
+    x_f32 = x.contiguous().to(torch.float32)
+    blocks = x_f32.reshape(rows, cols // scale_block_k, scale_block_k)
+    amax = blocks.abs().amax(dim=2)
+    scale_bytes = encode_ue8m0_scale_bytes(amax / _FP4_E2M1_MAX, rounding="ceil")
+    scale_values = decode_ue8m0_scale_bytes(scale_bytes)
+    scaled_blocks = torch.where(amax[..., None] > 0, blocks / scale_values[..., None], torch.zeros_like(blocks))
+    fp4_codes = encode_fp4_e2m1_values(scaled_blocks.reshape(rows, cols))
+    packed_fp4 = pack_fp4_e2m1_codes(fp4_codes)
+    packed_scales = pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes(scale_bytes, block_rows=block_rows, block_words=block_words)
+    if return_scale_bytes:
+        return packed_fp4, packed_scales, scale_bytes
+    return packed_fp4, packed_scales

--- a/examples/dequantize_gemm/quantize/mxfp4.py
+++ b/examples/dequantize_gemm/quantize/mxfp4.py
@@ -41,6 +41,8 @@ def encode_ue8m0_scale_bytes(values, *, rounding: str = "ceil"):
 
     ``rounding="ceil"`` rounds up to the next power of two so values divided
     by the scale stay within the FP4 range; zero maps to byte ``0x00``.
+    Values above the largest representable scale (``2**127``) saturate to
+    byte ``0xFE`` (``0xFF`` is the UE8M0 NaN encoding and is never produced).
     """
 
     torch = _import_torch()
@@ -49,7 +51,7 @@ def encode_ue8m0_scale_bytes(values, *, rounding: str = "ceil"):
     if not isinstance(values, torch.Tensor):
         raise TypeError(f"values must be a torch.Tensor, got {type(values)!r}")
 
-    x = torch.nan_to_num(values.to(torch.float32), nan=0.0, posinf=2.0**127, neginf=0.0).clamp(min=0.0).contiguous()
+    x = torch.nan_to_num(values.to(torch.float32), nan=0.0, posinf=2.0**127, neginf=0.0).clamp(min=0.0, max=2.0**127).contiguous()
     bits = x.view(torch.int32)
     exponent = (bits >> 23) & 0xFF
     mantissa = bits & 0x7FFFFF

--- a/examples/dequantize_gemm/quantize/mxfp4.py
+++ b/examples/dequantize_gemm/quantize/mxfp4.py
@@ -106,6 +106,12 @@ def quantize_bf16_to_mxfp4_blockscaled(
     scale_source)`` — ``torch.int8[rows, K/2]`` FP4 data and the packed
     ``torch.uint32[rows_pad, K/128]`` K-major scale source — plus the
     semantic ``[rows, K/32]`` scale bytes when ``return_scale_bytes`` is set.
+
+    Special values: a NaN input poisons its block's amax, which encodes to
+    scale byte ``0x00`` and the whole 32-element block is written as zeros;
+    an Inf input saturates the block scale to ``0xFE`` (``2**127``) and the
+    Inf element to the FP4 max, collapsing the block's finite elements
+    toward zero. Both behaviors are pinned by CPU tests.
     """
 
     torch = _import_torch()

--- a/examples/dequantize_gemm/quantize/mxfp6.py
+++ b/examples/dequantize_gemm/quantize/mxfp6.py
@@ -1,0 +1,160 @@
+"""MXFP6 (E2M3/E3M2 data + UE8M0 scales) quantization utilities for SM120.
+
+Scale storage is byte-identical to the MXFP4/MXFP8 layout (one UE8M0 byte
+per 32 K elements, BlockScaledBasicChunk K-major words). Data storage:
+torch has no fp6 dtype, so packed fp6 lives in uint8 blobs - 4 elements per
+3 bytes as an LSB-first 6-bit stream, matching the bit order of the
+16U6_ALIGN16B smem form and the ``b6x16_p32`` ldmatrix (hardware-pinned in
+the sub-byte ldmatrix tests). Global footprint is exactly ``numel * 3 / 4``
+bytes (0.75 B/elem - the compression invariant).
+"""
+
+from __future__ import annotations
+
+from .mxfp4 import (
+    _MXFP4_SCALE_BLOCK_K as _MXFP6_SCALE_BLOCK_K,
+    _SCALE_BYTES_PER_WORD,
+    decode_ue8m0_scale_bytes,
+    encode_ue8m0_scale_bytes,
+    pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes,
+)
+from .nvfp4 import _check_block_shape, _import_torch
+
+# e2m3: 1 sign, 2 exponent (bias 1), 3 mantissa -> max 1.875 * 2^2 = 7.5
+# e3m2: 1 sign, 3 exponent (bias 3), 2 mantissa -> max 1.75 * 2^4 = 28
+_FP6_MAX = {"e2m3": 7.5, "e3m2": 28.0}
+_FP6_SPECS = {"e2m3": (2, 3, 1), "e3m2": (3, 2, 3)}  # (exp_bits, man_bits, bias)
+
+
+def _fp6_code_values(dtype: str):
+    """Decode table: value of each of the 64 fp6 codes (sign at bit 5)."""
+    torch = _import_torch()
+    exp_bits, man_bits, bias = _FP6_SPECS[dtype]
+    values = []
+    for code in range(64):
+        sign = -1.0 if (code >> 5) & 1 else 1.0
+        exp = (code >> man_bits) & ((1 << exp_bits) - 1)
+        man = code & ((1 << man_bits) - 1)
+        if exp == 0:  # subnormal: man * 2^(1 - bias - man_bits)
+            value = man * 2.0 ** (1 - bias - man_bits)
+        else:  # normal; fp6 has no Inf/NaN encodings (fn types)
+            value = (1.0 + man * 2.0**-man_bits) * 2.0 ** (exp - bias)
+        values.append(sign * value)
+    return torch.tensor(values, dtype=torch.float32)
+
+
+def encode_fp6_values(values, dtype: str):
+    """Round-to-nearest fp6 codes for a float tensor (saturating).
+
+    Ties resolve toward the even mantissa code, matching IEEE
+    round-to-nearest-even on the code lattice.
+    """
+    torch = _import_torch()
+    if dtype not in _FP6_SPECS:
+        raise ValueError(f"dtype must be one of {sorted(_FP6_SPECS)}, got {dtype!r}")
+    lut = _fp6_code_values(dtype).to(values.device)
+    magnitude_codes = torch.arange(32, device=values.device)
+    magnitudes = lut[:32]  # codes 0..31 are the non-negative values, ascending
+    x = torch.nan_to_num(values.to(torch.float32), nan=0.0)
+    sign = x < 0
+    mag = x.abs().clamp(max=_FP6_MAX[dtype])
+    # Midpoints separate nearest-code regions; on an exact midpoint the two
+    # bucketize flavors disagree by one, and we pick the even code (RN-even).
+    midpoints = (magnitudes[:-1] + magnitudes[1:]) / 2
+    idx_low = torch.bucketize(mag, midpoints, right=False)
+    idx_high = torch.bucketize(mag, midpoints, right=True)
+    tie = idx_low != idx_high
+    idx = torch.where(tie & (idx_low % 2 == 0), idx_low, idx_high)
+    codes = magnitude_codes[idx]
+    return (codes | (sign.to(torch.int64) << 5)).to(torch.uint8)
+
+
+def decode_fp6_values(codes, dtype: str):
+    torch = _import_torch()
+    lut = _fp6_code_values(dtype).to(codes.device)
+    return lut[codes.to(torch.long)]
+
+
+def pack_fp6_codes(codes):
+    """Pack 6-bit codes as an LSB-first bitstream: 4 elements -> 3 bytes.
+
+    The bit order matches the 16U6_ALIGN16B payload consumed by the
+    ``b6x16_p32`` ldmatrix (element i occupies bits [6i, 6i+6) of the
+    stream), so packed groups can be staged into smem byte-for-byte.
+    """
+    torch = _import_torch()
+    if codes.dtype != torch.uint8:
+        raise TypeError(f"codes must be torch.uint8, got {codes.dtype}")
+    rows, cols = codes.shape
+    if cols % 4 != 0:
+        raise ValueError(f"fp6 packing requires K multiple of 4, got {tuple(codes.shape)}")
+    c = codes.reshape(rows, cols // 4, 4).to(torch.int32)
+    b0 = c[:, :, 0] | ((c[:, :, 1] & 0x3) << 6)
+    b1 = (c[:, :, 1] >> 2) | ((c[:, :, 2] & 0xF) << 4)
+    b2 = (c[:, :, 2] >> 4) | (c[:, :, 3] << 2)
+    return torch.stack([b0, b1, b2], dim=2).reshape(rows, cols * 3 // 4).to(torch.uint8)
+
+
+def unpack_fp6_bytes(packed, cols: int):
+    """Inverse of ``pack_fp6_codes`` (for round-trip tests and references)."""
+    torch = _import_torch()
+    rows = packed.shape[0]
+    b = packed.reshape(rows, cols // 4, 3).to(torch.int32)
+    c0 = b[:, :, 0] & 0x3F
+    c1 = ((b[:, :, 0] >> 6) | (b[:, :, 1] << 2)) & 0x3F
+    c2 = ((b[:, :, 1] >> 4) | (b[:, :, 2] << 4)) & 0x3F
+    c3 = (b[:, :, 2] >> 2) & 0x3F
+    return torch.stack([c0, c1, c2, c3], dim=2).reshape(rows, cols).to(torch.uint8)
+
+
+def quantize_bf16_to_mxfp6_blockscaled(
+    x,
+    *,
+    dtype: str = "e3m2",
+    block_rows: int = 128,
+    block_words: int = 2,
+    scale_block_k: int = 32,
+    return_scale_bytes: bool = False,
+):
+    """Quantize a BF16 tensor to SM120 MXFP6 blockscaled storage.
+
+    Returns ``(packed_fp6, scale_source)`` - a ``torch.uint8[rows, K*3/4]``
+    LSB-first fp6 blob and the packed ``torch.uint32[rows_pad, K/128]``
+    K-major scale source - plus the semantic ``[rows, K/32]`` scale bytes
+    when ``return_scale_bytes`` is set. NaN/Inf behavior matches the
+    MXFP4/MXFP8 quantizers (NaN zeroes its block via scale 0x00; Inf
+    saturates the block scale to 0xFE).
+    """
+    torch = _import_torch()
+    _check_block_shape(block_rows, block_words)
+    if scale_block_k != _MXFP6_SCALE_BLOCK_K:
+        raise ValueError(f"SM120 MXFP6 scale_block_k must be 32, got {scale_block_k}")
+    if dtype not in _FP6_MAX:
+        raise ValueError(f"dtype must be one of {sorted(_FP6_MAX)}, got {dtype!r}")
+    if not isinstance(x, torch.Tensor):
+        raise TypeError(f"x must be a torch.Tensor, got {type(x)!r}")
+    if x.ndim != 2:
+        raise ValueError(f"x must be a 2D tensor, got shape {tuple(x.shape)}")
+    if not x.dtype.is_floating_point:
+        raise TypeError(f"x must be a floating-point tensor, got {x.dtype}")
+
+    rows, cols = x.shape
+    scale_cols_per_tile = block_words * _SCALE_BYTES_PER_WORD
+    if rows % block_rows != 0 or cols % (scale_block_k * scale_cols_per_tile) != 0:
+        raise ValueError(
+            f"SM120 MXFP6 quantization requires rows multiple of {block_rows} and K multiple of "
+            f"{scale_block_k * scale_cols_per_tile}, got {tuple(x.shape)}"
+        )
+
+    x_f32 = x.contiguous().to(torch.float32)
+    blocks = x_f32.reshape(rows, cols // scale_block_k, scale_block_k)
+    amax = blocks.abs().amax(dim=2)
+    scale_bytes = encode_ue8m0_scale_bytes(amax / _FP6_MAX[dtype], rounding="ceil")
+    scale_values = decode_ue8m0_scale_bytes(scale_bytes)
+    scaled_blocks = torch.where(amax[..., None] > 0, blocks / scale_values[..., None], torch.zeros_like(blocks))
+    fp6_codes = encode_fp6_values(scaled_blocks.reshape(rows, cols), dtype)
+    packed_fp6 = pack_fp6_codes(fp6_codes)
+    packed_scales = pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes(scale_bytes, block_rows=block_rows, block_words=block_words)
+    if return_scale_bytes:
+        return packed_fp6, packed_scales, scale_bytes
+    return packed_fp6, packed_scales

--- a/examples/dequantize_gemm/quantize/mxfp8.py
+++ b/examples/dequantize_gemm/quantize/mxfp8.py
@@ -72,6 +72,10 @@ def quantize_bf16_to_mxfp8_blockscaled(
     scale_bytes = encode_ue8m0_scale_bytes(amax / _FP8_MAX[dtype], rounding="ceil")
     scale_values = decode_ue8m0_scale_bytes(scale_bytes)
     scaled_blocks = torch.where(amax[..., None] > 0, blocks / scale_values[..., None], torch.zeros_like(blocks))
+    # Saturate before the cast: a direct cast of Inf yields NaN for e4m3fn
+    # (which has no Inf encoding) and preserves Inf for e5m2; the contract
+    # is that Inf saturates to the format maximum (pinned by CPU tests).
+    scaled_blocks = scaled_blocks.clamp(min=-_FP8_MAX[dtype], max=_FP8_MAX[dtype])
     torch_fp8 = torch.float8_e4m3fn if dtype == "e4m3" else torch.float8_e5m2
     fp8_data = scaled_blocks.reshape(rows, cols).to(torch_fp8)
     packed_scales = pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes(scale_bytes, block_rows=block_rows, block_words=block_words)

--- a/examples/dequantize_gemm/quantize/mxfp8.py
+++ b/examples/dequantize_gemm/quantize/mxfp8.py
@@ -1,0 +1,80 @@
+"""MXFP8 (FP8 data + UE8M0 scales) quantization utilities for SM120.
+
+The scale storage is byte-identical to the MXFP4 layout: one UE8M0 byte per
+``scale_block_k = 32`` consecutive K elements, packed into the SM120
+BlockScaledBasicChunk K-major word order (one uint32 word covers K=128).
+Only the data side differs - FP8 elements are stored one per byte, so the
+global A/B footprint is exactly ``numel`` bytes (the compression invariant
+tests pin this).
+"""
+
+from __future__ import annotations
+
+from .mxfp4 import (
+    _MXFP4_SCALE_BLOCK_K as _MXFP8_SCALE_BLOCK_K,
+    _SCALE_BYTES_PER_WORD,
+    decode_ue8m0_scale_bytes,
+    encode_ue8m0_scale_bytes,
+    pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes,
+)
+from .nvfp4 import _check_block_shape, _import_torch
+
+_FP8_MAX = {"e4m3": 448.0, "e5m2": 57344.0}
+
+
+def quantize_bf16_to_mxfp8_blockscaled(
+    x,
+    *,
+    dtype: str = "e4m3",
+    block_rows: int = 128,
+    block_words: int = 2,
+    scale_block_k: int = 32,
+    return_scale_bytes: bool = False,
+):
+    """Quantize a BF16 activation tensor to SM120 MXFP8 blockscaled storage.
+
+    Every ``scale_block_k = 32`` consecutive K elements share one UE8M0
+    (power-of-two, ceil-rounded) scale chosen so the scaled block fits the
+    target FP8 range. Returns ``(fp8_data, scale_source)`` — a
+    ``torch.float8_*[rows, K]`` tensor and the packed
+    ``torch.uint32[rows_pad, K/128]`` K-major scale source — plus the
+    semantic ``[rows, K/32]`` scale bytes when ``return_scale_bytes`` is set.
+
+    Special values follow the MXFP4 quantizer: NaN poisons its block's amax
+    (scale byte ``0x00``, block written as zeros); Inf saturates the block
+    scale to ``0xFE`` and the Inf element to the FP8 max.
+    """
+
+    torch = _import_torch()
+    _check_block_shape(block_rows, block_words)
+    if scale_block_k != _MXFP8_SCALE_BLOCK_K:
+        raise ValueError(f"SM120 MXFP8 scale_block_k must be 32, got {scale_block_k}")
+    if dtype not in _FP8_MAX:
+        raise ValueError(f"dtype must be one of {sorted(_FP8_MAX)}, got {dtype!r}")
+    if not isinstance(x, torch.Tensor):
+        raise TypeError(f"x must be a torch.Tensor, got {type(x)!r}")
+    if x.ndim != 2:
+        raise ValueError(f"x must be a 2D tensor, got shape {tuple(x.shape)}")
+    if not x.dtype.is_floating_point:
+        raise TypeError(f"x must be a floating-point tensor, got {x.dtype}")
+
+    rows, cols = x.shape
+    scale_cols_per_tile = block_words * _SCALE_BYTES_PER_WORD
+    if rows % block_rows != 0 or cols % (scale_block_k * scale_cols_per_tile) != 0:
+        raise ValueError(
+            f"SM120 MXFP8 quantization requires rows multiple of {block_rows} and K multiple of "
+            f"{scale_block_k * scale_cols_per_tile}, got {tuple(x.shape)}"
+        )
+
+    x_f32 = x.contiguous().to(torch.float32)
+    blocks = x_f32.reshape(rows, cols // scale_block_k, scale_block_k)
+    amax = blocks.abs().amax(dim=2)
+    scale_bytes = encode_ue8m0_scale_bytes(amax / _FP8_MAX[dtype], rounding="ceil")
+    scale_values = decode_ue8m0_scale_bytes(scale_bytes)
+    scaled_blocks = torch.where(amax[..., None] > 0, blocks / scale_values[..., None], torch.zeros_like(blocks))
+    torch_fp8 = torch.float8_e4m3fn if dtype == "e4m3" else torch.float8_e5m2
+    fp8_data = scaled_blocks.reshape(rows, cols).to(torch_fp8)
+    packed_scales = pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes(scale_bytes, block_rows=block_rows, block_words=block_words)
+    if return_scale_bytes:
+        return fp8_data, packed_scales, scale_bytes
+    return fp8_data, packed_scales

--- a/examples/dequantize_gemm/quantize/nvfp4.py
+++ b/examples/dequantize_gemm/quantize/nvfp4.py
@@ -44,10 +44,13 @@ def _import_torch():
 
 
 def _check_block_shape(block_rows: int, block_words: int) -> None:
-    if block_rows != _BLOCKSCALED_CHUNK_ROWS or block_words != _BLOCKSCALED_CHUNK_WORDS:
+    # The chunk atom is always 128 rows. block_words tracks block_K // 64 and
+    # only enters the packer as a per-tile width; the physical word order is
+    # the same 128-row K-major stack for every supported width.
+    if block_rows != _BLOCKSCALED_CHUNK_ROWS or block_words not in (1, 2, 4):
         raise ValueError(
             "SM120 BlockScaledBasicChunk K-major scale packing currently supports "
-            f"block_rows={_BLOCKSCALED_CHUNK_ROWS} and block_words={_BLOCKSCALED_CHUNK_WORDS}, "
+            f"block_rows={_BLOCKSCALED_CHUNK_ROWS} and block_words in (1, 2, 4), "
             f"got block_rows={block_rows}, block_words={block_words}"
         )
 
@@ -484,7 +487,8 @@ def quantize_bf16_to_nvfp4_blockscaled(
         accepted for tests and converted internally, but the intended runtime
         contract is BF16 activation input. The SM120 source contract requires
         ``rows`` to be a multiple of ``128`` and ``K`` to be a multiple of
-        ``256`` for the promoted ``blockscaled_chunk_kmajor`` scale layout.
+        ``64 * block_words`` for the promoted ``blockscaled_chunk_kmajor``
+        scale layout.
     scale_block_k:
         Number of consecutive K elements sharing one UE4M3 scale byte. SM120
         dense NVFP4 uses ``16``.

--- a/examples/gemm_sm120/sm120_mxfp4_blockscaled_gemm.py
+++ b/examples/gemm_sm120/sm120_mxfp4_blockscaled_gemm.py
@@ -76,8 +76,15 @@ def sm120_mxfp4_blockscaled_gemm(
             "boundary bug is tracked upstream); pad M or N to a multiple of 128"
         )
     assert K % block_K == 0
+    # block_M/N are pinned to one 128-row packer atom: this example's
+    # tile-rows staging (SFA[(by * k_blocks + ko) * block_M + r, w]) only
+    # matches the packed layout for single-atom tiles. block_M=256 needs
+    # atom-major indexing (((by * 2 + r // 128) * k_blocks + ko) * 128 +
+    # r % 128) instead - see the kmajor dual-atom sweep in the KB tools.
     assert block_M == 128
     assert block_N == 128
+    # block_K in (128, 256) also keeps K a multiple of 32, the packed-fp4
+    # TMA (16U4_ALIGN8B) inner-dim requirement.
     assert block_K in (128, 256), "one scale_vec::2X word covers K=128"
     assert num_stages >= 2
 
@@ -242,22 +249,49 @@ def run_tilelang(args: argparse.Namespace) -> tuple[float, float]:
         source_path.write_text(kernel.get_kernel_source())
         print(f"TileLang CUDA source: {source_path}")
 
-    A = _make_packed_fp4(args.m, args.k, seed=args.seed)
-    B = _make_packed_fp4(args.n, args.k, seed=args.seed + 1)
-    SFA_semantic = _make_pow2_scale_words(args.m, args.k, seed=args.seed + 100)
-    SFB_semantic = _make_pow2_scale_words(args.n, args.k, seed=args.seed + 200)
-
-    # Zero-copy tile-rows view of the packed layout (see the kernel docstring).
     sf_words_per_block_k = args.block_k // 128
-    SFA = swizzle_blockscaled_chunk_kmajor_scale_words(SFA_semantic, block_words=sf_words_per_block_k).reshape(-1, sf_words_per_block_k)
-    SFB = swizzle_blockscaled_chunk_kmajor_scale_words(SFB_semantic, block_words=sf_words_per_block_k).reshape(-1, sf_words_per_block_k)
+    if args.from_bf16:
+        # Full quantization flow: bf16 activations -> packed FP4 + packed
+        # UE8M0 scales -> GEMM, verified against the dequantized product.
+        import sys
+
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+        from examples.dequantize_gemm.quantize import quantize_bf16_to_mxfp4_blockscaled
+
+        x_a = (torch.randn(args.m, args.k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+        x_b = (torch.randn(args.n, args.k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+        A, SFA_packed, sfa_bytes = quantize_bf16_to_mxfp4_blockscaled(x_a, block_words=sf_words_per_block_k, return_scale_bytes=True)
+        B, SFB_packed, sfb_bytes = quantize_bf16_to_mxfp4_blockscaled(x_b, block_words=sf_words_per_block_k, return_scale_bytes=True)
+        SFA = SFA_packed.reshape(-1, sf_words_per_block_k)
+        SFB = SFB_packed.reshape(-1, sf_words_per_block_k)
+    else:
+        A = _make_packed_fp4(args.m, args.k, seed=args.seed)
+        B = _make_packed_fp4(args.n, args.k, seed=args.seed + 1)
+        SFA_semantic = _make_pow2_scale_words(args.m, args.k, seed=args.seed + 100)
+        SFB_semantic = _make_pow2_scale_words(args.n, args.k, seed=args.seed + 200)
+
+        # Zero-copy tile-rows view of the packed layout (see the kernel docstring).
+        SFA = swizzle_blockscaled_chunk_kmajor_scale_words(SFA_semantic, block_words=sf_words_per_block_k).reshape(-1, sf_words_per_block_k)
+        SFB = swizzle_blockscaled_chunk_kmajor_scale_words(SFB_semantic, block_words=sf_words_per_block_k).reshape(-1, sf_words_per_block_k)
     C = torch.empty((args.m, args.n), device="cuda", dtype=out_torch_dtype)
 
     kernel(A, B, SFA, SFB, C)
     torch.cuda.synchronize()
 
     if args.verify:
-        _verify(A, B, SFA_semantic, SFB_semantic, C, out_torch_dtype)
+        if args.from_bf16:
+            a_deq = _decode_rowmajor_fp4(A, args.m, args.k) * torch.pow(
+                2.0, (sfa_bytes.to(torch.int32) - 127).to(torch.float32)
+            ).repeat_interleave(32, dim=1)
+            b_deq = _decode_rowmajor_fp4(B, args.n, args.k) * torch.pow(
+                2.0, (sfb_bytes.to(torch.int32) - 127).to(torch.float32)
+            ).repeat_interleave(32, dim=1)
+            ref = a_deq @ b_deq.T
+            # Quantized math is exact; the only divergence is the bf16
+            # output rounding (2^-8 relative).
+            torch.testing.assert_close(C.float(), ref, rtol=8e-3, atol=1e-2)
+        else:
+            _verify(A, B, SFA_semantic, SFB_semantic, C, out_torch_dtype)
         print("TileLang correctness: passed")
 
     latency_ms = do_bench(
@@ -290,6 +324,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--n-repeat", type=int, default=0)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--verify", action="store_true")
+    parser.add_argument("--from-bf16", action="store_true", help="quantize bf16 inputs instead of synthetic fp4 data")
     parser.add_argument("--dump-source")
     return parser.parse_args()
 

--- a/examples/gemm_sm120/sm120_mxfp4_blockscaled_gemm.py
+++ b/examples/gemm_sm120/sm120_mxfp4_blockscaled_gemm.py
@@ -1,0 +1,315 @@
+"""SM120 MXFP4 block-scaled GEMM example.
+
+Same shape as the NVFP4 example, with the MXFP4 scale mode: every 32
+consecutive K elements share one UE8M0 (power-of-two) scale byte, so one
+uint32 scale word covers K=128 and the ``mma.sync`` instruction is
+``kind::mxf4nvf4.block_scale.scale_vec::2X ... ue8m0``.
+
+Run from the repository root:
+
+    python examples/gemm_sm120/sm120_mxfp4_blockscaled_gemm.py --m 2048 --n 2048 --k 2048 --verify
+"""
+
+import argparse
+from pathlib import Path
+
+import torch
+
+import tilelang
+import tilelang.language as T
+from tilelang.profiler import do_bench
+
+
+def swizzle_blockscaled_chunk_kmajor_scale_words(words, block_rows: int = 128, block_words: int = 2):
+    """Pack semantic scale words in SM120 BlockScaledBasicChunk K-major order."""
+
+    if block_rows != 128 or block_words not in (1, 2, 4):
+        raise ValueError(
+            "SM120 BlockScaledBasicChunk K-major scale packing requires "
+            f"block_rows=128 and block_words in (1, 2, 4), got block_rows={block_rows}, block_words={block_words}"
+        )
+    if not isinstance(words, torch.Tensor):
+        raise TypeError(f"words must be a torch.Tensor, got {type(words)!r}")
+    if words.dtype != torch.uint32:
+        raise TypeError(f"words must have dtype torch.uint32, got {words.dtype}")
+    if words.ndim != 2:
+        raise ValueError(f"words must be a 2D tensor, got shape {tuple(words.shape)}")
+
+    rows, cols = words.shape
+    if cols % block_words != 0:
+        raise ValueError(f"blockscaled_chunk_kmajor scale storage requires K-word columns multiple of {block_words}, got {tuple(words.shape)}")
+    if rows % block_rows != 0:
+        padded_rows = (rows + block_rows - 1) // block_rows * block_rows
+        padded = torch.zeros((padded_rows, cols), dtype=words.dtype, device=words.device)
+        padded[:rows] = words
+        words = padded
+        rows = padded_rows
+
+    row_blocks = rows // block_rows
+    source = words.contiguous().reshape(row_blocks, 4, 32, cols)
+    return source.permute(0, 3, 2, 1).contiguous().reshape(rows, cols)
+
+
+def _tflops(m: int, n: int, k: int, latency_ms: float) -> float:
+    return 2.0 * m * n * k / (latency_ms * 1.0e-3) / 1.0e12
+
+
+@tilelang.jit
+def sm120_mxfp4_blockscaled_gemm(
+    M: int,
+    N: int,
+    K: int,
+    block_M: int = 128,
+    block_N: int = 128,
+    block_K: int = 256,
+    num_stages: int = 2,
+    out_dtype=T.bfloat16,
+):
+    # Same tail-tile rules as the NVFP4 example: one of M/N may be arbitrary,
+    # scale sources are padded to whole 128-row atoms by the swizzle helper.
+    assert N % 8 == 0, "N must be a multiple of 8 (16-byte aligned output rows)"
+    if M % block_M != 0 and N % block_N != 0:
+        raise ValueError(
+            "simultaneous M and N tail tiles are not supported yet (a copy-lowering "
+            "boundary bug is tracked upstream); pad M or N to a multiple of 128"
+        )
+    assert K % block_K == 0
+    assert block_M == 128
+    assert block_N == 128
+    assert block_K in (128, 256), "one scale_vec::2X word covers K=128"
+    assert num_stages >= 2
+
+    in_dtype = T.float4_e2m1fn
+    accum_dtype = T.float32
+    sf_words_per_block_k = block_K // 128
+    sf_granularity_k = 32
+    M_pad = -(-M // block_M) * block_M
+    N_pad = -(-N // block_N) * block_N
+    k_blocks = K // block_K
+
+    # Tile-rows view of the packed K-major scale source, same convention as
+    # the NVFP4 example: [n_mn_blocks * n_k_blocks * block_MN, words_per_kblock].
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), in_dtype),
+        B: T.Tensor((N, K), in_dtype),
+        SFA: T.Tensor((M_pad * k_blocks, sf_words_per_block_k), T.uint32),
+        SFB: T.Tensor((N_pad * k_blocks, sf_words_per_block_k), T.uint32),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (
+            bx,
+            by,
+        ):
+            A_shared = T.alloc_shared((block_M, block_K), in_dtype)
+            B_shared = T.alloc_shared((block_N, block_K), in_dtype)
+            SFA_shared = T.alloc_shared((block_M, sf_words_per_block_k), T.uint32)
+            SFB_shared = T.alloc_shared((block_N, sf_words_per_block_k), T.uint32)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            T.clear(C_local)
+            for ko in T.Pipelined(K // block_K, num_stages=num_stages):
+                T.copy(A[by * block_M, ko * block_K], A_shared)
+                T.copy(B[bx * block_N, ko * block_K], B_shared)
+
+                # Not T.copy(SFA[slice], SFA_shared): that slice mis-lowers on
+                # the bulk-TMA path today (upstream fix pending).
+                for r, w in T.Parallel(block_M, sf_words_per_block_k):
+                    SFA_shared[r, w] = SFA[(by * k_blocks + ko) * block_M + r, w]
+                for r, w in T.Parallel(block_N, sf_words_per_block_k):
+                    SFB_shared[r, w] = SFB[(bx * k_blocks + ko) * block_N + r, w]
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=False,
+                    k_start=ko * block_K,
+                    sf_a_granularity_k=sf_granularity_k,
+                    sf_b_granularity_k=sf_granularity_k,
+                    sf_layout="blockscaled_chunk_kmajor",
+                    scale_dtype="ue8m0",
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _make_packed_fp4(rows: int, cols: int, *, seed: int) -> torch.Tensor:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    return torch.randint(-128, 128, (rows, cols // 2), device="cuda", dtype=torch.int8, generator=generator)
+
+
+def _pack_scale_words(scale_bytes: torch.Tensor) -> torch.Tensor:
+    scale_i64 = scale_bytes.to(torch.int64).reshape(scale_bytes.shape[0], -1, 4)
+    words = scale_i64[:, :, 0]
+    words = words | (scale_i64[:, :, 1] << 8)
+    words = words | (scale_i64[:, :, 2] << 16)
+    words = words | (scale_i64[:, :, 3] << 24)
+    return words.to(torch.uint32).contiguous()
+
+
+def _make_pow2_scale_words(rows: int, k: int, *, seed: int) -> torch.Tensor:
+    # Scales from {0.5, 1, 2} (exact powers of two) so verification is bitwise.
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    choices = torch.tensor([0x7E, 0x7F, 0x80], device="cuda", dtype=torch.int64)
+    idx = torch.randint(0, choices.numel(), (rows, k // 32), device="cuda", dtype=torch.int64, generator=generator)
+    return _pack_scale_words(choices[idx])
+
+
+def _decode_rowmajor_fp4(packed: torch.Tensor, rows: int, cols: int) -> torch.Tensor:
+    fp4_e2m1_values = (
+        0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,
+        -0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,
+    )
+    u = packed.contiguous().view(torch.uint8)
+    lut = torch.tensor(fp4_e2m1_values, device=packed.device, dtype=torch.float32)
+    out = torch.empty((rows, cols), device=packed.device, dtype=torch.float32)
+    out[:, 0::2] = lut[(u & 0x0F).long()]
+    out[:, 1::2] = lut[((u >> 4) & 0x0F).long()]
+    return out
+
+
+def _decode_ue8m0_scale_words(words: torch.Tensor, k: int) -> torch.Tensor:
+    w = words.to(torch.int64)
+    scale_bytes = torch.empty((words.shape[0], k // 32), device=words.device, dtype=torch.int64)
+    scale_bytes[:, 0::4] = w & 0xFF
+    scale_bytes[:, 1::4] = (w >> 8) & 0xFF
+    scale_bytes[:, 2::4] = (w >> 16) & 0xFF
+    scale_bytes[:, 3::4] = (w >> 24) & 0xFF
+    return torch.pow(2.0, (scale_bytes - 127).to(torch.float32))
+
+
+def _verify(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    SFA: torch.Tensor,
+    SFB: torch.Tensor,
+    C: torch.Tensor,
+    out_dtype: torch.dtype,
+) -> None:
+    A_full = _decode_rowmajor_fp4(A, A.shape[0], A.shape[1] * 2)
+    B_full = _decode_rowmajor_fp4(B, B.shape[0], B.shape[1] * 2)
+    sfa = _decode_ue8m0_scale_words(SFA, A_full.shape[1])
+    sfb = _decode_ue8m0_scale_words(SFB, B_full.shape[1])
+    ref = torch.zeros((A_full.shape[0], B_full.shape[0]), device=C.device, dtype=torch.float32)
+    for k_sf in range(A_full.shape[1] // 32):
+        k0 = k_sf * 32
+        k1 = k0 + 32
+        ref += (A_full[:, k0:k1] * sfa[:, k_sf].unsqueeze(1)) @ (B_full[:, k0:k1] * sfb[:, k_sf].unsqueeze(1)).T
+    torch.testing.assert_close(C, ref.to(out_dtype), rtol=0.0, atol=0.0)
+
+
+def run_tilelang(args: argparse.Namespace) -> tuple[float, float]:
+    out_torch_dtype = torch.bfloat16 if args.out_dtype == "bfloat16" else torch.float32
+    out_tilelang_dtype = T.bfloat16 if args.out_dtype == "bfloat16" else T.float32
+
+    kernel = sm120_mxfp4_blockscaled_gemm(
+        args.m,
+        args.n,
+        args.k,
+        args.block_m,
+        args.block_n,
+        args.block_k,
+        args.num_stages,
+        out_tilelang_dtype,
+    )
+
+    if args.dump_source:
+        source_path = Path(args.dump_source)
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text(kernel.get_kernel_source())
+        print(f"TileLang CUDA source: {source_path}")
+
+    A = _make_packed_fp4(args.m, args.k, seed=args.seed)
+    B = _make_packed_fp4(args.n, args.k, seed=args.seed + 1)
+    SFA_semantic = _make_pow2_scale_words(args.m, args.k, seed=args.seed + 100)
+    SFB_semantic = _make_pow2_scale_words(args.n, args.k, seed=args.seed + 200)
+
+    # Zero-copy tile-rows view of the packed layout (see the kernel docstring).
+    sf_words_per_block_k = args.block_k // 128
+    SFA = swizzle_blockscaled_chunk_kmajor_scale_words(SFA_semantic, block_words=sf_words_per_block_k).reshape(-1, sf_words_per_block_k)
+    SFB = swizzle_blockscaled_chunk_kmajor_scale_words(SFB_semantic, block_words=sf_words_per_block_k).reshape(-1, sf_words_per_block_k)
+    C = torch.empty((args.m, args.n), device="cuda", dtype=out_torch_dtype)
+
+    kernel(A, B, SFA, SFB, C)
+    torch.cuda.synchronize()
+
+    if args.verify:
+        _verify(A, B, SFA_semantic, SFB_semantic, C, out_torch_dtype)
+        print("TileLang correctness: passed")
+
+    latency_ms = do_bench(
+        lambda: kernel(A, B, SFA, SFB, C),
+        warmup=args.warmup_ms,
+        rep=args.rep_ms,
+        _n_warmup=args.n_warmup,
+        _n_repeat=args.n_repeat,
+        backend=args.backend,
+        return_mode=args.return_mode,
+    )
+    return latency_ms, _tflops(args.m, args.n, args.k, latency_ms)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--m", type=int, default=2048)
+    parser.add_argument("--n", type=int, default=2048)
+    parser.add_argument("--k", type=int, default=2048)
+    parser.add_argument("--block-m", type=int, default=128)
+    parser.add_argument("--block-n", type=int, default=128)
+    parser.add_argument("--block-k", type=int, default=256)
+    parser.add_argument("--num-stages", type=int, default=2)
+    parser.add_argument("--out-dtype", choices=["bfloat16", "float32"], default="bfloat16")
+    parser.add_argument("--backend", choices=["event", "cupti", "cudagraph"], default="event")
+    parser.add_argument("--return-mode", choices=["min", "max", "mean", "median"], default="mean")
+    parser.add_argument("--warmup-ms", type=float, default=25)
+    parser.add_argument("--rep-ms", type=float, default=100)
+    parser.add_argument("--n-warmup", type=int, default=0)
+    parser.add_argument("--n-repeat", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--verify", action="store_true")
+    parser.add_argument("--dump-source")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    capability = torch.cuda.get_device_capability()
+    if capability < (12, 0):
+        raise RuntimeError(f"SM120 or newer is required, got compute capability {capability}")
+
+    print(f"Shape: M={args.m}, N={args.n}, K={args.k}")
+    print(
+        f"TileLang tile: {args.block_m}x{args.block_n}x{args.block_k}, "
+        f"threads=128, stages={args.num_stages}, output={args.out_dtype}, "
+        "inputs=random fp4 / random power-of-two ue8m0 scales"
+    )
+    latency_ms, tflops = run_tilelang(args)
+    print(f"TileLang latency: {latency_ms:.4f} ms")
+    print(f"TileLang FLOPS: {tflops:.2f} TFLOPS")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/gemm_sm120/sm120_mxfp4_blockscaled_gemm.py
+++ b/examples/gemm_sm120/sm120_mxfp4_blockscaled_gemm.py
@@ -37,7 +37,9 @@ def swizzle_blockscaled_chunk_kmajor_scale_words(words, block_rows: int = 128, b
 
     rows, cols = words.shape
     if cols % block_words != 0:
-        raise ValueError(f"blockscaled_chunk_kmajor scale storage requires K-word columns multiple of {block_words}, got {tuple(words.shape)}")
+        raise ValueError(
+            f"blockscaled_chunk_kmajor scale storage requires K-word columns multiple of {block_words}, got {tuple(words.shape)}"
+        )
     if rows % block_rows != 0:
         padded_rows = (rows + block_rows - 1) // block_rows * block_rows
         padded = torch.zeros((padded_rows, cols), dtype=words.dtype, device=words.device)

--- a/examples/gemm_sm120/sm120_mxfp8_blockscaled_gemm.py
+++ b/examples/gemm_sm120/sm120_mxfp8_blockscaled_gemm.py
@@ -72,6 +72,7 @@ def sm120_mxfp8_blockscaled_gemm(
     num_stages: int = 2,
     in_dtype_name: str = "e4m3",
     out_dtype=T.bfloat16,
+    b_dtype_name: str | None = None,
 ):
     assert N % 8 == 0, "N must be a multiple of 8 (16-byte aligned output rows)"
     if M % block_M != 0 and N % block_N != 0:
@@ -92,6 +93,9 @@ def sm120_mxfp8_blockscaled_gemm(
     assert num_stages >= 2
 
     in_dtype = getattr(T, _TILELANG_FP8[in_dtype_name])
+    # Any {e4m3, e5m2} A/B pairing is legal for kind::mxf8f6f4; B defaults
+    # to A's dtype.
+    b_dtype = getattr(T, _TILELANG_FP8[b_dtype_name or in_dtype_name])
     accum_dtype = T.float32
     sf_words_per_block_k = block_K // 128
     sf_granularity_k = 32
@@ -102,7 +106,7 @@ def sm120_mxfp8_blockscaled_gemm(
     @T.prim_func
     def main(
         A: T.Tensor((M, K), in_dtype),
-        B: T.Tensor((N, K), in_dtype),
+        B: T.Tensor((N, K), b_dtype),
         SFA: T.Tensor((M_pad * k_blocks, sf_words_per_block_k), T.uint32),
         SFB: T.Tensor((N_pad * k_blocks, sf_words_per_block_k), T.uint32),
         C: T.Tensor((M, N), out_dtype),
@@ -112,7 +116,7 @@ def sm120_mxfp8_blockscaled_gemm(
             by,
         ):
             A_shared = T.alloc_shared((block_M, block_K), in_dtype)
-            B_shared = T.alloc_shared((block_N, block_K), in_dtype)
+            B_shared = T.alloc_shared((block_N, block_K), b_dtype)
             SFA_shared = T.alloc_shared((block_M, sf_words_per_block_k), T.uint32)
             SFB_shared = T.alloc_shared((block_N, sf_words_per_block_k), T.uint32)
             C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
@@ -217,6 +221,7 @@ def run_tilelang(args: argparse.Namespace) -> tuple[float, float]:
         args.num_stages,
         args.in_dtype,
         out_tilelang_dtype,
+        args.b_dtype,
     )
 
     if args.dump_source:
@@ -240,13 +245,13 @@ def run_tilelang(args: argparse.Namespace) -> tuple[float, float]:
             x_a, dtype=args.in_dtype, block_words=sf_words_per_block_k, return_scale_bytes=True
         )
         B, SFB_packed, sfb_bytes = quantize_bf16_to_mxfp8_blockscaled(
-            x_b, dtype=args.in_dtype, block_words=sf_words_per_block_k, return_scale_bytes=True
+            x_b, dtype=args.b_dtype or args.in_dtype, block_words=sf_words_per_block_k, return_scale_bytes=True
         )
         SFA = SFA_packed.reshape(-1, sf_words_per_block_k)
         SFB = SFB_packed.reshape(-1, sf_words_per_block_k)
     else:
         A = _make_fp8(args.m, args.k, args.in_dtype, seed=args.seed)
-        B = _make_fp8(args.n, args.k, args.in_dtype, seed=args.seed + 1)
+        B = _make_fp8(args.n, args.k, args.b_dtype or args.in_dtype, seed=args.seed + 1)
         SFA_semantic = _make_pow2_scale_words(args.m, args.k, seed=args.seed + 100)
         SFB_semantic = _make_pow2_scale_words(args.n, args.k, seed=args.seed + 200)
 
@@ -292,6 +297,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--block-k", type=int, default=128)
     parser.add_argument("--num-stages", type=int, default=2)
     parser.add_argument("--in-dtype", choices=["e4m3", "e5m2"], default="e4m3")
+    parser.add_argument("--b-dtype", choices=["e4m3", "e5m2"], default=None, help="B operand dtype (defaults to --in-dtype)")
     parser.add_argument("--out-dtype", choices=["bfloat16", "float32"], default="bfloat16")
     parser.add_argument("--backend", choices=["event", "cupti", "cudagraph"], default="event")
     parser.add_argument("--return-mode", choices=["min", "max", "mean", "median"], default="mean")

--- a/examples/gemm_sm120/sm120_mxfp8_blockscaled_gemm.py
+++ b/examples/gemm_sm120/sm120_mxfp8_blockscaled_gemm.py
@@ -1,0 +1,329 @@
+"""SM120 MXFP8 block-scaled GEMM example.
+
+Same structure as the MXFP4 example, with ``kind::mxf8f6f4``: FP8 operands
+(any {e4m3, e5m2} A/B pairing), every 32 consecutive K elements share one
+UE8M0 (power-of-two) scale byte, so one uint32 scale word covers K=128 and
+the ``mma.sync`` instruction is
+``m16n8k32.kind::mxf8f6f4.block_scale.scale_vec::1X ... ue8m0``.
+
+Run from the repository root:
+
+    python examples/gemm_sm120/sm120_mxfp8_blockscaled_gemm.py --m 2048 --n 2048 --k 2048 --verify
+"""
+
+import argparse
+from pathlib import Path
+
+import torch
+
+import tilelang
+import tilelang.language as T
+from tilelang.profiler import do_bench
+
+
+def swizzle_blockscaled_chunk_kmajor_scale_words(words, block_rows: int = 128, block_words: int = 2):
+    """Pack semantic scale words in SM120 BlockScaledBasicChunk K-major order."""
+
+    if block_rows != 128 or block_words not in (1, 2, 4):
+        raise ValueError(
+            "SM120 BlockScaledBasicChunk K-major scale packing requires "
+            f"block_rows=128 and block_words in (1, 2, 4), got block_rows={block_rows}, block_words={block_words}"
+        )
+    if not isinstance(words, torch.Tensor):
+        raise TypeError(f"words must be a torch.Tensor, got {type(words)!r}")
+    if words.dtype != torch.uint32:
+        raise TypeError(f"words must have dtype torch.uint32, got {words.dtype}")
+    if words.ndim != 2:
+        raise ValueError(f"words must be a 2D tensor, got shape {tuple(words.shape)}")
+
+    rows, cols = words.shape
+    if cols % block_words != 0:
+        raise ValueError(
+            f"blockscaled_chunk_kmajor scale storage requires K-word columns multiple of {block_words}, got {tuple(words.shape)}"
+        )
+    if rows % block_rows != 0:
+        padded_rows = (rows + block_rows - 1) // block_rows * block_rows
+        padded = torch.zeros((padded_rows, cols), dtype=words.dtype, device=words.device)
+        padded[:rows] = words
+        words = padded
+        rows = padded_rows
+
+    row_blocks = rows // block_rows
+    source = words.contiguous().reshape(row_blocks, 4, 32, cols)
+    return source.permute(0, 3, 2, 1).contiguous().reshape(rows, cols)
+
+
+def _tflops(m: int, n: int, k: int, latency_ms: float) -> float:
+    return 2.0 * m * n * k / (latency_ms * 1.0e-3) / 1.0e12
+
+
+_TORCH_FP8 = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}
+_TILELANG_FP8 = {"e4m3": "float8_e4m3fn", "e5m2": "float8_e5m2"}
+
+
+@tilelang.jit
+def sm120_mxfp8_blockscaled_gemm(
+    M: int,
+    N: int,
+    K: int,
+    block_M: int = 128,
+    block_N: int = 128,
+    block_K: int = 128,
+    num_stages: int = 2,
+    in_dtype_name: str = "e4m3",
+    out_dtype=T.bfloat16,
+):
+    assert N % 8 == 0, "N must be a multiple of 8 (16-byte aligned output rows)"
+    if M % block_M != 0 and N % block_N != 0:
+        raise ValueError(
+            "simultaneous M and N tail tiles are not supported yet (a copy-lowering "
+            "boundary bug is tracked upstream); pad M or N to a multiple of 128"
+        )
+    assert K % block_K == 0
+    # Same single-atom staging constraint as the MXFP4 example: the
+    # tile-rows view SFA[(by * k_blocks + ko) * block_M + r, w] matches the
+    # 128-row packer atom only for block_M == 128.
+    assert block_M == 128
+    assert block_N == 128
+    # FP8 data is twice as wide as packed FP4: 128x256 A+B tiles alone are
+    # 64 KiB per stage, so block_K=256 with 2+ stages exceeds the ~100 KiB
+    # dynamic smem limit; block_K=128 is the practical default.
+    assert block_K in (128, 256), "one uint32 ue8m0 scale word covers K=128"
+    assert num_stages >= 2
+
+    in_dtype = getattr(T, _TILELANG_FP8[in_dtype_name])
+    accum_dtype = T.float32
+    sf_words_per_block_k = block_K // 128
+    sf_granularity_k = 32
+    M_pad = -(-M // block_M) * block_M
+    N_pad = -(-N // block_N) * block_N
+    k_blocks = K // block_K
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), in_dtype),
+        B: T.Tensor((N, K), in_dtype),
+        SFA: T.Tensor((M_pad * k_blocks, sf_words_per_block_k), T.uint32),
+        SFB: T.Tensor((N_pad * k_blocks, sf_words_per_block_k), T.uint32),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (
+            bx,
+            by,
+        ):
+            A_shared = T.alloc_shared((block_M, block_K), in_dtype)
+            B_shared = T.alloc_shared((block_N, block_K), in_dtype)
+            SFA_shared = T.alloc_shared((block_M, sf_words_per_block_k), T.uint32)
+            SFB_shared = T.alloc_shared((block_N, sf_words_per_block_k), T.uint32)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            T.clear(C_local)
+            for ko in T.Pipelined(K // block_K, num_stages=num_stages):
+                T.copy(A[by * block_M, ko * block_K], A_shared)
+                T.copy(B[bx * block_N, ko * block_K], B_shared)
+
+                for r, w in T.Parallel(block_M, sf_words_per_block_k):
+                    SFA_shared[r, w] = SFA[(by * k_blocks + ko) * block_M + r, w]
+                for r, w in T.Parallel(block_N, sf_words_per_block_k):
+                    SFB_shared[r, w] = SFB[(bx * k_blocks + ko) * block_N + r, w]
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=False,
+                    k_start=ko * block_K,
+                    sf_a_granularity_k=sf_granularity_k,
+                    sf_b_granularity_k=sf_granularity_k,
+                    sf_layout="blockscaled_chunk_kmajor",
+                    scale_dtype="ue8m0",
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _make_fp8(rows: int, cols: int, dtype_name: str, *, seed: int) -> torch.Tensor:
+    # Small integers, exactly representable in both fp8 formats, so the
+    # bitwise verification band stays exact.
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    values = torch.randint(-4, 5, (rows, cols), device="cuda", dtype=torch.int64, generator=generator)
+    return values.to(torch.float32).to(_TORCH_FP8[dtype_name])
+
+
+def _pack_scale_words(scale_bytes: torch.Tensor) -> torch.Tensor:
+    scale_i64 = scale_bytes.to(torch.int64).reshape(scale_bytes.shape[0], -1, 4)
+    words = scale_i64[:, :, 0]
+    words = words | (scale_i64[:, :, 1] << 8)
+    words = words | (scale_i64[:, :, 2] << 16)
+    words = words | (scale_i64[:, :, 3] << 24)
+    return words.to(torch.uint32).contiguous()
+
+
+def _make_pow2_scale_words(rows: int, k: int, *, seed: int) -> torch.Tensor:
+    # Scales from {0.5, 1, 2} (exact powers of two) so verification is bitwise.
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    choices = torch.tensor([0x7E, 0x7F, 0x80], device="cuda", dtype=torch.int64)
+    idx = torch.randint(0, choices.numel(), (rows, k // 32), device="cuda", dtype=torch.int64, generator=generator)
+    return _pack_scale_words(choices[idx])
+
+
+def _decode_ue8m0_scale_words(words: torch.Tensor, k: int) -> torch.Tensor:
+    w = words.to(torch.int64)
+    scale_bytes = torch.empty((words.shape[0], k // 32), device=words.device, dtype=torch.int64)
+    scale_bytes[:, 0::4] = w & 0xFF
+    scale_bytes[:, 1::4] = (w >> 8) & 0xFF
+    scale_bytes[:, 2::4] = (w >> 16) & 0xFF
+    scale_bytes[:, 3::4] = (w >> 24) & 0xFF
+    return torch.pow(2.0, (scale_bytes - 127).to(torch.float32))
+
+
+def _verify(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    SFA: torch.Tensor,
+    SFB: torch.Tensor,
+    C: torch.Tensor,
+    out_dtype: torch.dtype,
+) -> None:
+    A_full = A.to(torch.float32)
+    B_full = B.to(torch.float32)
+    sfa = _decode_ue8m0_scale_words(SFA, A_full.shape[1])
+    sfb = _decode_ue8m0_scale_words(SFB, B_full.shape[1])
+    ref = torch.zeros((A_full.shape[0], B_full.shape[0]), device=C.device, dtype=torch.float32)
+    for k_sf in range(A_full.shape[1] // 32):
+        k0 = k_sf * 32
+        k1 = k0 + 32
+        ref += (A_full[:, k0:k1] * sfa[:, k_sf].unsqueeze(1)) @ (B_full[:, k0:k1] * sfb[:, k_sf].unsqueeze(1)).T
+    torch.testing.assert_close(C, ref.to(out_dtype), rtol=0.0, atol=0.0)
+
+
+def run_tilelang(args: argparse.Namespace) -> tuple[float, float]:
+    out_torch_dtype = torch.bfloat16 if args.out_dtype == "bfloat16" else torch.float32
+    out_tilelang_dtype = T.bfloat16 if args.out_dtype == "bfloat16" else T.float32
+
+    kernel = sm120_mxfp8_blockscaled_gemm(
+        args.m,
+        args.n,
+        args.k,
+        args.block_m,
+        args.block_n,
+        args.block_k,
+        args.num_stages,
+        args.in_dtype,
+        out_tilelang_dtype,
+    )
+
+    if args.dump_source:
+        source_path = Path(args.dump_source)
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text(kernel.get_kernel_source())
+        print(f"TileLang CUDA source: {source_path}")
+
+    sf_words_per_block_k = args.block_k // 128
+    if args.from_bf16:
+        # Full quantization flow: bf16 activations -> FP8 data + packed
+        # UE8M0 scales -> GEMM, verified against the dequantized product.
+        import sys
+
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+        from examples.dequantize_gemm.quantize import quantize_bf16_to_mxfp8_blockscaled
+
+        x_a = (torch.randn(args.m, args.k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+        x_b = (torch.randn(args.n, args.k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+        A, SFA_packed, sfa_bytes = quantize_bf16_to_mxfp8_blockscaled(
+            x_a, dtype=args.in_dtype, block_words=sf_words_per_block_k, return_scale_bytes=True
+        )
+        B, SFB_packed, sfb_bytes = quantize_bf16_to_mxfp8_blockscaled(
+            x_b, dtype=args.in_dtype, block_words=sf_words_per_block_k, return_scale_bytes=True
+        )
+        SFA = SFA_packed.reshape(-1, sf_words_per_block_k)
+        SFB = SFB_packed.reshape(-1, sf_words_per_block_k)
+    else:
+        A = _make_fp8(args.m, args.k, args.in_dtype, seed=args.seed)
+        B = _make_fp8(args.n, args.k, args.in_dtype, seed=args.seed + 1)
+        SFA_semantic = _make_pow2_scale_words(args.m, args.k, seed=args.seed + 100)
+        SFB_semantic = _make_pow2_scale_words(args.n, args.k, seed=args.seed + 200)
+
+        # Zero-copy tile-rows view of the packed layout (see the kernel docstring).
+        SFA = swizzle_blockscaled_chunk_kmajor_scale_words(SFA_semantic, block_words=sf_words_per_block_k).reshape(-1, sf_words_per_block_k)
+        SFB = swizzle_blockscaled_chunk_kmajor_scale_words(SFB_semantic, block_words=sf_words_per_block_k).reshape(-1, sf_words_per_block_k)
+    C = torch.empty((args.m, args.n), device="cuda", dtype=out_torch_dtype)
+
+    kernel(A, B, SFA, SFB, C)
+    torch.cuda.synchronize()
+
+    if args.verify:
+        if args.from_bf16:
+            a_deq = A.to(torch.float32) * torch.pow(2.0, (sfa_bytes.to(torch.int32) - 127).to(torch.float32)).repeat_interleave(32, dim=1)
+            b_deq = B.to(torch.float32) * torch.pow(2.0, (sfb_bytes.to(torch.int32) - 127).to(torch.float32)).repeat_interleave(32, dim=1)
+            ref = a_deq @ b_deq.T
+            # Quantized math is exact in fp32; the only divergence is the
+            # bf16 output rounding (2^-8 relative).
+            torch.testing.assert_close(C.float(), ref, rtol=8e-3, atol=1e-2)
+        else:
+            _verify(A, B, SFA_semantic, SFB_semantic, C, out_torch_dtype)
+        print("TileLang correctness: passed")
+
+    latency_ms = do_bench(
+        lambda: kernel(A, B, SFA, SFB, C),
+        warmup=args.warmup_ms,
+        rep=args.rep_ms,
+        _n_warmup=args.n_warmup,
+        _n_repeat=args.n_repeat,
+        backend=args.backend,
+        return_mode=args.return_mode,
+    )
+    return latency_ms, _tflops(args.m, args.n, args.k, latency_ms)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--m", type=int, default=2048)
+    parser.add_argument("--n", type=int, default=2048)
+    parser.add_argument("--k", type=int, default=2048)
+    parser.add_argument("--block-m", type=int, default=128)
+    parser.add_argument("--block-n", type=int, default=128)
+    parser.add_argument("--block-k", type=int, default=128)
+    parser.add_argument("--num-stages", type=int, default=2)
+    parser.add_argument("--in-dtype", choices=["e4m3", "e5m2"], default="e4m3")
+    parser.add_argument("--out-dtype", choices=["bfloat16", "float32"], default="bfloat16")
+    parser.add_argument("--backend", choices=["event", "cupti", "cudagraph"], default="event")
+    parser.add_argument("--return-mode", choices=["min", "max", "mean", "median"], default="mean")
+    parser.add_argument("--warmup-ms", type=float, default=25)
+    parser.add_argument("--rep-ms", type=float, default=100)
+    parser.add_argument("--n-warmup", type=int, default=0)
+    parser.add_argument("--n-repeat", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--verify", action="store_true")
+    parser.add_argument("--from-bf16", action="store_true", help="quantize bf16 inputs instead of synthetic fp8 data")
+    parser.add_argument("--dump-source")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    capability = torch.cuda.get_device_capability()
+    if capability < (12, 0):
+        raise RuntimeError(f"SM120 or newer is required, got compute capability {capability}")
+
+    print(f"Shape: M={args.m}, N={args.n}, K={args.k}")
+    print(
+        f"TileLang tile: {args.block_m}x{args.block_n}x{args.block_k}, "
+        f"threads=128, stages={args.num_stages}, in={args.in_dtype}, output={args.out_dtype}, "
+        "inputs=random fp8 / random power-of-two ue8m0 scales"
+    )
+    latency_ms, tflops = run_tilelang(args)
+    print(f"TileLang latency: {latency_ms:.4f} ms")
+    print(f"TileLang FLOPS: {tflops:.2f} TFLOPS")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/gemm_sm120/sm120_nvfp4_blockscaled_gemm.py
+++ b/examples/gemm_sm120/sm120_nvfp4_blockscaled_gemm.py
@@ -23,10 +23,10 @@ from tilelang.profiler import do_bench
 def swizzle_blockscaled_chunk_kmajor_scale_words(words, block_rows: int = 128, block_words: int = 4):
     """Pack semantic scale words in SM120 BlockScaledBasicChunk K-major order."""
 
-    if block_rows != 128 or block_words != 4:
+    if block_rows != 128 or block_words not in (1, 2, 4):
         raise ValueError(
             "SM120 BlockScaledBasicChunk K-major scale packing requires "
-            f"block_rows=128 and block_words=4, got block_rows={block_rows}, block_words={block_words}"
+            f"block_rows=128 and block_words in (1, 2, 4), got block_rows={block_rows}, block_words={block_words}"
         )
     if not isinstance(words, torch.Tensor):
         raise TypeError(f"words must be a torch.Tensor, got {type(words)!r}")
@@ -80,8 +80,7 @@ def sm120_nvfp4_blockscaled_gemm(
     assert K % block_K == 0
     assert block_M == 128
     assert block_N == 128
-    assert block_K > 0 and block_K % 64 == 0
-    assert K % 256 == 0
+    assert block_K in (64, 128, 256), "the scale packer supports block_K // 64 in (1, 2, 4)"
     assert num_stages >= 2
 
     in_dtype = T.float4_e2m1fn
@@ -265,8 +264,8 @@ def run_tilelang(args: argparse.Namespace) -> tuple[float, float]:
 
     # Zero-copy tile-rows view of the packed layout (see the kernel docstring).
     sf_words_per_block_k = args.block_k // 64
-    SFA = swizzle_blockscaled_chunk_kmajor_scale_words(SFA_semantic).reshape(-1, sf_words_per_block_k)
-    SFB = swizzle_blockscaled_chunk_kmajor_scale_words(SFB_semantic).reshape(-1, sf_words_per_block_k)
+    SFA = swizzle_blockscaled_chunk_kmajor_scale_words(SFA_semantic, block_words=sf_words_per_block_k).reshape(-1, sf_words_per_block_k)
+    SFB = swizzle_blockscaled_chunk_kmajor_scale_words(SFB_semantic, block_words=sf_words_per_block_k).reshape(-1, sf_words_per_block_k)
     C = torch.empty((args.m, args.n), device="cuda", dtype=out_torch_dtype)
 
     kernel(A, B, SFA, SFB, C)

--- a/examples/gemm_sm120/sm120_w4a8_mxf8f6f4_gemm.py
+++ b/examples/gemm_sm120/sm120_w4a8_mxf8f6f4_gemm.py
@@ -1,0 +1,360 @@
+"""SM120 W4A8 block-scaled GEMM example (kind::mxf8f6f4, mixed fp4 x fp8).
+
+The classic weight-4bit / activation-8bit shape: A holds MXFP4 weights
+(packed e2m1, 2 elements per global byte - the memory-compression point of
+4-bit quantization), B holds FP8 activations (e4m3 by default, e5m2 via
+--b-dtype). Every 32 consecutive K elements of each operand share one UE8M0
+scale byte; the instruction is
+``m16n8k32.kind::mxf8f6f4.block_scale.scale_vec::1X``.
+
+A's global->shared staging uses the 16U4_ALIGN16B bulk-TMA path (packed
+global -> unpacked 8-bit-container smem, hardware-unpacked); the su4
+ldmatrix then lifts the containers into registers with the e2m1 bits[5:2]
+placement. Bitwise agreement of this producer with the SIMT reference
+producer is pinned in
+testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py;
+the engine-vs-engine (CUTLASS) bitwise comparison lives in
+maint/gemm/gemm_sm120/correctness_evaluation_w4a8_vs_cutlass.py.
+
+Run from the repository root:
+
+    python examples/gemm_sm120/sm120_w4a8_mxf8f6f4_gemm.py --m 2048 --n 2048 --k 2048 --verify
+"""
+
+import argparse
+from pathlib import Path
+
+import torch
+
+import tilelang
+import tilelang.language as T
+from tilelang.profiler import do_bench
+
+
+_FP4_E2M1_VALUES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0)
+_TORCH_FP8 = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}
+_TILELANG_FP8 = {"e4m3": "float8_e4m3fn", "e5m2": "float8_e5m2"}
+
+
+def swizzle_blockscaled_chunk_kmajor_scale_words(words, block_rows: int = 128, block_words: int = 2):
+    """Pack semantic scale words in SM120 BlockScaledBasicChunk K-major order."""
+
+    if block_rows != 128 or block_words not in (1, 2, 4):
+        raise ValueError(
+            "SM120 BlockScaledBasicChunk K-major scale packing requires "
+            f"block_rows=128 and block_words in (1, 2, 4), got block_rows={block_rows}, block_words={block_words}"
+        )
+    if not isinstance(words, torch.Tensor):
+        raise TypeError(f"words must be a torch.Tensor, got {type(words)!r}")
+    if words.dtype != torch.uint32:
+        raise TypeError(f"words must have dtype torch.uint32, got {words.dtype}")
+    if words.ndim != 2:
+        raise ValueError(f"words must be a 2D tensor, got shape {tuple(words.shape)}")
+
+    rows, cols = words.shape
+    if cols % block_words != 0:
+        raise ValueError(
+            f"blockscaled_chunk_kmajor scale storage requires K-word columns multiple of {block_words}, got {tuple(words.shape)}"
+        )
+    if rows % block_rows != 0:
+        padded_rows = (rows + block_rows - 1) // block_rows * block_rows
+        padded = torch.zeros((padded_rows, cols), dtype=words.dtype, device=words.device)
+        padded[:rows] = words
+        words = padded
+        rows = padded_rows
+
+    row_blocks = rows // block_rows
+    source = words.contiguous().reshape(row_blocks, 4, 32, cols)
+    return source.permute(0, 3, 2, 1).contiguous().reshape(rows, cols)
+
+
+def _tflops(m: int, n: int, k: int, latency_ms: float) -> float:
+    return 2.0 * m * n * k / (latency_ms * 1.0e-3) / 1.0e12
+
+
+@tilelang.jit
+def sm120_w4a8_mxf8f6f4_gemm(
+    M: int,
+    N: int,
+    K: int,
+    block_M: int = 128,
+    block_N: int = 128,
+    block_K: int = 128,
+    num_stages: int = 2,
+    b_dtype_name: str = "e4m3",
+    out_dtype=T.bfloat16,
+):
+    assert N % 8 == 0, "N must be a multiple of 8 (16-byte aligned output rows)"
+    if M % block_M != 0 and N % block_N != 0:
+        raise ValueError(
+            "simultaneous M and N tail tiles are not supported yet (a copy-lowering "
+            "boundary bug is tracked upstream); pad M or N to a multiple of 128"
+        )
+    # The CUDA driver's packed-align16 tensor-map rule: the packed-fp4 TMA
+    # (16U4_ALIGN16B) requires the innermost GLOBAL dimension to be a whole
+    # number of 128-element groups. The compiler enforces this too (see the
+    # Copy::LowerBulk diagnostic); asserting here gives the friendlier error.
+    assert K % 128 == 0, "packed-fp4 TMA (16U4_ALIGN16B) requires K to be a multiple of 128 elements"
+    assert K % block_K == 0
+    # Same single-atom scale-staging constraint as the other SM120 examples.
+    assert block_M == 128
+    assert block_N == 128
+    assert block_K in (128, 256), "one uint32 ue8m0 scale word covers K=128"
+    assert num_stages >= 2
+
+    b_dtype = getattr(T, _TILELANG_FP8[b_dtype_name])
+    accum_dtype = T.float32
+    sf_words_per_block_k = block_K // 128
+    sf_granularity_k = 32
+    M_pad = -(-M // block_M) * block_M
+    N_pad = -(-N // block_N) * block_N
+    k_blocks = K // block_K
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), T.float4_e2m1fn),
+        B: T.Tensor((N, K), b_dtype),
+        SFA: T.Tensor((M_pad * k_blocks, sf_words_per_block_k), T.uint32),
+        SFB: T.Tensor((N_pad * k_blocks, sf_words_per_block_k), T.uint32),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (
+            bx,
+            by,
+        ):
+            A_shared = T.alloc_shared((block_M, block_K), T.float4_e2m1_unpacked)
+            B_shared = T.alloc_shared((block_N, block_K), b_dtype)
+            SFA_shared = T.alloc_shared((block_M, sf_words_per_block_k), T.uint32)
+            SFB_shared = T.alloc_shared((block_N, sf_words_per_block_k), T.uint32)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            T.clear(C_local)
+            for ko in T.Pipelined(K // block_K, num_stages=num_stages):
+                # Packed fp4 global -> unpacked smem via 16U4_ALIGN16B TMA.
+                T.copy(A[by * block_M, ko * block_K], A_shared)
+                T.copy(B[bx * block_N, ko * block_K], B_shared)
+
+                for r, w in T.Parallel(block_M, sf_words_per_block_k):
+                    SFA_shared[r, w] = SFA[(by * k_blocks + ko) * block_M + r, w]
+                for r, w in T.Parallel(block_N, sf_words_per_block_k):
+                    SFB_shared[r, w] = SFB[(bx * k_blocks + ko) * block_N + r, w]
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=False,
+                    k_start=ko * block_K,
+                    sf_a_granularity_k=sf_granularity_k,
+                    sf_b_granularity_k=sf_granularity_k,
+                    sf_layout="blockscaled_chunk_kmajor",
+                    scale_dtype="ue8m0",
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _make_packed_fp4(rows: int, cols: int, *, seed: int) -> torch.Tensor:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    return torch.randint(-128, 128, (rows, cols // 2), device="cuda", dtype=torch.int8, generator=generator)
+
+
+def _make_fp8(rows: int, cols: int, dtype_name: str, *, seed: int) -> torch.Tensor:
+    # Small integers, exact in both fp8 formats, keeping the bitwise band exact.
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    values = torch.randint(-4, 5, (rows, cols), device="cuda", dtype=torch.int64, generator=generator)
+    return values.to(torch.float32).to(_TORCH_FP8[dtype_name])
+
+
+def _pack_scale_words(scale_bytes: torch.Tensor) -> torch.Tensor:
+    scale_i64 = scale_bytes.to(torch.int64).reshape(scale_bytes.shape[0], -1, 4)
+    words = scale_i64[:, :, 0]
+    words = words | (scale_i64[:, :, 1] << 8)
+    words = words | (scale_i64[:, :, 2] << 16)
+    words = words | (scale_i64[:, :, 3] << 24)
+    return words.to(torch.uint32).contiguous()
+
+
+def _make_pow2_scale_words(rows: int, k: int, *, seed: int) -> torch.Tensor:
+    # Scales from {0.5, 1, 2} (exact powers of two) so verification is bitwise.
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    choices = torch.tensor([0x7E, 0x7F, 0x80], device="cuda", dtype=torch.int64)
+    idx = torch.randint(0, choices.numel(), (rows, k // 32), device="cuda", dtype=torch.int64, generator=generator)
+    return _pack_scale_words(choices[idx])
+
+
+def _decode_rowmajor_fp4(packed: torch.Tensor, rows: int, cols: int) -> torch.Tensor:
+    u = packed.contiguous().view(torch.uint8)
+    lut = torch.tensor(_FP4_E2M1_VALUES, device=packed.device, dtype=torch.float32)
+    out = torch.empty((rows, cols), device=packed.device, dtype=torch.float32)
+    out[:, 0::2] = lut[(u & 0x0F).long()]
+    out[:, 1::2] = lut[((u >> 4) & 0x0F).long()]
+    return out
+
+
+def _decode_ue8m0_scale_words(words: torch.Tensor, k: int) -> torch.Tensor:
+    w = words.to(torch.int64)
+    scale_bytes = torch.empty((words.shape[0], k // 32), device=words.device, dtype=torch.int64)
+    scale_bytes[:, 0::4] = w & 0xFF
+    scale_bytes[:, 1::4] = (w >> 8) & 0xFF
+    scale_bytes[:, 2::4] = (w >> 16) & 0xFF
+    scale_bytes[:, 3::4] = (w >> 24) & 0xFF
+    return torch.pow(2.0, (scale_bytes - 127).to(torch.float32))
+
+
+def _verify(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    SFA: torch.Tensor,
+    SFB: torch.Tensor,
+    C: torch.Tensor,
+    out_dtype: torch.dtype,
+) -> None:
+    A_full = _decode_rowmajor_fp4(A, A.shape[0], A.shape[1] * 2)
+    B_full = B.to(torch.float32)
+    sfa = _decode_ue8m0_scale_words(SFA, A_full.shape[1])
+    sfb = _decode_ue8m0_scale_words(SFB, B_full.shape[1])
+    ref = torch.zeros((A_full.shape[0], B_full.shape[0]), device=C.device, dtype=torch.float32)
+    for k_sf in range(A_full.shape[1] // 32):
+        k0 = k_sf * 32
+        k1 = k0 + 32
+        ref += (A_full[:, k0:k1] * sfa[:, k_sf].unsqueeze(1)) @ (B_full[:, k0:k1] * sfb[:, k_sf].unsqueeze(1)).T
+    torch.testing.assert_close(C, ref.to(out_dtype), rtol=0.0, atol=0.0)
+
+
+def run_tilelang(args: argparse.Namespace) -> tuple[float, float]:
+    out_torch_dtype = torch.bfloat16 if args.out_dtype == "bfloat16" else torch.float32
+    out_tilelang_dtype = T.bfloat16 if args.out_dtype == "bfloat16" else T.float32
+
+    kernel = sm120_w4a8_mxf8f6f4_gemm(
+        args.m,
+        args.n,
+        args.k,
+        args.block_m,
+        args.block_n,
+        args.block_k,
+        args.num_stages,
+        args.b_dtype,
+        out_tilelang_dtype,
+    )
+
+    if args.dump_source:
+        source_path = Path(args.dump_source)
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text(kernel.get_kernel_source())
+        print(f"TileLang CUDA source: {source_path}")
+
+    sf_words_per_block_k = args.block_k // 128
+    if args.from_bf16:
+        # Full quantization flow: bf16 weights -> MXFP4, bf16 activations ->
+        # MXFP8, then the mixed GEMM, verified against the dequantized
+        # product. The bitwise (engine-vs-engine) version of this band lives
+        # in the maint CUTLASS comparison.
+        import sys
+
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+        from examples.dequantize_gemm.quantize import (
+            quantize_bf16_to_mxfp4_blockscaled,
+            quantize_bf16_to_mxfp8_blockscaled,
+        )
+
+        x_a = (torch.randn(args.m, args.k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+        x_b = (torch.randn(args.n, args.k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+        A, SFA_packed, sfa_bytes = quantize_bf16_to_mxfp4_blockscaled(x_a, block_words=sf_words_per_block_k, return_scale_bytes=True)
+        B, SFB_packed, sfb_bytes = quantize_bf16_to_mxfp8_blockscaled(
+            x_b, dtype=args.b_dtype, block_words=sf_words_per_block_k, return_scale_bytes=True
+        )
+        SFA = SFA_packed.reshape(-1, sf_words_per_block_k)
+        SFB = SFB_packed.reshape(-1, sf_words_per_block_k)
+    else:
+        A = _make_packed_fp4(args.m, args.k, seed=args.seed)
+        B = _make_fp8(args.n, args.k, args.b_dtype, seed=args.seed + 1)
+        SFA_semantic = _make_pow2_scale_words(args.m, args.k, seed=args.seed + 100)
+        SFB_semantic = _make_pow2_scale_words(args.n, args.k, seed=args.seed + 200)
+
+        # Zero-copy tile-rows view of the packed layout (see the kernel docstring).
+        SFA = swizzle_blockscaled_chunk_kmajor_scale_words(SFA_semantic, block_words=sf_words_per_block_k).reshape(-1, sf_words_per_block_k)
+        SFB = swizzle_blockscaled_chunk_kmajor_scale_words(SFB_semantic, block_words=sf_words_per_block_k).reshape(-1, sf_words_per_block_k)
+    C = torch.empty((args.m, args.n), device="cuda", dtype=out_torch_dtype)
+
+    kernel(A, B, SFA, SFB, C)
+    torch.cuda.synchronize()
+
+    if args.verify:
+        if args.from_bf16:
+            a_deq = _decode_rowmajor_fp4(A, args.m, args.k) * torch.pow(
+                2.0, (sfa_bytes.to(torch.int32) - 127).to(torch.float32)
+            ).repeat_interleave(32, dim=1)
+            b_deq = B.to(torch.float32) * torch.pow(2.0, (sfb_bytes.to(torch.int32) - 127).to(torch.float32)).repeat_interleave(32, dim=1)
+            ref = a_deq @ b_deq.T
+            # Quantized math is exact in fp32; the only divergence is the
+            # bf16 output rounding (2^-8 relative).
+            torch.testing.assert_close(C.float(), ref, rtol=8e-3, atol=1e-2)
+        else:
+            _verify(A, B, SFA_semantic, SFB_semantic, C, out_torch_dtype)
+        print("TileLang correctness: passed")
+
+    latency_ms = do_bench(
+        lambda: kernel(A, B, SFA, SFB, C),
+        warmup=args.warmup_ms,
+        rep=args.rep_ms,
+        _n_warmup=args.n_warmup,
+        _n_repeat=args.n_repeat,
+        backend=args.backend,
+        return_mode=args.return_mode,
+    )
+    return latency_ms, _tflops(args.m, args.n, args.k, latency_ms)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--m", type=int, default=2048)
+    parser.add_argument("--n", type=int, default=2048)
+    parser.add_argument("--k", type=int, default=2048)
+    parser.add_argument("--block-m", type=int, default=128)
+    parser.add_argument("--block-n", type=int, default=128)
+    parser.add_argument("--block-k", type=int, default=128)
+    parser.add_argument("--num-stages", type=int, default=2)
+    parser.add_argument("--b-dtype", choices=["e4m3", "e5m2"], default="e4m3", help="activation (B) fp8 dtype")
+    parser.add_argument("--out-dtype", choices=["bfloat16", "float32"], default="bfloat16")
+    parser.add_argument("--backend", choices=["event", "cupti", "cudagraph"], default="event")
+    parser.add_argument("--return-mode", choices=["min", "max", "mean", "median"], default="mean")
+    parser.add_argument("--warmup-ms", type=float, default=25)
+    parser.add_argument("--rep-ms", type=float, default=100)
+    parser.add_argument("--n-warmup", type=int, default=0)
+    parser.add_argument("--n-repeat", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--verify", action="store_true")
+    parser.add_argument("--from-bf16", action="store_true", help="quantize bf16 inputs instead of synthetic data")
+    parser.add_argument("--dump-source")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    capability = torch.cuda.get_device_capability()
+    if capability < (12, 0):
+        raise RuntimeError(f"SM120 or newer is required, got compute capability {capability}")
+
+    print(f"Shape: M={args.m}, N={args.n}, K={args.k}")
+    print(
+        f"TileLang tile: {args.block_m}x{args.block_n}x{args.block_k}, "
+        f"threads=128, stages={args.num_stages}, weights=mxfp4, activations=mxfp8-{args.b_dtype}, "
+        f"output={args.out_dtype}"
+    )
+    latency_ms, tflops = run_tilelang(args)
+    print(f"TileLang latency: {latency_ms:.4f} ms")
+    print(f"TileLang FLOPS: {tflops:.2f} TFLOPS")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/gemm_sm120/sm120_w6a8_mxf8f6f4_gemm.py
+++ b/examples/gemm_sm120/sm120_w6a8_mxf8f6f4_gemm.py
@@ -8,10 +8,10 @@ a packed uint8 blob - an LSB-first 6-bit stream, 4 elements per 3 bytes
 consecutive K elements share one UE8M0 scale byte; the instruction is
 ``m16n8k32.kind::mxf8f6f4.block_scale.scale_vec::1X``.
 
-B's global->shared staging is a SIMT producer writing the b6x16_p32 padded
-form (12 payload bytes + 4 padding per 16-element group); the su6 ldmatrix
-unpacks the containers into registers (bits[5:0], no shift). The
-16U6_ALIGN16B TMA producer is tracked as follow-up work. Engine-vs-engine
+B's global->shared staging uses the 16U6_ALIGN16B bulk-TMA path (packed
+global -> unpacked 8-bit-container smem, hardware-unpacked); the su6
+ldmatrix lifts the containers into registers (bits[5:0], no shift).
+Engine-vs-engine
 (CUTLASS) bitwise comparison lives in
 maint/gemm/gemm_sm120/correctness_evaluation_w6a8_vs_cutlass.py.
 
@@ -102,6 +102,7 @@ def sm120_w6a8_mxf8f6f4_gemm(
     assert num_stages >= 2
 
     a_dtype = getattr(T, _TILELANG_FP8[a_dtype_name])
+    b_global_dtype = getattr(T, {"e2m3": "float6_e2m3fn", "e3m2": "float6_e3m2fn"}[b_flavor])
     b_smem_dtype = getattr(T, {"e2m3": "float6_e2m3fn_unpacked", "e3m2": "float6_e3m2fn_unpacked"}[b_flavor])
     accum_dtype = T.float32
     sf_words_per_block_k = block_K // 128
@@ -113,7 +114,9 @@ def sm120_w6a8_mxf8f6f4_gemm(
     @T.prim_func
     def main(
         A: T.Tensor((M, K), a_dtype),
-        B_blob: T.Tensor((N, K * 3 // 4), T.uint8),
+        # Declared as packed fp6; the host feeds a uint8 blob of N*K*3/4
+        # bytes through the sub-byte binder (total-bits checked).
+        B: T.Tensor((N, K), b_global_dtype),
         SFA: T.Tensor((M_pad * k_blocks, sf_words_per_block_k), T.uint32),
         SFB: T.Tensor((N_pad * k_blocks, sf_words_per_block_k), T.uint32),
         C: T.Tensor((M, N), out_dtype),
@@ -131,10 +134,10 @@ def sm120_w6a8_mxf8f6f4_gemm(
             T.clear(C_local)
             for ko in T.Pipelined(K // block_K, num_stages=num_stages):
                 T.copy(A[by * block_M, ko * block_K], A_shared)
-                # SIMT producer of the b6x16_p32 padded form: 12 payload
-                # bytes + 4 padding bytes per 16-element group.
-                for j, g, b in T.Parallel(block_N, block_K // 16, 12):
-                    B_shared[j, 16 * g + b] = T.reinterpret(b_smem_dtype, B_blob[bx * block_N + j, ko * (block_K * 3 // 4) + 12 * g + b])
+                # Packed fp6 global -> unpacked smem via 16U6_ALIGN16B TMA
+                # (bitwise-equal to the SIMT reference producer, pinned in
+                # the subbyte test file).
+                T.copy(B[bx * block_N, ko * block_K], B_shared)
 
                 for r, w in T.Parallel(block_M, sf_words_per_block_k):
                     SFA_shared[r, w] = SFA[(by * k_blocks + ko) * block_M + r, w]

--- a/examples/gemm_sm120/sm120_w6a8_mxf8f6f4_gemm.py
+++ b/examples/gemm_sm120/sm120_w6a8_mxf8f6f4_gemm.py
@@ -1,0 +1,369 @@
+"""SM120 W6A8 block-scaled GEMM example (kind::mxf8f6f4, mixed fp8 x fp6).
+
+Mirrors CUTLASS example 79c (the only SM120 fp6 example there:
+mxfp8 e4m3 activations x mxfp6 e3m2 weights -> bf16): A holds FP8
+activations (e4m3 by default, e5m2 via --a-dtype), B holds MXFP6 weights as
+a packed uint8 blob - an LSB-first 6-bit stream, 4 elements per 3 bytes
+(0.75 B/elem, the compression point; torch has no fp6 dtype). Every 32
+consecutive K elements share one UE8M0 scale byte; the instruction is
+``m16n8k32.kind::mxf8f6f4.block_scale.scale_vec::1X``.
+
+B's global->shared staging is a SIMT producer writing the b6x16_p32 padded
+form (12 payload bytes + 4 padding per 16-element group); the su6 ldmatrix
+unpacks the containers into registers (bits[5:0], no shift). The
+16U6_ALIGN16B TMA producer is tracked as follow-up work. Engine-vs-engine
+(CUTLASS) bitwise comparison lives in
+maint/gemm/gemm_sm120/correctness_evaluation_w6a8_vs_cutlass.py.
+
+Run from the repository root:
+
+    python examples/gemm_sm120/sm120_w6a8_mxf8f6f4_gemm.py --m 2048 --n 2048 --k 2048 --verify
+"""
+
+import argparse
+from pathlib import Path
+
+import torch
+
+import tilelang
+import tilelang.language as T
+from tilelang.profiler import do_bench
+
+
+_FP4_E2M1_VALUES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0)
+_TORCH_FP8 = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}
+_TILELANG_FP8 = {"e4m3": "float8_e4m3fn", "e5m2": "float8_e5m2"}
+
+
+def swizzle_blockscaled_chunk_kmajor_scale_words(words, block_rows: int = 128, block_words: int = 2):
+    """Pack semantic scale words in SM120 BlockScaledBasicChunk K-major order."""
+
+    if block_rows != 128 or block_words not in (1, 2, 4):
+        raise ValueError(
+            "SM120 BlockScaledBasicChunk K-major scale packing requires "
+            f"block_rows=128 and block_words in (1, 2, 4), got block_rows={block_rows}, block_words={block_words}"
+        )
+    if not isinstance(words, torch.Tensor):
+        raise TypeError(f"words must be a torch.Tensor, got {type(words)!r}")
+    if words.dtype != torch.uint32:
+        raise TypeError(f"words must have dtype torch.uint32, got {words.dtype}")
+    if words.ndim != 2:
+        raise ValueError(f"words must be a 2D tensor, got shape {tuple(words.shape)}")
+
+    rows, cols = words.shape
+    if cols % block_words != 0:
+        raise ValueError(
+            f"blockscaled_chunk_kmajor scale storage requires K-word columns multiple of {block_words}, got {tuple(words.shape)}"
+        )
+    if rows % block_rows != 0:
+        padded_rows = (rows + block_rows - 1) // block_rows * block_rows
+        padded = torch.zeros((padded_rows, cols), dtype=words.dtype, device=words.device)
+        padded[:rows] = words
+        words = padded
+        rows = padded_rows
+
+    row_blocks = rows // block_rows
+    source = words.contiguous().reshape(row_blocks, 4, 32, cols)
+    return source.permute(0, 3, 2, 1).contiguous().reshape(rows, cols)
+
+
+def _tflops(m: int, n: int, k: int, latency_ms: float) -> float:
+    return 2.0 * m * n * k / (latency_ms * 1.0e-3) / 1.0e12
+
+
+@tilelang.jit
+def sm120_w6a8_mxf8f6f4_gemm(
+    M: int,
+    N: int,
+    K: int,
+    block_M: int = 128,
+    block_N: int = 128,
+    block_K: int = 128,
+    num_stages: int = 2,
+    a_dtype_name: str = "e4m3",
+    b_flavor: str = "e3m2",
+    out_dtype=T.bfloat16,
+):
+    assert N % 8 == 0, "N must be a multiple of 8 (16-byte aligned output rows)"
+    if M % block_M != 0 and N % block_N != 0:
+        raise ValueError(
+            "simultaneous M and N tail tiles are not supported yet (a copy-lowering "
+            "boundary bug is tracked upstream); pad M or N to a multiple of 128"
+        )
+    # The fp6 packer works in 16-element groups and the scale words cover
+    # K=128; keep K a multiple of 128 (also future-proof for the 16U6 TMA).
+    assert K % 128 == 0, "MXFP6 staging requires K to be a multiple of 128 elements"
+    assert b_flavor in ("e2m3", "e3m2")
+    assert K % block_K == 0
+    # Same single-atom scale-staging constraint as the other SM120 examples.
+    assert block_M == 128
+    assert block_N == 128
+    assert block_K in (128, 256), "one uint32 ue8m0 scale word covers K=128"
+    assert num_stages >= 2
+
+    a_dtype = getattr(T, _TILELANG_FP8[a_dtype_name])
+    b_smem_dtype = getattr(T, {"e2m3": "float6_e2m3fn_unpacked", "e3m2": "float6_e3m2fn_unpacked"}[b_flavor])
+    accum_dtype = T.float32
+    sf_words_per_block_k = block_K // 128
+    sf_granularity_k = 32
+    M_pad = -(-M // block_M) * block_M
+    N_pad = -(-N // block_N) * block_N
+    k_blocks = K // block_K
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), a_dtype),
+        B_blob: T.Tensor((N, K * 3 // 4), T.uint8),
+        SFA: T.Tensor((M_pad * k_blocks, sf_words_per_block_k), T.uint32),
+        SFB: T.Tensor((N_pad * k_blocks, sf_words_per_block_k), T.uint32),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (
+            bx,
+            by,
+        ):
+            A_shared = T.alloc_shared((block_M, block_K), a_dtype)
+            B_shared = T.alloc_shared((block_N, block_K), b_smem_dtype)
+            SFA_shared = T.alloc_shared((block_M, sf_words_per_block_k), T.uint32)
+            SFB_shared = T.alloc_shared((block_N, sf_words_per_block_k), T.uint32)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            T.clear(C_local)
+            for ko in T.Pipelined(K // block_K, num_stages=num_stages):
+                T.copy(A[by * block_M, ko * block_K], A_shared)
+                # SIMT producer of the b6x16_p32 padded form: 12 payload
+                # bytes + 4 padding bytes per 16-element group.
+                for j, g, b in T.Parallel(block_N, block_K // 16, 12):
+                    B_shared[j, 16 * g + b] = T.reinterpret(b_smem_dtype, B_blob[bx * block_N + j, ko * (block_K * 3 // 4) + 12 * g + b])
+
+                for r, w in T.Parallel(block_M, sf_words_per_block_k):
+                    SFA_shared[r, w] = SFA[(by * k_blocks + ko) * block_M + r, w]
+                for r, w in T.Parallel(block_N, sf_words_per_block_k):
+                    SFB_shared[r, w] = SFB[(bx * k_blocks + ko) * block_N + r, w]
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=False,
+                    k_start=ko * block_K,
+                    sf_a_granularity_k=sf_granularity_k,
+                    sf_b_granularity_k=sf_granularity_k,
+                    sf_layout="blockscaled_chunk_kmajor",
+                    scale_dtype="ue8m0",
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _make_packed_fp6(rows: int, cols: int, *, seed: int) -> torch.Tensor:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    return torch.randint(0, 256, (rows, cols * 3 // 4), device="cuda", dtype=torch.uint8, generator=generator)
+
+
+def _make_fp8(rows: int, cols: int, dtype_name: str, *, seed: int) -> torch.Tensor:
+    # Small integers, exact in both fp8 formats, keeping the bitwise band exact.
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    values = torch.randint(-4, 5, (rows, cols), device="cuda", dtype=torch.int64, generator=generator)
+    return values.to(torch.float32).to(_TORCH_FP8[dtype_name])
+
+
+def _pack_scale_words(scale_bytes: torch.Tensor) -> torch.Tensor:
+    scale_i64 = scale_bytes.to(torch.int64).reshape(scale_bytes.shape[0], -1, 4)
+    words = scale_i64[:, :, 0]
+    words = words | (scale_i64[:, :, 1] << 8)
+    words = words | (scale_i64[:, :, 2] << 16)
+    words = words | (scale_i64[:, :, 3] << 24)
+    return words.to(torch.uint32).contiguous()
+
+
+def _make_pow2_scale_words(rows: int, k: int, *, seed: int) -> torch.Tensor:
+    # Scales from {0.5, 1, 2} (exact powers of two) so verification is bitwise.
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    choices = torch.tensor([0x7E, 0x7F, 0x80], device="cuda", dtype=torch.int64)
+    idx = torch.randint(0, choices.numel(), (rows, k // 32), device="cuda", dtype=torch.int64, generator=generator)
+    return _pack_scale_words(choices[idx])
+
+
+def _decode_fp6_blob(blob: torch.Tensor, rows: int, cols: int, flavor: str) -> torch.Tensor:
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    _sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
+    from examples.dequantize_gemm.quantize import decode_fp6_values, unpack_fp6_bytes
+
+    codes = unpack_fp6_bytes(blob.cpu(), cols)
+    return decode_fp6_values(codes, flavor).to(blob.device)
+
+
+def _decode_ue8m0_scale_words(words: torch.Tensor, k: int) -> torch.Tensor:
+    w = words.to(torch.int64)
+    scale_bytes = torch.empty((words.shape[0], k // 32), device=words.device, dtype=torch.int64)
+    scale_bytes[:, 0::4] = w & 0xFF
+    scale_bytes[:, 1::4] = (w >> 8) & 0xFF
+    scale_bytes[:, 2::4] = (w >> 16) & 0xFF
+    scale_bytes[:, 3::4] = (w >> 24) & 0xFF
+    return torch.pow(2.0, (scale_bytes - 127).to(torch.float32))
+
+
+def _verify(
+    A: torch.Tensor,
+    B_blob: torch.Tensor,
+    SFA: torch.Tensor,
+    SFB: torch.Tensor,
+    C: torch.Tensor,
+    out_dtype: torch.dtype,
+    b_flavor: str,
+) -> None:
+    A_full = A.to(torch.float32)
+    B_full = _decode_fp6_blob(B_blob, B_blob.shape[0], B_blob.shape[1] * 4 // 3, b_flavor)
+    sfa = _decode_ue8m0_scale_words(SFA, A_full.shape[1])
+    sfb = _decode_ue8m0_scale_words(SFB, B_full.shape[1])
+    ref = torch.zeros((A_full.shape[0], B_full.shape[0]), device=C.device, dtype=torch.float32)
+    for k_sf in range(A_full.shape[1] // 32):
+        k0 = k_sf * 32
+        k1 = k0 + 32
+        ref += (A_full[:, k0:k1] * sfa[:, k_sf].unsqueeze(1)) @ (B_full[:, k0:k1] * sfb[:, k_sf].unsqueeze(1)).T
+    torch.testing.assert_close(C, ref.to(out_dtype), rtol=0.0, atol=0.0)
+
+
+def run_tilelang(args: argparse.Namespace) -> tuple[float, float]:
+    out_torch_dtype = torch.bfloat16 if args.out_dtype == "bfloat16" else torch.float32
+    out_tilelang_dtype = T.bfloat16 if args.out_dtype == "bfloat16" else T.float32
+
+    kernel = sm120_w6a8_mxf8f6f4_gemm(
+        args.m,
+        args.n,
+        args.k,
+        args.block_m,
+        args.block_n,
+        args.block_k,
+        args.num_stages,
+        args.a_dtype,
+        args.b_flavor,
+        out_tilelang_dtype,
+    )
+
+    if args.dump_source:
+        source_path = Path(args.dump_source)
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text(kernel.get_kernel_source())
+        print(f"TileLang CUDA source: {source_path}")
+
+    sf_words_per_block_k = args.block_k // 128
+    if args.from_bf16:
+        # bf16 activations -> MXFP8, bf16 weights -> MXFP6; the bitwise
+        # engine-vs-engine version of this band is the maint comparison.
+        import sys
+
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+        from examples.dequantize_gemm.quantize import (
+            quantize_bf16_to_mxfp6_blockscaled,
+            quantize_bf16_to_mxfp8_blockscaled,
+        )
+
+        x_a = (torch.randn(args.m, args.k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+        x_b = (torch.randn(args.n, args.k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+        A, SFA_packed, sfa_bytes = quantize_bf16_to_mxfp8_blockscaled(
+            x_a, dtype=args.a_dtype, block_words=sf_words_per_block_k, return_scale_bytes=True
+        )
+        B_cpu, SFB_packed, sfb_bytes = quantize_bf16_to_mxfp6_blockscaled(
+            x_b.cpu().float(), dtype=args.b_flavor, block_words=sf_words_per_block_k, return_scale_bytes=True
+        )
+        B = B_cpu.cuda()
+        sfb_bytes = sfb_bytes.cuda()
+        SFA = SFA_packed.reshape(-1, sf_words_per_block_k)
+        SFB = SFB_packed.cuda().reshape(-1, sf_words_per_block_k)
+    else:
+        A = _make_fp8(args.m, args.k, args.a_dtype, seed=args.seed)
+        B = _make_packed_fp6(args.n, args.k, seed=args.seed + 1)
+        SFA_semantic = _make_pow2_scale_words(args.m, args.k, seed=args.seed + 100)
+        SFB_semantic = _make_pow2_scale_words(args.n, args.k, seed=args.seed + 200)
+
+        # Zero-copy tile-rows view of the packed layout (see the kernel docstring).
+        SFA = swizzle_blockscaled_chunk_kmajor_scale_words(SFA_semantic, block_words=sf_words_per_block_k).reshape(-1, sf_words_per_block_k)
+        SFB = swizzle_blockscaled_chunk_kmajor_scale_words(SFB_semantic, block_words=sf_words_per_block_k).reshape(-1, sf_words_per_block_k)
+    C = torch.empty((args.m, args.n), device="cuda", dtype=out_torch_dtype)
+
+    kernel(A, B, SFA, SFB, C)
+    torch.cuda.synchronize()
+
+    if args.verify:
+        if args.from_bf16:
+            a_deq = A.to(torch.float32) * torch.pow(2.0, (sfa_bytes.to(torch.int32) - 127).to(torch.float32)).repeat_interleave(32, dim=1)
+            b_deq = _decode_fp6_blob(B, args.n, args.k, args.b_flavor) * torch.pow(
+                2.0, (sfb_bytes.to(torch.int32) - 127).to(torch.float32)
+            ).repeat_interleave(32, dim=1)
+            ref = a_deq @ b_deq.T
+            # Quantized math is exact in fp32; the only divergence is the
+            # bf16 output rounding (2^-8 relative).
+            torch.testing.assert_close(C.float(), ref, rtol=8e-3, atol=1e-2)
+        else:
+            _verify(A, B, SFA_semantic, SFB_semantic, C, out_torch_dtype, args.b_flavor)
+        print("TileLang correctness: passed")
+
+    latency_ms = do_bench(
+        lambda: kernel(A, B, SFA, SFB, C),
+        warmup=args.warmup_ms,
+        rep=args.rep_ms,
+        _n_warmup=args.n_warmup,
+        _n_repeat=args.n_repeat,
+        backend=args.backend,
+        return_mode=args.return_mode,
+    )
+    return latency_ms, _tflops(args.m, args.n, args.k, latency_ms)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--m", type=int, default=2048)
+    parser.add_argument("--n", type=int, default=2048)
+    parser.add_argument("--k", type=int, default=2048)
+    parser.add_argument("--block-m", type=int, default=128)
+    parser.add_argument("--block-n", type=int, default=128)
+    parser.add_argument("--block-k", type=int, default=128)
+    parser.add_argument("--num-stages", type=int, default=2)
+    parser.add_argument("--a-dtype", choices=["e4m3", "e5m2"], default="e4m3", help="activation (A) fp8 dtype")
+    parser.add_argument("--b-flavor", choices=["e2m3", "e3m2"], default="e3m2", help="weight (B) fp6 flavor")
+    parser.add_argument("--out-dtype", choices=["bfloat16", "float32"], default="bfloat16")
+    parser.add_argument("--backend", choices=["event", "cupti", "cudagraph"], default="event")
+    parser.add_argument("--return-mode", choices=["min", "max", "mean", "median"], default="mean")
+    parser.add_argument("--warmup-ms", type=float, default=25)
+    parser.add_argument("--rep-ms", type=float, default=100)
+    parser.add_argument("--n-warmup", type=int, default=0)
+    parser.add_argument("--n-repeat", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--verify", action="store_true")
+    parser.add_argument("--from-bf16", action="store_true", help="quantize bf16 inputs instead of synthetic data")
+    parser.add_argument("--dump-source")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    capability = torch.cuda.get_device_capability()
+    if capability < (12, 0):
+        raise RuntimeError(f"SM120 or newer is required, got compute capability {capability}")
+
+    print(f"Shape: M={args.m}, N={args.n}, K={args.k}")
+    print(
+        f"TileLang tile: {args.block_m}x{args.block_n}x{args.block_k}, "
+        f"threads=128, stages={args.num_stages}, activations=mxfp8-{args.a_dtype}, weights=mxfp6-{args.b_flavor}, "
+        f"output={args.out_dtype}"
+    )
+    latency_ms, tflops = run_tilelang(args)
+    print(f"TileLang latency: {latency_ms:.4f} ms")
+    print(f"TileLang FLOPS: {tflops:.2f} TFLOPS")
+
+
+if __name__ == "__main__":
+    main()

--- a/maint/gemm/gemm_sm120/correctness_evaluation_mxf4_vs_cutlass.py
+++ b/maint/gemm/gemm_sm120/correctness_evaluation_mxf4_vs_cutlass.py
@@ -280,11 +280,15 @@ def run_compare() -> None:
         sfb_logical = torch.full((n, k // _SF_VEC_SIZE), 0x7F, device="cuda", dtype=torch.uint8)
     elif scale_mode == "varying":
         # Power-of-two exponents around 1.0, varying by row and K group so a
-        # byte-pair (parity) mix-up in the 2X path changes the result.
+        # byte-pair (parity) mix-up in the 2X path changes the result. The
+        # window is kept narrow (2^-8..2^7): the bitwise assertion below rests
+        # on both engines accumulating K in order with an fp32 accumulator, and
+        # a modest magnitude spread keeps summation rounding tame on top of
+        # that shared order.
         row = torch.arange(m, device="cuda", dtype=torch.int32).reshape(m, 1)
         col = torch.arange(k // _SF_VEC_SIZE, device="cuda", dtype=torch.int32).reshape(1, k // _SF_VEC_SIZE)
-        sfa_logical = (0x70 + ((row * 3 + col * 5) % 32)).to(torch.uint8)
-        sfb_logical = (0x70 + ((row * 7 + col * 11) % 32)).to(torch.uint8)
+        sfa_logical = (0x77 + ((row * 3 + col * 5) % 16)).to(torch.uint8)
+        sfb_logical = (0x77 + ((row * 7 + col * 11) % 16)).to(torch.uint8)
     else:
         raise ValueError(f"Unsupported MXF4_SCALE_MODE={scale_mode!r}")
 

--- a/maint/gemm/gemm_sm120/correctness_evaluation_mxf4_vs_cutlass.py
+++ b/maint/gemm/gemm_sm120/correctness_evaluation_mxf4_vs_cutlass.py
@@ -1,0 +1,322 @@
+"""Compare TileLang's SM120 MXFP4 block-scaled GEMM against CUTLASS.
+
+Run from the repository root:
+
+    python -m maint.gemm.gemm_sm120.correctness_evaluation_mxf4_vs_cutlass
+
+The scale factors are UE8M0 (power-of-two), so both engines perform the
+same exact fp32 arithmetic and the comparison is bitwise.
+"""
+
+import os
+from pathlib import Path
+
+import torch
+import tilelang
+import tilelang.language as T
+from tilelang.cuda.language.intrinsics import TensorCoreIntrinEmitterSM120, make_mma_swizzle_layout
+from tilelang.transform import simplify_prim_func
+
+
+_SF_VEC_SIZE = 32
+_WORD_SPAN = _SF_VEC_SIZE * 4  # K elements covered by one uint32 scale word
+
+
+@simplify_prim_func
+def _make_tilelang_mxf4_kernel(m: int, n: int, k: int, micro_k: int):
+    in_dtype = T.float4_e2m1fn
+    out_dtype = T.float32
+    accum_dtype = T.float32
+
+    micro_size_x = 16
+    micro_size_y = 16
+    block_row_warps = 2
+    block_col_warps = 2
+    warp_row_tiles = 32
+    warp_col_tiles = 32
+    chunk = k
+    shared_scope = "shared.dyn"
+
+    block_M = block_row_warps * warp_row_tiles
+    block_N = block_col_warps * warp_col_tiles
+    block_K = chunk
+
+    A_shared_shape = (block_M, block_K)
+    B_shared_shape = (block_N, block_K)
+    SFA_shared_shape = (block_M, block_K // _WORD_SPAN)
+    SFB_shared_shape = (block_N, block_K // _WORD_SPAN)
+    C_shared_shape = (
+        block_M // micro_size_x,
+        block_N // micro_size_y,
+        micro_size_x,
+        micro_size_y,
+    )
+
+    warp_size = 32
+    threads = warp_size * (block_row_warps * block_col_warps)
+    local_size_a = (micro_size_x * micro_k) // warp_size
+    local_size_b = (micro_size_y * micro_k) // warp_size
+    local_size_c = (micro_size_x * micro_size_y) // warp_size
+    warp_rows = warp_row_tiles // micro_size_x
+    warp_cols = warp_col_tiles // micro_size_y
+
+    mma_emitter = TensorCoreIntrinEmitterSM120(
+        is_blockscaled=True,
+        a_dtype=in_dtype,
+        b_dtype=in_dtype,
+        accum_dtype=accum_dtype,
+        a_transposed=False,
+        b_transposed=True,
+        block_row_warps=block_row_warps,
+        block_col_warps=block_col_warps,
+        warp_row_tiles=warp_row_tiles,
+        warp_col_tiles=warp_col_tiles,
+        chunk=chunk,
+        kind="mxf4nvf4",
+        scale_vec_size=micro_k // _SF_VEC_SIZE,
+        stype="ue8m0",
+    )
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((m, k), in_dtype),
+        B: T.Tensor((n, k), in_dtype),
+        SFA: T.Tensor((m, k // _WORD_SPAN), T.uint32),
+        SFB: T.Tensor((n, k // _WORD_SPAN), T.uint32),
+        C: T.Tensor((m, n), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(n, block_N), T.ceildiv(m, block_M), threads=threads) as (
+            bx,
+            by,
+        ):
+            A_shared = T.alloc_shared(A_shared_shape, in_dtype, scope=shared_scope)
+            B_shared = T.alloc_shared(B_shared_shape, in_dtype, scope=shared_scope)
+            SFA_shared = T.alloc_shared(SFA_shared_shape, T.uint32, scope=shared_scope)
+            SFB_shared = T.alloc_shared(SFB_shared_shape, T.uint32, scope=shared_scope)
+            C_shared = T.alloc_shared(C_shared_shape, out_dtype, scope=shared_scope)
+            A_local = T.alloc_local((warp_rows * local_size_a), in_dtype)
+            B_local = T.alloc_local((warp_cols * local_size_b), in_dtype)
+            C_local = T.alloc_local((warp_rows * warp_cols * local_size_c), accum_dtype)
+
+            T.annotate_layout(
+                {
+                    A_shared: make_mma_swizzle_layout(A_shared),
+                    B_shared: make_mma_swizzle_layout(B_shared),
+                }
+            )
+            T.use_swizzle(panel_size=10)
+
+            T.clear(C_local)
+
+            for ko in T.Pipelined((k // block_K), num_stages=2):
+                for i, k_inner in T.Parallel(block_M, block_K):
+                    A_shared[i, k_inner] = A[by * block_M + i, ko * block_K + k_inner]
+
+                for j, k_inner in T.Parallel(block_N, block_K):
+                    B_shared[j, k_inner] = B[bx * block_N + j, ko * block_K + k_inner]
+
+                for i, k_inner in T.Parallel(block_M, block_K // _WORD_SPAN):
+                    SFA_shared[i, k_inner] = SFA[by * block_M + i, ko * (block_K // _WORD_SPAN) + k_inner]
+
+                for j, k_inner in T.Parallel(block_N, block_K // _WORD_SPAN):
+                    SFB_shared[j, k_inner] = SFB[bx * block_N + j, ko * (block_K // _WORD_SPAN) + k_inner]
+
+                for ki in T.serial(0, (block_K // micro_k)):
+                    mma_emitter.ldmatrix_a(A_local, A_shared, ki)
+                    mma_emitter.ldmatrix_b(B_local, B_shared, ki)
+                    mma_emitter.mma(
+                        A_local,
+                        B_local,
+                        C_local,
+                        ki,
+                        SFA_buf=SFA_shared,
+                        SFB_buf=SFB_shared,
+                        k_start=0,
+                        sf_a_granularity_k=_SF_VEC_SIZE,
+                        sf_b_granularity_k=_SF_VEC_SIZE,
+                    )
+
+            mma_emitter.stmatrix(C_local, C_shared)
+
+            for i, j in T.Parallel(block_M, block_N):
+                C[by * block_M + i, bx * block_N + j] = C_shared[
+                    i // micro_size_x,
+                    j // micro_size_y,
+                    i % micro_size_x,
+                    j % micro_size_y,
+                ]
+
+    return main
+
+
+def _pack_tilelang_sf_u32(sf_bytes):
+    assert sf_bytes.dtype == torch.uint8
+    mn, sf_blocks = sf_bytes.shape
+    assert sf_blocks % 4 == 0
+    words = sf_bytes.reshape(mn, sf_blocks // 4, 4).to(torch.int64)
+    packed = words[:, :, 0] | (words[:, :, 1] << 8) | (words[:, :, 2] << 16) | (words[:, :, 3] << 24)
+    return packed.to(torch.uint32).contiguous()
+
+
+def _pack_cutlass_sf_bytes(sf_bytes):
+    """Pack logical (MN, K/32) UE8M0 bytes into CUTLASS Sm1xxBlockScaledConfig<32> order.
+
+    Blk_MN=128 / Blk_SF=4 are scale-vector-size independent, so the byte
+    layout matches the NVFP4 packer with the K/32 index in place of K/16.
+    """
+    assert sf_bytes.dtype == torch.uint8
+    mn, sf_blocks = sf_bytes.shape
+    assert mn == 128
+    assert sf_blocks % 4 == 0
+
+    out = torch.empty((mn * sf_blocks,), device=sf_bytes.device, dtype=torch.uint8)
+    for sf_idx in range(sf_blocks):
+        k_word_group = sf_idx // 4
+        byte_in_word = sf_idx % 4
+        for row in range(mn):
+            offset = k_word_group * mn * 4 + (row % 32) * 16 + (row // 32) * 4 + byte_in_word
+            out[offset] = sf_bytes[row, sf_idx]
+    return out.contiguous()
+
+
+def _decode_rowmajor_fp4(packed, rows: int, cols: int):
+    fp4_e2m1_values = (
+        0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,
+        -0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,
+    )
+    u = packed.contiguous().view(torch.uint8)
+    lut = torch.tensor(fp4_e2m1_values, device=packed.device, dtype=torch.float32)
+    out = torch.empty((rows, cols), device=packed.device, dtype=torch.float32)
+    out[:, 0::2] = lut[(u & 0x0F).long()]
+    out[:, 1::2] = lut[((u >> 4) & 0x0F).long()]
+    return out
+
+
+def _decode_ue8m0(sf_bytes):
+    return torch.pow(2.0, (sf_bytes.to(torch.int32) - 127).to(torch.float32))
+
+
+def _blockscaled_mxf4_reference(a, b, sfa_logical, sfb_logical):
+    m, packed_k = a.shape
+    n, packed_b_k = b.shape
+    assert packed_b_k == packed_k
+    k = packed_k * 2
+    a_f32 = _decode_rowmajor_fp4(a, m, k)
+    b_f32 = _decode_rowmajor_fp4(b, n, k)
+    sfa = _decode_ue8m0(sfa_logical).repeat_interleave(_SF_VEC_SIZE, dim=1)
+    sfb = _decode_ue8m0(sfb_logical).repeat_interleave(_SF_VEC_SIZE, dim=1)
+    return (a_f32 * sfa) @ (b_f32 * sfb).T
+
+
+def _build_cutlass_extension():
+    from torch.utils.cpp_extension import load
+
+    source_path = Path(__file__).resolve().with_name("cutlass_mxf4_ref.cu")
+    repo_root = source_path.parents[3]
+    cutlass_root_env = os.environ.get("CUTLASS_ROOT")
+    cutlass_root = Path(cutlass_root_env) if cutlass_root_env else repo_root / "3rdparty" / "cutlass"
+    include_paths = [
+        cutlass_root / "include",
+        cutlass_root / "tools" / "util" / "include",
+    ]
+    if not all(path.exists() for path in include_paths):
+        raise RuntimeError(
+            "CUTLASS headers were not found. Set CUTLASS_ROOT to a CUTLASS checkout "
+            "or populate the repository's 3rdparty/cutlass submodule."
+        )
+
+    return load(
+        name="tilelang_cutlass_mxf4_ref",
+        sources=[str(source_path)],
+        extra_include_paths=[str(path) for path in include_paths],
+        extra_cuda_cflags=[
+            "-std=c++20",
+            "-arch=sm_120a",
+            "--expt-relaxed-constexpr",
+            "-DCUTLASS_ARCH_MMA_SM120_SUPPORTED",
+        ],
+        extra_cflags=["-std=c++20"],
+        verbose=True,
+    )
+
+
+def run_compare() -> None:
+    m = 128
+    n = 128
+    k = 256
+    micro_k = 64
+
+    torch.manual_seed(0)
+    assert torch.cuda.is_available(), "CUDA is required"
+
+    input_mode = os.environ.get("MXF4_INPUT_MODE", "random")
+    if input_mode == "constant":
+        input_byte = int(os.environ.get("MXF4_INPUT_BYTE", "0x22"), 0)
+        a = torch.full((m, k // 2), input_byte, device="cuda", dtype=torch.uint8).view(torch.int8)
+        b = torch.full((n, k // 2), input_byte, device="cuda", dtype=torch.uint8).view(torch.int8)
+    elif input_mode == "random":
+        a = torch.randint(-128, 128, (m, k // 2), device="cuda", dtype=torch.int8)
+        b = torch.randint(-128, 128, (n, k // 2), device="cuda", dtype=torch.int8)
+    else:
+        raise ValueError(f"Unsupported MXF4_INPUT_MODE={input_mode!r}")
+
+    scale_mode = os.environ.get("MXF4_SCALE_MODE", "varying")
+    if scale_mode == "constant":
+        sfa_logical = torch.full((m, k // _SF_VEC_SIZE), 0x7F, device="cuda", dtype=torch.uint8)
+        sfb_logical = torch.full((n, k // _SF_VEC_SIZE), 0x7F, device="cuda", dtype=torch.uint8)
+    elif scale_mode == "varying":
+        # Power-of-two exponents around 1.0, varying by row and K group so a
+        # byte-pair (parity) mix-up in the 2X path changes the result.
+        row = torch.arange(m, device="cuda", dtype=torch.int32).reshape(m, 1)
+        col = torch.arange(k // _SF_VEC_SIZE, device="cuda", dtype=torch.int32).reshape(1, k // _SF_VEC_SIZE)
+        sfa_logical = (0x70 + ((row * 3 + col * 5) % 32)).to(torch.uint8)
+        sfb_logical = (0x70 + ((row * 7 + col * 11) % 32)).to(torch.uint8)
+    else:
+        raise ValueError(f"Unsupported MXF4_SCALE_MODE={scale_mode!r}")
+
+    sfa_tl = _pack_tilelang_sf_u32(sfa_logical)
+    sfb_tl = _pack_tilelang_sf_u32(sfb_logical)
+    sfa_cutlass = _pack_cutlass_sf_bytes(sfa_logical)
+    sfb_cutlass = _pack_cutlass_sf_bytes(sfb_logical)
+
+    kernel = tilelang.compile(
+        _make_tilelang_mxf4_kernel(m, n, k, micro_k),
+        target="cuda",
+        out_idx=[4],
+    )
+    c_tl = kernel(a, b, sfa_tl, sfb_tl)
+
+    cutlass_ref = _build_cutlass_extension()
+    c_in = torch.zeros((m, n), device="cuda", dtype=torch.float32)
+    c_cutlass = torch.empty((m, n), device="cuda", dtype=torch.float32)
+    cutlass_ref.cutlass_mxf4_gemm_128x128x256(a, b, sfa_cutlass, sfb_cutlass, c_in, c_cutlass)
+
+    torch.cuda.synchronize()
+    ref = _blockscaled_mxf4_reference(a, b, sfa_logical, sfb_logical)
+    print("scale_mode:", scale_mode)
+    print("input_mode:", input_mode)
+    print("max_abs_diff:", (c_tl - c_cutlass).abs().max().item())
+    print("max_abs_diff_tilelang_ref:", (c_tl - ref).abs().max().item())
+    print("max_abs_diff_cutlass_ref:", (c_cutlass - ref).abs().max().item())
+    if os.environ.get("MXF4_SKIP_ASSERT", "0") == "1":
+        return
+    torch.testing.assert_close(c_tl, c_cutlass, rtol=0.0, atol=0.0)
+    print("TileLang MXFP4 block-scale output matches CUTLASS exactly.")
+
+
+if __name__ == "__main__":
+    run_compare()

--- a/maint/gemm/gemm_sm120/correctness_evaluation_mxf8_vs_cutlass.py
+++ b/maint/gemm/gemm_sm120/correctness_evaluation_mxf8_vs_cutlass.py
@@ -1,0 +1,234 @@
+"""Compare TileLang's SM120 MXFP8 (kind::mxf8f6f4) GEMM against CUTLASS.
+
+Run from the repository root:
+
+    python -m maint.gemm.gemm_sm120.correctness_evaluation_mxf8_vs_cutlass
+
+All four {e4m3, e5m2} A/B pairings are compared. Two data bands:
+
+- Controlled band (asserted bitwise): small-integer fp8 values and a narrow
+  power-of-two scale window, so both engines perform the same exact fp32
+  arithmetic in the same K order.
+- Full code domain (e5m2 x e5m2 only): random raw bytes naturally include
+  Inf/NaN; the NaN masks must match and the remaining entries stay bitwise.
+
+Set CUTLASS_ROOT to the CUTLASS checkout to compile the reference against
+(the official test requirement is v4.7.0); it defaults to the vendored
+3rdparty/cutlass tree.
+"""
+
+import os
+from pathlib import Path
+
+import torch
+import tilelang
+import tilelang.language as T
+from tilelang.transform import simplify_prim_func
+
+
+_SF_VEC_SIZE = 32
+_WORD_SPAN = _SF_VEC_SIZE * 4  # K elements covered by one uint32 scale word
+_TORCH_FP8 = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}
+_TILELANG_FP8 = {"e4m3": "float8_e4m3fn", "e5m2": "float8_e5m2"}
+
+
+@simplify_prim_func
+def _make_tilelang_mxf8_kernel(m: int, n: int, k: int, a_name: str, b_name: str):
+    a_dtype = getattr(T, _TILELANG_FP8[a_name])
+    b_dtype = getattr(T, _TILELANG_FP8[b_name])
+    accum_dtype = T.float32
+
+    block_M = block_N = 128
+    block_K = k
+    threads = 128
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((m, k), a_dtype),
+        B: T.Tensor((n, k), b_dtype),
+        SFA: T.Tensor((m, k // _WORD_SPAN), T.uint32),
+        SFB: T.Tensor((n, k // _WORD_SPAN), T.uint32),
+        C: T.Tensor((m, n), accum_dtype),
+    ):
+        with T.Kernel(T.ceildiv(n, block_N), T.ceildiv(m, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), a_dtype, scope="shared.dyn")
+            B_shared = T.alloc_shared((block_N, block_K), b_dtype, scope="shared.dyn")
+            SFA_shared = T.alloc_shared((block_M, block_K // _WORD_SPAN), T.uint32, scope="shared.dyn")
+            SFB_shared = T.alloc_shared((block_N, block_K // _WORD_SPAN), T.uint32, scope="shared.dyn")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            for ko in T.Pipelined((k // block_K), num_stages=1):
+                for i, k_inner in T.Parallel(block_M, block_K):
+                    A_shared[i, k_inner] = A[by * block_M + i, ko * block_K + k_inner]
+                for j, k_inner in T.Parallel(block_N, block_K):
+                    B_shared[j, k_inner] = B[bx * block_N + j, ko * block_K + k_inner]
+                for i, k_inner in T.Parallel(block_M, block_K // _WORD_SPAN):
+                    SFA_shared[i, k_inner] = SFA[by * block_M + i, ko * (block_K // _WORD_SPAN) + k_inner]
+                for j, k_inner in T.Parallel(block_N, block_K // _WORD_SPAN):
+                    SFB_shared[j, k_inner] = SFB[bx * block_N + j, ko * (block_K // _WORD_SPAN) + k_inner]
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=True,
+                    k_start=0,
+                    sf_a_granularity_k=_SF_VEC_SIZE,
+                    sf_b_granularity_k=_SF_VEC_SIZE,
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _pack_tilelang_sf_u32(sf_bytes):
+    assert sf_bytes.dtype == torch.uint8
+    mn, sf_blocks = sf_bytes.shape
+    assert sf_blocks % 4 == 0
+    words = sf_bytes.reshape(mn, sf_blocks // 4, 4).to(torch.int64)
+    packed = words[:, :, 0] | (words[:, :, 1] << 8) | (words[:, :, 2] << 16) | (words[:, :, 3] << 24)
+    return packed.to(torch.uint32).contiguous()
+
+
+def _pack_cutlass_sf_bytes(sf_bytes):
+    """Pack logical (MN, K/32) UE8M0 bytes into CUTLASS Sm1xxBlockScaledConfig<32> order."""
+    assert sf_bytes.dtype == torch.uint8
+    mn, sf_blocks = sf_bytes.shape
+    assert mn % 128 == 0
+    assert sf_blocks % 4 == 0
+
+    rows = torch.arange(mn, device=sf_bytes.device).reshape(mn, 1)
+    cols = torch.arange(sf_blocks, device=sf_bytes.device).reshape(1, sf_blocks)
+    atom = rows // 128
+    row_in_atom = rows % 128
+    k_word_group = cols // 4
+    byte_in_word = cols % 4
+    words_total = sf_blocks // 4
+    offsets = atom * 128 * sf_blocks + k_word_group * 128 * 4 + (row_in_atom % 32) * 16 + (row_in_atom // 32) * 4 + byte_in_word
+    out = torch.empty((mn * sf_blocks,), device=sf_bytes.device, dtype=torch.uint8)
+    out[offsets.reshape(-1)] = sf_bytes.reshape(-1)
+    assert words_total >= 1
+    return out.contiguous()
+
+
+def _decode_ue8m0(sf_bytes):
+    return torch.pow(2.0, (sf_bytes.to(torch.int32) - 127).to(torch.float32))
+
+
+def _python_reference(a, b, sfa_logical, sfb_logical):
+    sfa = _decode_ue8m0(sfa_logical).repeat_interleave(_SF_VEC_SIZE, dim=1)
+    sfb = _decode_ue8m0(sfb_logical).repeat_interleave(_SF_VEC_SIZE, dim=1)
+    return (a.to(torch.float32) * sfa) @ (b.to(torch.float32) * sfb).T
+
+
+def _build_cutlass_extension():
+    from torch.utils.cpp_extension import load
+
+    source_path = Path(__file__).resolve().with_name("cutlass_mxf8_ref.cu")
+    repo_root = source_path.parents[3]
+    cutlass_root_env = os.environ.get("CUTLASS_ROOT")
+    cutlass_root = Path(cutlass_root_env) if cutlass_root_env else repo_root / "3rdparty" / "cutlass"
+    include_paths = [
+        cutlass_root / "include",
+        cutlass_root / "tools" / "util" / "include",
+    ]
+    if not all(path.exists() for path in include_paths):
+        raise RuntimeError(
+            "CUTLASS headers were not found. Set CUTLASS_ROOT to a CUTLASS checkout "
+            "or populate the repository's 3rdparty/cutlass submodule."
+        )
+
+    return load(
+        name="tilelang_cutlass_mxf8_ref",
+        sources=[str(source_path)],
+        extra_include_paths=[str(path) for path in include_paths],
+        extra_cuda_cflags=[
+            "-std=c++20",
+            "-arch=sm_120a",
+            "--expt-relaxed-constexpr",
+            "-DCUTLASS_ARCH_MMA_SM120_SUPPORTED",
+        ],
+        extra_cflags=["-std=c++20"],
+        verbose=True,
+    )
+
+
+def _make_controlled_inputs(m, n, k, a_name, b_name):
+    a = torch.randint(-4, 5, (m, k), device="cuda", dtype=torch.float32).to(_TORCH_FP8[a_name])
+    b = torch.randint(-4, 5, (n, k), device="cuda", dtype=torch.float32).to(_TORCH_FP8[b_name])
+    return a, b
+
+
+def _make_varying_scales(mn, k):
+    # Power-of-two exponents around 1.0, varying by row and K group; narrow
+    # window so summation stays exact on top of the shared K order.
+    row = torch.arange(mn, device="cuda", dtype=torch.int32).reshape(mn, 1)
+    col = torch.arange(k // _SF_VEC_SIZE, device="cuda", dtype=torch.int32).reshape(1, k // _SF_VEC_SIZE)
+    return (127 + (row + col) % 3 - 1).to(torch.uint8)
+
+
+def _compare_one(ext, a_name, b_name, m, n, k, full_domain=False):
+    if full_domain:
+        a = torch.randint(0, 256, (m, k), device="cuda", dtype=torch.uint8).view(_TORCH_FP8[a_name])
+        b = torch.randint(0, 256, (n, k), device="cuda", dtype=torch.uint8).view(_TORCH_FP8[b_name])
+    else:
+        a, b = _make_controlled_inputs(m, n, k, a_name, b_name)
+    sfa_logical = _make_varying_scales(m, k)
+    sfb_logical = _make_varying_scales(n, k)
+
+    kernel = tilelang.compile(_make_tilelang_mxf8_kernel(m, n, k, a_name, b_name), target="cuda", out_idx=[4])
+    C_tl = kernel(a, b, _pack_tilelang_sf_u32(sfa_logical), _pack_tilelang_sf_u32(sfb_logical))
+
+    C_ref = torch.zeros((m, n), device="cuda", dtype=torch.float32)
+    D_cutlass = torch.zeros((m, n), device="cuda", dtype=torch.float32)
+    ext.cutlass_mxf8_gemm(
+        a.view(torch.int8).contiguous(),
+        b.view(torch.int8).contiguous(),
+        _pack_cutlass_sf_bytes(sfa_logical),
+        _pack_cutlass_sf_bytes(sfb_logical),
+        C_ref,
+        D_cutlass,
+        m,
+        n,
+        k,
+        a_name == "e4m3",
+        b_name == "e4m3",
+    )
+
+    band = "full-domain" if full_domain else "controlled"
+    if full_domain:
+        nan_tl = torch.isnan(C_tl)
+        nan_cutlass = torch.isnan(D_cutlass)
+        assert torch.equal(nan_tl, nan_cutlass), f"{a_name}x{b_name} NaN masks differ"
+        finite = ~nan_tl
+        bitwise = torch.equal(C_tl[finite].view(torch.int32), D_cutlass[finite].view(torch.int32))
+        assert bitwise, f"{a_name}x{b_name} {band}: finite entries not bitwise equal"
+        print(f"{a_name}x{b_name} [{band}]: NaN masks equal, finite entries bitwise equal")
+    else:
+        max_abs = (C_tl - D_cutlass).abs().max().item()
+        assert torch.equal(C_tl, D_cutlass), f"{a_name}x{b_name} {band}: max abs diff {max_abs}"
+        ref = _python_reference(a, b, sfa_logical, sfb_logical)
+        print(
+            f"{a_name}x{b_name} [{band}]: TileLang vs CUTLASS bitwise equal "
+            f"(both vs python reference max abs diff {(C_tl - ref).abs().max().item():.3e})"
+        )
+
+
+def run_compare() -> None:
+    torch.manual_seed(0)
+    assert torch.cuda.is_available(), "CUDA is required"
+    ext = _build_cutlass_extension()
+
+    m = n = 256
+    k = 256
+    for a_name in ("e4m3", "e5m2"):
+        for b_name in ("e4m3", "e5m2"):
+            _compare_one(ext, a_name, b_name, m, n, k)
+    _compare_one(ext, "e5m2", "e5m2", m, n, k, full_domain=True)
+
+
+if __name__ == "__main__":
+    run_compare()

--- a/maint/gemm/gemm_sm120/correctness_evaluation_mxf8_vs_cutlass.py
+++ b/maint/gemm/gemm_sm120/correctness_evaluation_mxf8_vs_cutlass.py
@@ -221,6 +221,44 @@ def _compare_one(ext, a_name, b_name, m, n, k, full_domain=False, block_K=None):
         )
 
 
+def _compare_quantized(ext, dtype_name, m, n, k):
+    """The quantized band: real quantizer output, engine vs engine, bitwise.
+
+    Feeding the SAME quantized tensors and scale bytes to both backends
+    removes the python-reference tolerance problem entirely: both engines
+    run the same instruction in the same K order, so the comparison is
+    exact even though the data has mixed magnitudes and rounding partial
+    sums.
+    """
+    from examples.dequantize_gemm.quantize import quantize_bf16_to_mxfp8_blockscaled
+
+    x_a = (torch.randn(m, k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+    x_b = (torch.randn(n, k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+    a, _, sfa_logical = quantize_bf16_to_mxfp8_blockscaled(x_a, dtype=dtype_name, return_scale_bytes=True)
+    b, _, sfb_logical = quantize_bf16_to_mxfp8_blockscaled(x_b, dtype=dtype_name, return_scale_bytes=True)
+
+    kernel = tilelang.compile(_make_tilelang_mxf8_kernel(m, n, k, dtype_name, dtype_name), target="cuda", out_idx=[4])
+    C_tl = kernel(a, b, _pack_tilelang_sf_u32(sfa_logical), _pack_tilelang_sf_u32(sfb_logical))
+
+    C_ref = torch.zeros((m, n), device="cuda", dtype=torch.float32)
+    D_cutlass = torch.zeros((m, n), device="cuda", dtype=torch.float32)
+    ext.cutlass_mxf8_gemm(
+        a.view(torch.int8).contiguous(),
+        b.view(torch.int8).contiguous(),
+        _pack_cutlass_sf_bytes(sfa_logical),
+        _pack_cutlass_sf_bytes(sfb_logical),
+        C_ref,
+        D_cutlass,
+        m,
+        n,
+        k,
+        dtype_name == "e4m3",
+        dtype_name == "e4m3",
+    )
+    assert torch.equal(C_tl.view(torch.int32), D_cutlass.view(torch.int32)), f"{dtype_name} quantized band not bitwise"
+    print(f"{dtype_name}x{dtype_name} [quantized bf16->mxfp8]: TileLang vs CUTLASS bitwise equal")
+
+
 def run_compare() -> None:
     torch.manual_seed(0)
     assert torch.cuda.is_available(), "CUDA is required"
@@ -241,6 +279,9 @@ def run_compare() -> None:
     # byte parity) stays pinned against CUTLASS forever.
     _compare_one(ext, "e4m3", "e4m3", m, n, k, block_K=128)
     _compare_one(ext, "e5m2", "e5m2", m, n, k, full_domain=True, block_K=128)
+    # Real quantizer output through both engines, bitwise (no tolerance).
+    _compare_quantized(ext, "e4m3", m, n, k)
+    _compare_quantized(ext, "e5m2", m, n, k)
 
 
 if __name__ == "__main__":

--- a/maint/gemm/gemm_sm120/correctness_evaluation_mxf8_vs_cutlass.py
+++ b/maint/gemm/gemm_sm120/correctness_evaluation_mxf8_vs_cutlass.py
@@ -33,13 +33,13 @@ _TILELANG_FP8 = {"e4m3": "float8_e4m3fn", "e5m2": "float8_e5m2"}
 
 
 @simplify_prim_func
-def _make_tilelang_mxf8_kernel(m: int, n: int, k: int, a_name: str, b_name: str):
+def _make_tilelang_mxf8_kernel(m: int, n: int, k: int, a_name: str, b_name: str, block_K: int | None = None):
     a_dtype = getattr(T, _TILELANG_FP8[a_name])
     b_dtype = getattr(T, _TILELANG_FP8[b_name])
     accum_dtype = T.float32
 
     block_M = block_N = 128
-    block_K = k
+    block_K = k if block_K is None else block_K
     threads = 128
 
     @T.prim_func
@@ -57,6 +57,9 @@ def _make_tilelang_mxf8_kernel(m: int, n: int, k: int, a_name: str, b_name: str)
             SFB_shared = T.alloc_shared((block_N, block_K // _WORD_SPAN), T.uint32, scope="shared.dyn")
             C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
 
+            # clear_accum is a per-call clear; multi-ko loops hoist it.
+            if k // block_K > 1:
+                T.clear(C_local)
             for ko in T.Pipelined((k // block_K), num_stages=1):
                 for i, k_inner in T.Parallel(block_M, block_K):
                     A_shared[i, k_inner] = A[by * block_M + i, ko * block_K + k_inner]
@@ -73,7 +76,7 @@ def _make_tilelang_mxf8_kernel(m: int, n: int, k: int, a_name: str, b_name: str)
                     SFA_shared,
                     SFB_shared,
                     transpose_B=True,
-                    clear_accum=True,
+                    clear_accum=(k // block_K == 1),
                     k_start=0,
                     sf_a_granularity_k=_SF_VEC_SIZE,
                     sf_b_granularity_k=_SF_VEC_SIZE,
@@ -170,7 +173,7 @@ def _make_varying_scales(mn, k):
     return (127 + (row + col) % 3 - 1).to(torch.uint8)
 
 
-def _compare_one(ext, a_name, b_name, m, n, k, full_domain=False):
+def _compare_one(ext, a_name, b_name, m, n, k, full_domain=False, block_K=None):
     if full_domain:
         a = torch.randint(0, 256, (m, k), device="cuda", dtype=torch.uint8).view(_TORCH_FP8[a_name])
         b = torch.randint(0, 256, (n, k), device="cuda", dtype=torch.uint8).view(_TORCH_FP8[b_name])
@@ -179,7 +182,7 @@ def _compare_one(ext, a_name, b_name, m, n, k, full_domain=False):
     sfa_logical = _make_varying_scales(m, k)
     sfb_logical = _make_varying_scales(n, k)
 
-    kernel = tilelang.compile(_make_tilelang_mxf8_kernel(m, n, k, a_name, b_name), target="cuda", out_idx=[4])
+    kernel = tilelang.compile(_make_tilelang_mxf8_kernel(m, n, k, a_name, b_name, block_K=block_K), target="cuda", out_idx=[4])
     C_tl = kernel(a, b, _pack_tilelang_sf_u32(sfa_logical), _pack_tilelang_sf_u32(sfb_logical))
 
     C_ref = torch.zeros((m, n), device="cuda", dtype=torch.float32)
@@ -199,6 +202,7 @@ def _compare_one(ext, a_name, b_name, m, n, k, full_domain=False):
     )
 
     band = "full-domain" if full_domain else "controlled"
+    band += f" bK={k if block_K is None else block_K}"
     if full_domain:
         nan_tl = torch.isnan(C_tl)
         nan_cutlass = torch.isnan(D_cutlass)
@@ -227,7 +231,16 @@ def run_compare() -> None:
     for a_name in ("e4m3", "e5m2"):
         for b_name in ("e4m3", "e5m2"):
             _compare_one(ext, a_name, b_name, m, n, k)
-    _compare_one(ext, "e5m2", "e5m2", m, n, k, full_domain=True)
+    # Full code domain for every pairing: e5m2 contributes Inf/NaN bytes,
+    # e4m3 contributes its NaN encoding (0x7F); mixed pairs have no plain
+    # T.gemm oracle, so CUTLASS is their only full-domain pin.
+    for a_name in ("e4m3", "e5m2"):
+        for b_name in ("e4m3", "e5m2"):
+            _compare_one(ext, a_name, b_name, m, n, k, full_domain=True)
+    # chunk=128: the config that was once silently broken (kblock4 fast-path
+    # byte parity) stays pinned against CUTLASS forever.
+    _compare_one(ext, "e4m3", "e4m3", m, n, k, block_K=128)
+    _compare_one(ext, "e5m2", "e5m2", m, n, k, full_domain=True, block_K=128)
 
 
 if __name__ == "__main__":

--- a/maint/gemm/gemm_sm120/correctness_evaluation_mxf8_vs_cutlass.py
+++ b/maint/gemm/gemm_sm120/correctness_evaluation_mxf8_vs_cutlass.py
@@ -221,7 +221,7 @@ def _compare_one(ext, a_name, b_name, m, n, k, full_domain=False, block_K=None):
         )
 
 
-def _compare_quantized(ext, dtype_name, m, n, k):
+def _compare_quantized(ext, a_name, b_name, m, n, k):
     """The quantized band: real quantizer output, engine vs engine, bitwise.
 
     Feeding the SAME quantized tensors and scale bytes to both backends
@@ -234,10 +234,10 @@ def _compare_quantized(ext, dtype_name, m, n, k):
 
     x_a = (torch.randn(m, k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
     x_b = (torch.randn(n, k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
-    a, _, sfa_logical = quantize_bf16_to_mxfp8_blockscaled(x_a, dtype=dtype_name, return_scale_bytes=True)
-    b, _, sfb_logical = quantize_bf16_to_mxfp8_blockscaled(x_b, dtype=dtype_name, return_scale_bytes=True)
+    a, _, sfa_logical = quantize_bf16_to_mxfp8_blockscaled(x_a, dtype=a_name, return_scale_bytes=True)
+    b, _, sfb_logical = quantize_bf16_to_mxfp8_blockscaled(x_b, dtype=b_name, return_scale_bytes=True)
 
-    kernel = tilelang.compile(_make_tilelang_mxf8_kernel(m, n, k, dtype_name, dtype_name), target="cuda", out_idx=[4])
+    kernel = tilelang.compile(_make_tilelang_mxf8_kernel(m, n, k, a_name, b_name), target="cuda", out_idx=[4])
     C_tl = kernel(a, b, _pack_tilelang_sf_u32(sfa_logical), _pack_tilelang_sf_u32(sfb_logical))
 
     C_ref = torch.zeros((m, n), device="cuda", dtype=torch.float32)
@@ -252,11 +252,11 @@ def _compare_quantized(ext, dtype_name, m, n, k):
         m,
         n,
         k,
-        dtype_name == "e4m3",
-        dtype_name == "e4m3",
+        a_name == "e4m3",
+        b_name == "e4m3",
     )
-    assert torch.equal(C_tl.view(torch.int32), D_cutlass.view(torch.int32)), f"{dtype_name} quantized band not bitwise"
-    print(f"{dtype_name}x{dtype_name} [quantized bf16->mxfp8]: TileLang vs CUTLASS bitwise equal")
+    assert torch.equal(C_tl.view(torch.int32), D_cutlass.view(torch.int32)), f"{a_name}x{b_name} quantized band not bitwise"
+    print(f"{a_name}x{b_name} [quantized bf16->mxfp8]: TileLang vs CUTLASS bitwise equal")
 
 
 def run_compare() -> None:
@@ -280,8 +280,10 @@ def run_compare() -> None:
     _compare_one(ext, "e4m3", "e4m3", m, n, k, block_K=128)
     _compare_one(ext, "e5m2", "e5m2", m, n, k, full_domain=True, block_K=128)
     # Real quantizer output through both engines, bitwise (no tolerance).
-    _compare_quantized(ext, "e4m3", m, n, k)
-    _compare_quantized(ext, "e5m2", m, n, k)
+    _compare_quantized(ext, "e4m3", "e4m3", m, n, k)
+    _compare_quantized(ext, "e5m2", "e5m2", m, n, k)
+    # The fp8-training pairing: e4m3 activations x e5m2 gradients.
+    _compare_quantized(ext, "e4m3", "e5m2", m, n, k)
 
 
 if __name__ == "__main__":

--- a/maint/gemm/gemm_sm120/correctness_evaluation_w4a8_vs_cutlass.py
+++ b/maint/gemm/gemm_sm120/correctness_evaluation_w4a8_vs_cutlass.py
@@ -1,0 +1,244 @@
+"""Compare TileLang's SM120 W4A8 (mxfp4 x mxfp8, kind::mxf8f6f4) vs CUTLASS.
+
+Run from the repository root:
+
+    python -m maint.gemm.gemm_sm120.correctness_evaluation_w4a8_vs_cutlass
+
+Bands (both fp8 activation flavors where applicable):
+
+- Controlled band (asserted bitwise): full-range packed fp4 weights (e2m1
+  has no Inf/NaN, all values dyadic) x small-integer fp8 activations with a
+  narrow power-of-two scale window - every partial sum exact in fp32.
+- Full code domain: random e5m2 activation bytes (Inf/NaN included); NaN
+  masks must match and finite entries stay bitwise.
+- Quantized band: bf16 -> mxfp4 (weights) + mxfp8 (activations) quantizer
+  outputs through both engines, bitwise (the standard oracle for real data).
+
+Set CUTLASS_ROOT to the CUTLASS checkout (official requirement v4.7.0).
+"""
+
+import os
+from pathlib import Path
+
+import torch
+import tilelang
+import tilelang.language as T
+from tilelang.transform import simplify_prim_func
+
+
+_SF_VEC_SIZE = 32
+_WORD_SPAN = _SF_VEC_SIZE * 4
+_TORCH_FP8 = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}
+_TILELANG_FP8 = {"e4m3": "float8_e4m3fn", "e5m2": "float8_e5m2"}
+_FP4_E2M1_VALUES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0)
+
+
+@simplify_prim_func
+def _make_tilelang_w4a8_kernel(m: int, n: int, k: int, b_name: str):
+    b_dtype = getattr(T, _TILELANG_FP8[b_name])
+    accum_dtype = T.float32
+
+    block_M = block_N = 128
+    block_K = k
+    threads = 128
+
+    @T.prim_func
+    def main(
+        A_packed: T.Tensor((m, k // 2), T.uint8),
+        B: T.Tensor((n, k), b_dtype),
+        SFA: T.Tensor((m, k // _WORD_SPAN), T.uint32),
+        SFB: T.Tensor((n, k // _WORD_SPAN), T.uint32),
+        C: T.Tensor((m, n), accum_dtype),
+    ):
+        with T.Kernel(T.ceildiv(n, block_N), T.ceildiv(m, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), T.float4_e2m1_unpacked, scope="shared.dyn")
+            B_shared = T.alloc_shared((block_N, block_K), b_dtype, scope="shared.dyn")
+            SFA_shared = T.alloc_shared((block_M, block_K // _WORD_SPAN), T.uint32, scope="shared.dyn")
+            SFB_shared = T.alloc_shared((block_N, block_K // _WORD_SPAN), T.uint32, scope="shared.dyn")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            for ko in T.Pipelined((k // block_K), num_stages=1):
+                # SIMT producer of the padded-packed smem form.
+                for i, g, j in T.Parallel(block_M, block_K // 16, 8):
+                    A_shared[i, 16 * g + j] = T.reinterpret(
+                        T.float4_e2m1_unpacked, A_packed[by * block_M + i, ko * (block_K // 2) + 8 * g + j]
+                    )
+                for j, k_inner in T.Parallel(block_N, block_K):
+                    B_shared[j, k_inner] = B[bx * block_N + j, ko * block_K + k_inner]
+                for i, k_inner in T.Parallel(block_M, block_K // _WORD_SPAN):
+                    SFA_shared[i, k_inner] = SFA[by * block_M + i, ko * (block_K // _WORD_SPAN) + k_inner]
+                for j, k_inner in T.Parallel(block_N, block_K // _WORD_SPAN):
+                    SFB_shared[j, k_inner] = SFB[bx * block_N + j, ko * (block_K // _WORD_SPAN) + k_inner]
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=True,
+                    k_start=0,
+                    sf_a_granularity_k=_SF_VEC_SIZE,
+                    sf_b_granularity_k=_SF_VEC_SIZE,
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _pack_tilelang_sf_u32(sf_bytes):
+    assert sf_bytes.dtype == torch.uint8
+    mn, sf_blocks = sf_bytes.shape
+    assert sf_blocks % 4 == 0
+    words = sf_bytes.reshape(mn, sf_blocks // 4, 4).to(torch.int64)
+    packed = words[:, :, 0] | (words[:, :, 1] << 8) | (words[:, :, 2] << 16) | (words[:, :, 3] << 24)
+    return packed.to(torch.uint32).contiguous()
+
+
+def _pack_cutlass_sf_bytes(sf_bytes):
+    """Pack logical (MN, K/32) UE8M0 bytes into CUTLASS Sm1xxBlockScaledConfig<32> order."""
+    assert sf_bytes.dtype == torch.uint8
+    mn, sf_blocks = sf_bytes.shape
+    assert mn % 128 == 0
+    assert sf_blocks % 4 == 0
+
+    rows = torch.arange(mn, device=sf_bytes.device).reshape(mn, 1)
+    cols = torch.arange(sf_blocks, device=sf_bytes.device).reshape(1, sf_blocks)
+    atom = rows // 128
+    row_in_atom = rows % 128
+    k_word_group = cols // 4
+    byte_in_word = cols % 4
+    offsets = atom * 128 * sf_blocks + k_word_group * 128 * 4 + (row_in_atom % 32) * 16 + (row_in_atom // 32) * 4 + byte_in_word
+    out = torch.empty((mn * sf_blocks,), device=sf_bytes.device, dtype=torch.uint8)
+    out[offsets.reshape(-1)] = sf_bytes.reshape(-1)
+    return out.contiguous()
+
+
+def _decode_packed_fp4(packed, rows, cols):
+    lut = torch.tensor(_FP4_E2M1_VALUES, device=packed.device, dtype=torch.float32)
+    out = torch.empty((rows, cols), device=packed.device, dtype=torch.float32)
+    out[:, 0::2] = lut[(packed & 0x0F).long()]
+    out[:, 1::2] = lut[((packed >> 4) & 0x0F).long()]
+    return out
+
+
+def _decode_ue8m0(sf_bytes):
+    return torch.pow(2.0, (sf_bytes.to(torch.int32) - 127).to(torch.float32))
+
+
+def _build_cutlass_extension():
+    from torch.utils.cpp_extension import load
+
+    source_path = Path(__file__).resolve().with_name("cutlass_w4a8_ref.cu")
+    repo_root = source_path.parents[3]
+    cutlass_root_env = os.environ.get("CUTLASS_ROOT")
+    cutlass_root = Path(cutlass_root_env) if cutlass_root_env else repo_root / "3rdparty" / "cutlass"
+    include_paths = [
+        cutlass_root / "include",
+        cutlass_root / "tools" / "util" / "include",
+    ]
+    if not all(path.exists() for path in include_paths):
+        raise RuntimeError(
+            "CUTLASS headers were not found. Set CUTLASS_ROOT to a CUTLASS checkout "
+            "or populate the repository's 3rdparty/cutlass submodule."
+        )
+
+    return load(
+        name="tilelang_cutlass_w4a8_ref",
+        sources=[str(source_path)],
+        extra_include_paths=[str(path) for path in include_paths],
+        extra_cuda_cflags=[
+            "-std=c++20",
+            "-arch=sm_120a",
+            "--expt-relaxed-constexpr",
+            "-DCUTLASS_ARCH_MMA_SM120_SUPPORTED",
+        ],
+        extra_cflags=["-std=c++20"],
+        verbose=True,
+    )
+
+
+def _make_varying_scales(mn, k):
+    row = torch.arange(mn, device="cuda", dtype=torch.int32).reshape(mn, 1)
+    col = torch.arange(k // _SF_VEC_SIZE, device="cuda", dtype=torch.int32).reshape(1, k // _SF_VEC_SIZE)
+    return (127 + (row + col) % 3 - 1).to(torch.uint8)
+
+
+def _run_pair(ext, kernel, a_packed, b, sfa_logical, sfb_logical, m, n, k, b_name):
+    C_tl = kernel(a_packed, b, _pack_tilelang_sf_u32(sfa_logical), _pack_tilelang_sf_u32(sfb_logical))
+    C_ref = torch.zeros((m, n), device="cuda", dtype=torch.float32)
+    D_cutlass = torch.zeros((m, n), device="cuda", dtype=torch.float32)
+    ext.cutlass_w4a8_gemm(
+        a_packed.view(torch.int8).contiguous(),
+        b.view(torch.int8).contiguous(),
+        _pack_cutlass_sf_bytes(sfa_logical),
+        _pack_cutlass_sf_bytes(sfb_logical),
+        C_ref,
+        D_cutlass,
+        m,
+        n,
+        k,
+        b_name == "e4m3",
+    )
+    return C_tl, D_cutlass
+
+
+def _compare_one(ext, b_name, m, n, k, full_domain=False):
+    a_packed = torch.randint(0, 256, (m, k // 2), device="cuda", dtype=torch.uint8)
+    if full_domain:
+        b = torch.randint(0, 256, (n, k), device="cuda", dtype=torch.uint8).view(_TORCH_FP8[b_name])
+    else:
+        b = torch.randint(-4, 5, (n, k), device="cuda", dtype=torch.float32).to(_TORCH_FP8[b_name])
+    sfa_logical = _make_varying_scales(m, k)
+    sfb_logical = _make_varying_scales(n, k)
+    kernel = tilelang.compile(_make_tilelang_w4a8_kernel(m, n, k, b_name), target="cuda", out_idx=[4])
+    C_tl, D_cutlass = _run_pair(ext, kernel, a_packed, b, sfa_logical, sfb_logical, m, n, k, b_name)
+
+    band = ("full-domain" if full_domain else "controlled") + f" B={b_name}"
+    if full_domain:
+        nan_tl = torch.isnan(C_tl)
+        assert torch.equal(nan_tl, torch.isnan(D_cutlass)), f"{band}: NaN masks differ"
+        finite = ~nan_tl
+        assert torch.equal(C_tl[finite].view(torch.int32), D_cutlass[finite].view(torch.int32)), f"{band}: not bitwise"
+        print(f"w4a8 [{band}]: NaN masks equal, finite entries bitwise equal")
+    else:
+        assert torch.equal(C_tl, D_cutlass), f"{band}: not bitwise"
+        sa = _decode_ue8m0(sfa_logical).repeat_interleave(_SF_VEC_SIZE, dim=1)
+        sb = _decode_ue8m0(sfb_logical).repeat_interleave(_SF_VEC_SIZE, dim=1)
+        ref = (_decode_packed_fp4(a_packed, m, k) * sa) @ (b.to(torch.float32) * sb).T
+        print(f"w4a8 [{band}]: TileLang vs CUTLASS bitwise (python ref max diff {(C_tl - ref).abs().max().item():.3e})")
+
+
+def _compare_quantized(ext, b_name, m, n, k):
+    from examples.dequantize_gemm.quantize import (
+        quantize_bf16_to_mxfp4_blockscaled,
+        quantize_bf16_to_mxfp8_blockscaled,
+    )
+
+    x_a = (torch.randn(m, k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+    x_b = (torch.randn(n, k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+    a_packed, _, sfa_logical = quantize_bf16_to_mxfp4_blockscaled(x_a, return_scale_bytes=True)
+    b, _, sfb_logical = quantize_bf16_to_mxfp8_blockscaled(x_b, dtype=b_name, return_scale_bytes=True)
+    kernel = tilelang.compile(_make_tilelang_w4a8_kernel(m, n, k, b_name), target="cuda", out_idx=[4])
+    C_tl, D_cutlass = _run_pair(ext, kernel, a_packed.view(torch.uint8), b, sfa_logical, sfb_logical, m, n, k, b_name)
+    assert torch.equal(C_tl.view(torch.int32), D_cutlass.view(torch.int32)), f"quantized B={b_name} not bitwise"
+    print(f"w4a8 [quantized bf16->mxfp4 x mxfp8, B={b_name}]: TileLang vs CUTLASS bitwise equal")
+
+
+def run_compare() -> None:
+    torch.manual_seed(0)
+    assert torch.cuda.is_available(), "CUDA is required"
+    ext = _build_cutlass_extension()
+
+    m = n = 256
+    k = 256
+    for b_name in ("e4m3", "e5m2"):
+        _compare_one(ext, b_name, m, n, k)
+    _compare_one(ext, "e5m2", m, n, k, full_domain=True)
+    for b_name in ("e4m3", "e5m2"):
+        _compare_quantized(ext, b_name, m, n, k)
+
+
+if __name__ == "__main__":
+    run_compare()

--- a/maint/gemm/gemm_sm120/correctness_evaluation_w6a8_vs_cutlass.py
+++ b/maint/gemm/gemm_sm120/correctness_evaluation_w6a8_vs_cutlass.py
@@ -1,0 +1,240 @@
+"""Compare TileLang's SM120 W6A8 (mxfp8 x mxfp6, kind::mxf8f6f4) vs CUTLASS.
+
+Run from the repository root:
+
+    python -m maint.gemm.gemm_sm120.correctness_evaluation_w6a8_vs_cutlass
+
+Bands (both fp8 activation flavors where applicable):
+
+- Controlled band (asserted bitwise): small-integer fp8 activations x
+  full-range packed fp6 weights (fp6 fn-types have no Inf/NaN, all values
+  dyadic) with a narrow power-of-two scale window - sums exact in fp32.
+- Full code domain: random e5m2 activation bytes (Inf/NaN included); NaN
+  masks must match and finite entries stay bitwise.
+- Quantized band: bf16 -> mxfp8 (activations) + mxfp6 (weights) quantizer
+  outputs through both engines, bitwise (the standard oracle for real data).
+
+Set CUTLASS_ROOT to the CUTLASS checkout (official requirement v4.7.0).
+"""
+
+import os
+from pathlib import Path
+
+import torch
+import tilelang
+import tilelang.language as T
+from tilelang.transform import simplify_prim_func
+
+
+_SF_VEC_SIZE = 32
+_WORD_SPAN = _SF_VEC_SIZE * 4
+_TORCH_FP8 = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}
+_TILELANG_FP8 = {"e4m3": "float8_e4m3fn", "e5m2": "float8_e5m2"}
+
+
+@simplify_prim_func
+def _make_tilelang_w6a8_kernel(m: int, n: int, k: int, a_name: str):
+    a_dtype = getattr(T, _TILELANG_FP8[a_name])
+    accum_dtype = T.float32
+
+    block_M = block_N = 128
+    block_K = k
+    threads = 128
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((m, k), a_dtype),
+        B_blob: T.Tensor((n, k * 3 // 4), T.uint8),
+        SFA: T.Tensor((m, k // _WORD_SPAN), T.uint32),
+        SFB: T.Tensor((n, k // _WORD_SPAN), T.uint32),
+        C: T.Tensor((m, n), accum_dtype),
+    ):
+        with T.Kernel(T.ceildiv(n, block_N), T.ceildiv(m, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), a_dtype, scope="shared.dyn")
+            B_shared = T.alloc_shared((block_N, block_K), T.float6_e3m2fn_unpacked, scope="shared.dyn")
+            SFA_shared = T.alloc_shared((block_M, block_K // _WORD_SPAN), T.uint32, scope="shared.dyn")
+            SFB_shared = T.alloc_shared((block_N, block_K // _WORD_SPAN), T.uint32, scope="shared.dyn")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            for ko in T.Pipelined((k // block_K), num_stages=1):
+                for i, k_inner in T.Parallel(block_M, block_K):
+                    A_shared[i, k_inner] = A[by * block_M + i, ko * block_K + k_inner]
+                # SIMT producer of the b6x16_p32 padded smem form.
+                for j, g, b in T.Parallel(block_N, block_K // 16, 12):
+                    B_shared[j, 16 * g + b] = T.reinterpret(
+                        T.float6_e3m2fn_unpacked, B_blob[bx * block_N + j, ko * (block_K * 3 // 4) + 12 * g + b]
+                    )
+                for i, k_inner in T.Parallel(block_M, block_K // _WORD_SPAN):
+                    SFA_shared[i, k_inner] = SFA[by * block_M + i, ko * (block_K // _WORD_SPAN) + k_inner]
+                for j, k_inner in T.Parallel(block_N, block_K // _WORD_SPAN):
+                    SFB_shared[j, k_inner] = SFB[bx * block_N + j, ko * (block_K // _WORD_SPAN) + k_inner]
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=True,
+                    k_start=0,
+                    sf_a_granularity_k=_SF_VEC_SIZE,
+                    sf_b_granularity_k=_SF_VEC_SIZE,
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _pack_tilelang_sf_u32(sf_bytes):
+    assert sf_bytes.dtype == torch.uint8
+    mn, sf_blocks = sf_bytes.shape
+    assert sf_blocks % 4 == 0
+    words = sf_bytes.reshape(mn, sf_blocks // 4, 4).to(torch.int64)
+    packed = words[:, :, 0] | (words[:, :, 1] << 8) | (words[:, :, 2] << 16) | (words[:, :, 3] << 24)
+    return packed.to(torch.uint32).contiguous()
+
+
+def _pack_cutlass_sf_bytes(sf_bytes):
+    """Pack logical (MN, K/32) UE8M0 bytes into CUTLASS Sm1xxBlockScaledConfig<32> order."""
+    assert sf_bytes.dtype == torch.uint8
+    mn, sf_blocks = sf_bytes.shape
+    assert mn % 128 == 0
+    assert sf_blocks % 4 == 0
+
+    rows = torch.arange(mn, device=sf_bytes.device).reshape(mn, 1)
+    cols = torch.arange(sf_blocks, device=sf_bytes.device).reshape(1, sf_blocks)
+    atom = rows // 128
+    row_in_atom = rows % 128
+    k_word_group = cols // 4
+    byte_in_word = cols % 4
+    offsets = atom * 128 * sf_blocks + k_word_group * 128 * 4 + (row_in_atom % 32) * 16 + (row_in_atom // 32) * 4 + byte_in_word
+    out = torch.empty((mn * sf_blocks,), device=sf_bytes.device, dtype=torch.uint8)
+    out[offsets.reshape(-1)] = sf_bytes.reshape(-1)
+    return out.contiguous()
+
+
+def _decode_fp6_blob(blob, cols):
+    from examples.dequantize_gemm.quantize import decode_fp6_values, unpack_fp6_bytes
+
+    return decode_fp6_values(unpack_fp6_bytes(blob.cpu(), cols), "e3m2").to(blob.device)
+
+
+def _decode_ue8m0(sf_bytes):
+    return torch.pow(2.0, (sf_bytes.to(torch.int32) - 127).to(torch.float32))
+
+
+def _build_cutlass_extension():
+    from torch.utils.cpp_extension import load
+
+    source_path = Path(__file__).resolve().with_name("cutlass_w6a8_ref.cu")
+    repo_root = source_path.parents[3]
+    cutlass_root_env = os.environ.get("CUTLASS_ROOT")
+    cutlass_root = Path(cutlass_root_env) if cutlass_root_env else repo_root / "3rdparty" / "cutlass"
+    include_paths = [
+        cutlass_root / "include",
+        cutlass_root / "tools" / "util" / "include",
+    ]
+    if not all(path.exists() for path in include_paths):
+        raise RuntimeError(
+            "CUTLASS headers were not found. Set CUTLASS_ROOT to a CUTLASS checkout "
+            "or populate the repository's 3rdparty/cutlass submodule."
+        )
+
+    return load(
+        name="tilelang_cutlass_w6a8_ref",
+        sources=[str(source_path)],
+        extra_include_paths=[str(path) for path in include_paths],
+        extra_cuda_cflags=[
+            "-std=c++20",
+            "-arch=sm_120a",
+            "--expt-relaxed-constexpr",
+            "-DCUTLASS_ARCH_MMA_SM120_SUPPORTED",
+        ],
+        extra_cflags=["-std=c++20"],
+        verbose=True,
+    )
+
+
+def _make_varying_scales(mn, k):
+    row = torch.arange(mn, device="cuda", dtype=torch.int32).reshape(mn, 1)
+    col = torch.arange(k // _SF_VEC_SIZE, device="cuda", dtype=torch.int32).reshape(1, k // _SF_VEC_SIZE)
+    return (127 + (row + col) % 3 - 1).to(torch.uint8)
+
+
+def _run_pair(ext, kernel, a, b_blob, sfa_logical, sfb_logical, m, n, k, a_name):
+    C_tl = kernel(a, b_blob, _pack_tilelang_sf_u32(sfa_logical), _pack_tilelang_sf_u32(sfb_logical))
+    C_ref = torch.zeros((m, n), device="cuda", dtype=torch.float32)
+    D_cutlass = torch.zeros((m, n), device="cuda", dtype=torch.float32)
+    ext.cutlass_w6a8_gemm(
+        a.view(torch.int8).contiguous(),
+        b_blob.view(torch.int8).contiguous(),
+        _pack_cutlass_sf_bytes(sfa_logical),
+        _pack_cutlass_sf_bytes(sfb_logical),
+        C_ref,
+        D_cutlass,
+        m,
+        n,
+        k,
+        a_name == "e4m3",
+    )
+    return C_tl, D_cutlass
+
+
+def _compare_one(ext, a_name, m, n, k, full_domain=False):
+    b_blob = torch.randint(0, 256, (n, k * 3 // 4), device="cuda", dtype=torch.uint8)
+    if full_domain:
+        a = torch.randint(0, 256, (m, k), device="cuda", dtype=torch.uint8).view(_TORCH_FP8[a_name])
+    else:
+        a = torch.randint(-4, 5, (m, k), device="cuda", dtype=torch.float32).to(_TORCH_FP8[a_name])
+    sfa_logical = _make_varying_scales(m, k)
+    sfb_logical = _make_varying_scales(n, k)
+    kernel = tilelang.compile(_make_tilelang_w6a8_kernel(m, n, k, a_name), target="cuda", out_idx=[4])
+    C_tl, D_cutlass = _run_pair(ext, kernel, a, b_blob, sfa_logical, sfb_logical, m, n, k, a_name)
+
+    band = ("full-domain" if full_domain else "controlled") + f" A={a_name}"
+    if full_domain:
+        nan_tl = torch.isnan(C_tl)
+        assert torch.equal(nan_tl, torch.isnan(D_cutlass)), f"{band}: NaN masks differ"
+        finite = ~nan_tl
+        assert torch.equal(C_tl[finite].view(torch.int32), D_cutlass[finite].view(torch.int32)), f"{band}: not bitwise"
+        print(f"w6a8 [{band}]: NaN masks equal, finite entries bitwise equal")
+    else:
+        assert torch.equal(C_tl, D_cutlass), f"{band}: not bitwise"
+        sa = _decode_ue8m0(sfa_logical).repeat_interleave(_SF_VEC_SIZE, dim=1)
+        sb = _decode_ue8m0(sfb_logical).repeat_interleave(_SF_VEC_SIZE, dim=1)
+        ref = (a.to(torch.float32) * sa) @ (_decode_fp6_blob(b_blob, k) * sb).T
+        print(f"w6a8 [{band}]: TileLang vs CUTLASS bitwise (python ref max diff {(C_tl - ref).abs().max().item():.3e})")
+
+
+def _compare_quantized(ext, a_name, m, n, k):
+    from examples.dequantize_gemm.quantize import (
+        quantize_bf16_to_mxfp6_blockscaled,
+        quantize_bf16_to_mxfp8_blockscaled,
+    )
+
+    x_a = (torch.randn(m, k, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+    x_b = torch.randn(n, k, dtype=torch.float32) * 2.0
+    a, _, sfa_logical = quantize_bf16_to_mxfp8_blockscaled(x_a, dtype=a_name, return_scale_bytes=True)
+    b_blob, _, sfb_logical = quantize_bf16_to_mxfp6_blockscaled(x_b, dtype="e3m2", return_scale_bytes=True)
+    kernel = tilelang.compile(_make_tilelang_w6a8_kernel(m, n, k, a_name), target="cuda", out_idx=[4])
+    C_tl, D_cutlass = _run_pair(ext, kernel, a, b_blob.cuda(), sfa_logical, sfb_logical.cuda(), m, n, k, a_name)
+    assert torch.equal(C_tl.view(torch.int32), D_cutlass.view(torch.int32)), f"quantized A={a_name} not bitwise"
+    print(f"w6a8 [quantized bf16->mxfp8 x mxfp6, A={a_name}]: TileLang vs CUTLASS bitwise equal")
+
+
+def run_compare() -> None:
+    torch.manual_seed(0)
+    assert torch.cuda.is_available(), "CUDA is required"
+    ext = _build_cutlass_extension()
+
+    m = n = 256
+    k = 256
+    for a_name in ("e4m3", "e5m2"):
+        _compare_one(ext, a_name, m, n, k)
+    _compare_one(ext, "e5m2", m, n, k, full_domain=True)
+    _compare_quantized(ext, "e4m3", m, n, k)
+
+
+if __name__ == "__main__":
+    run_compare()

--- a/maint/gemm/gemm_sm120/cutlass_mxf4_ref.cu
+++ b/maint/gemm/gemm_sm120/cutlass_mxf4_ref.cu
@@ -1,0 +1,161 @@
+#include <torch/extension.h>
+
+#include "cute/tensor.hpp"
+#include "cutlass/cutlass.h"
+
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/util/packed_stride.hpp"
+
+namespace {
+
+using namespace cute;
+
+using ElementA = cutlass::float_e2m1_t;
+using ElementB = cutlass::float_e2m1_t;
+using ElementC = float;
+using ElementD = float;
+using ElementAccumulator = float;
+using ElementCompute = float;
+
+using LayoutA = cutlass::layout::RowMajor;
+using LayoutB = cutlass::layout::ColumnMajor;
+using LayoutC = cutlass::layout::RowMajor;
+using LayoutD = cutlass::layout::RowMajor;
+
+// mx_float4_t selects UE8M0 scale factors with SfVectorSize=32 (MXFP4).
+using ElementPairA = cutlass::mx_float4_t<cutlass::float_e2m1_t>;
+using ElementPairB = cutlass::mx_float4_t<cutlass::float_e2m1_t>;
+
+static constexpr int AlignmentA =
+    16 * 8 / cutlass::sizeof_bits<ElementA>::value;
+static constexpr int AlignmentB =
+    16 * 8 / cutlass::sizeof_bits<ElementB>::value;
+static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+using TileShape = Shape<_128, _128, _256>;
+using ClusterShape = Shape<_1, _1, _1>;
+
+using CollectiveEpilogue =
+    typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp, TileShape,
+        ClusterShape, cutlass::epilogue::collective::EpilogueTileAuto,
+        ElementAccumulator, ElementCompute, ElementC, LayoutC, AlignmentC,
+        ElementD, LayoutD, AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+
+using CollectiveMainloop =
+    typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp,
+        ElementPairA, LayoutA, AlignmentA, ElementPairB, LayoutB, AlignmentB,
+        ElementAccumulator, TileShape, ClusterShape,
+        cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+            sizeof(typename CollectiveEpilogue::SharedStorage))>,
+        cutlass::gemm::KernelTmaWarpSpecializedPingpong>::CollectiveOp;
+
+template <typename T> struct Dummy {
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+
+using GemmKernel = typename Dummy<void>::GemmKernel;
+using Gemm = typename Dummy<void>::Gemm;
+using StrideA = typename GemmKernel::StrideA;
+using StrideB = typename GemmKernel::StrideB;
+using StrideC = typename GemmKernel::StrideC;
+using StrideD = typename GemmKernel::StrideD;
+
+void check_tensor(torch::Tensor const &tensor, char const *name,
+                  torch::DeviceType device) {
+  TORCH_CHECK(tensor.device().type() == device, name, " must be on CUDA");
+  TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+} // namespace
+
+void cutlass_mxf4_gemm_128x128x256(torch::Tensor A, torch::Tensor B,
+                                   torch::Tensor SFA, torch::Tensor SFB,
+                                   torch::Tensor C, torch::Tensor D) {
+#if !(defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) ||                             \
+      defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED))
+  TORCH_CHECK(
+      false,
+      "CUTLASS was not compiled with SM120/SM121 block-scale MMA support");
+#else
+  constexpr int M = 128;
+  constexpr int N = 128;
+  constexpr int K = 256;
+
+  check_tensor(A, "A", torch::kCUDA);
+  check_tensor(B, "B", torch::kCUDA);
+  check_tensor(SFA, "SFA", torch::kCUDA);
+  check_tensor(SFB, "SFB", torch::kCUDA);
+  check_tensor(C, "C", torch::kCUDA);
+  check_tensor(D, "D", torch::kCUDA);
+
+  TORCH_CHECK(A.numel() == M * K / 2,
+              "A must contain packed MXFP4 bytes for 128x256");
+  TORCH_CHECK(B.numel() == N * K / 2,
+              "B must contain packed MXFP4 bytes for 128x256");
+  TORCH_CHECK(SFA.numel() == M * (K / 32),
+              "SFA must be CUTLASS-layout UE8M0 bytes");
+  TORCH_CHECK(SFB.numel() == N * (K / 32),
+              "SFB must be CUTLASS-layout UE8M0 bytes");
+  TORCH_CHECK(C.numel() == M * N, "C must be 128x128 f32");
+  TORCH_CHECK(D.numel() == M * N, "D must be 128x128 f32");
+
+  auto problem = cute::make_shape(M, N, K, 1);
+  auto stride_A = cutlass::make_cute_packed_stride(StrideA{}, {M, K, 1});
+  auto stride_B = cutlass::make_cute_packed_stride(StrideB{}, {N, K, 1});
+  auto stride_C = cutlass::make_cute_packed_stride(StrideC{}, {M, N, 1});
+  auto stride_D = cutlass::make_cute_packed_stride(StrideD{}, {M, N, 1});
+
+  using Sm1xxBlkScaledConfig =
+      typename GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+  auto layout_SFA = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(problem);
+  auto layout_SFB = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(problem);
+
+  typename Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      problem,
+      {reinterpret_cast<ElementA *>(A.data_ptr()), stride_A,
+       reinterpret_cast<ElementB *>(B.data_ptr()), stride_B,
+       reinterpret_cast<ElementPairA::ScaleFactorType *>(SFA.data_ptr()),
+       layout_SFA,
+       reinterpret_cast<ElementPairB::ScaleFactorType *>(SFB.data_ptr()),
+       layout_SFB},
+      {{1.0f, 0.0f},
+       reinterpret_cast<ElementC *>(C.data_ptr()),
+       stride_C,
+       reinterpret_cast<ElementD *>(D.data_ptr()),
+       stride_D}};
+
+  Gemm gemm;
+  auto status = gemm.can_implement(arguments);
+  TORCH_CHECK(status == cutlass::Status::kSuccess,
+              "CUTLASS can_implement failed: ", cutlassGetStatusString(status));
+
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+  auto workspace = torch::empty(
+      {static_cast<int64_t>(workspace_size)},
+      torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
+
+  status = gemm.initialize(arguments, workspace.data_ptr());
+  TORCH_CHECK(status == cutlass::Status::kSuccess,
+              "CUTLASS initialize failed: ", cutlassGetStatusString(status));
+
+  status = gemm.run();
+  TORCH_CHECK(status == cutlass::Status::kSuccess,
+              "CUTLASS run failed: ", cutlassGetStatusString(status));
+  TORCH_CHECK(cudaDeviceSynchronize() == cudaSuccess, "CUTLASS kernel failed");
+#endif
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("cutlass_mxf4_gemm_128x128x256", &cutlass_mxf4_gemm_128x128x256,
+        "CUTLASS SM120 MXFP4 block-scaled GEMM 128x128x256");
+}

--- a/maint/gemm/gemm_sm120/cutlass_mxf8_ref.cu
+++ b/maint/gemm/gemm_sm120/cutlass_mxf8_ref.cu
@@ -1,0 +1,180 @@
+// CUTLASS SM120 MXFP8 (kind::mxf8f6f4) block-scaled GEMM reference used by
+// correctness_evaluation_mxf8_vs_cutlass.py. All four {e4m3, e5m2} A/B
+// pairings are instantiated; the tile is 128x128x128 with UE8M0 scales at
+// 32-element granularity (Sm1xxBlockScaledConfig<32>).
+#include <torch/extension.h>
+
+#include "cute/tensor.hpp"
+#include "cutlass/cutlass.h"
+
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/util/packed_stride.hpp"
+
+namespace {
+
+using namespace cute;
+
+using ElementC = float;
+using ElementD = float;
+using ElementAccumulator = float;
+using ElementCompute = float;
+
+using LayoutA = cutlass::layout::RowMajor;
+using LayoutB = cutlass::layout::ColumnMajor;
+using LayoutC = cutlass::layout::RowMajor;
+using LayoutD = cutlass::layout::RowMajor;
+
+static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+using TileShape = Shape<_128, _128, _128>;
+using ClusterShape = Shape<_1, _1, _1>;
+
+template <typename ElemA, typename ElemB> struct MxF8Gemm {
+  using ElementPairA = cutlass::mx_float8_t<ElemA>;
+  using ElementPairB = cutlass::mx_float8_t<ElemB>;
+  static constexpr int AlignmentA = 16;
+  static constexpr int AlignmentB = 16;
+
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp, TileShape,
+          ClusterShape, cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator, ElementCompute, ElementC, LayoutC, AlignmentC,
+          ElementD, LayoutD, AlignmentD,
+          cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp,
+          ElementPairA, LayoutA, AlignmentA, ElementPairB, LayoutB, AlignmentB,
+          ElementAccumulator, TileShape, ClusterShape,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+
+void check_tensor(torch::Tensor const &tensor, char const *name) {
+  TORCH_CHECK(tensor.device().type() == torch::kCUDA, name, " must be on CUDA");
+  TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+template <typename ElemA, typename ElemB>
+void run_mxf8_gemm(torch::Tensor A, torch::Tensor B, torch::Tensor SFA,
+                   torch::Tensor SFB, torch::Tensor C, torch::Tensor D,
+                   int64_t m, int64_t n, int64_t k) {
+  using Config = MxF8Gemm<ElemA, ElemB>;
+  using Gemm = typename Config::Gemm;
+  using GemmKernel = typename Config::GemmKernel;
+
+  const int M = static_cast<int>(m);
+  const int N = static_cast<int>(n);
+  const int K = static_cast<int>(k);
+  const int64_t m_pad = (m + 127) / 128 * 128;
+  const int64_t n_pad = (n + 127) / 128 * 128;
+
+  TORCH_CHECK(K % 128 == 0, "K must be a multiple of the CUTLASS tile K=128");
+
+  check_tensor(A, "A");
+  check_tensor(B, "B");
+  check_tensor(SFA, "SFA");
+  check_tensor(SFB, "SFB");
+  check_tensor(C, "C");
+  check_tensor(D, "D");
+
+  TORCH_CHECK(A.numel() == m * k, "A must contain FP8 bytes");
+  TORCH_CHECK(B.numel() == n * k, "B must contain FP8 bytes");
+  TORCH_CHECK(SFA.numel() == m_pad * (k / 32),
+              "SFA must be CUTLASS-layout UE8M0 bytes (128-row padded)");
+  TORCH_CHECK(SFB.numel() == n_pad * (k / 32),
+              "SFB must be CUTLASS-layout UE8M0 bytes (128-row padded)");
+  TORCH_CHECK(C.numel() == m * n, "C must be MxN f32");
+  TORCH_CHECK(D.numel() == m * n, "D must be MxN f32");
+
+  auto problem = cute::make_shape(M, N, K, 1);
+  auto stride_A = cutlass::make_cute_packed_stride(
+      typename GemmKernel::StrideA{}, {M, K, 1});
+  auto stride_B = cutlass::make_cute_packed_stride(
+      typename GemmKernel::StrideB{}, {N, K, 1});
+  auto stride_C = cutlass::make_cute_packed_stride(
+      typename GemmKernel::StrideC{}, {M, N, 1});
+  auto stride_D = cutlass::make_cute_packed_stride(
+      typename GemmKernel::StrideD{}, {M, N, 1});
+
+  using Sm1xxBlkScaledConfig =
+      typename GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+  auto layout_SFA = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(problem);
+  auto layout_SFB = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(problem);
+
+  typename Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      problem,
+      {reinterpret_cast<ElemA *>(A.data_ptr()), stride_A,
+       reinterpret_cast<ElemB *>(B.data_ptr()), stride_B,
+       reinterpret_cast<cutlass::float_ue8m0_t *>(SFA.data_ptr()), layout_SFA,
+       reinterpret_cast<cutlass::float_ue8m0_t *>(SFB.data_ptr()), layout_SFB},
+      {{1.0f, 0.0f},
+       reinterpret_cast<ElementC *>(C.data_ptr()),
+       stride_C,
+       reinterpret_cast<ElementD *>(D.data_ptr()),
+       stride_D}};
+
+  Gemm gemm;
+  auto status = gemm.can_implement(arguments);
+  TORCH_CHECK(status == cutlass::Status::kSuccess,
+              "CUTLASS can_implement failed: ", cutlassGetStatusString(status));
+
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+  auto workspace = torch::empty(
+      {static_cast<int64_t>(workspace_size)},
+      torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
+
+  status = gemm.initialize(arguments, workspace.data_ptr());
+  TORCH_CHECK(status == cutlass::Status::kSuccess,
+              "CUTLASS initialize failed: ", cutlassGetStatusString(status));
+
+  status = gemm.run();
+  TORCH_CHECK(status == cutlass::Status::kSuccess,
+              "CUTLASS run failed: ", cutlassGetStatusString(status));
+  TORCH_CHECK(cudaDeviceSynchronize() == cudaSuccess, "CUTLASS kernel failed");
+}
+
+} // namespace
+
+void cutlass_mxf8_gemm(torch::Tensor A, torch::Tensor B, torch::Tensor SFA,
+                       torch::Tensor SFB, torch::Tensor C, torch::Tensor D,
+                       int64_t m, int64_t n, int64_t k, bool a_is_e4m3,
+                       bool b_is_e4m3) {
+#if !(defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) ||                             \
+      defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED))
+  TORCH_CHECK(
+      false,
+      "CUTLASS was not compiled with SM120/SM121 block-scale MMA support");
+#else
+  if (a_is_e4m3 && b_is_e4m3) {
+    run_mxf8_gemm<cutlass::float_e4m3_t, cutlass::float_e4m3_t>(A, B, SFA, SFB,
+                                                                C, D, m, n, k);
+  } else if (a_is_e4m3 && !b_is_e4m3) {
+    run_mxf8_gemm<cutlass::float_e4m3_t, cutlass::float_e5m2_t>(A, B, SFA, SFB,
+                                                                C, D, m, n, k);
+  } else if (!a_is_e4m3 && b_is_e4m3) {
+    run_mxf8_gemm<cutlass::float_e5m2_t, cutlass::float_e4m3_t>(A, B, SFA, SFB,
+                                                                C, D, m, n, k);
+  } else {
+    run_mxf8_gemm<cutlass::float_e5m2_t, cutlass::float_e5m2_t>(A, B, SFA, SFB,
+                                                                C, D, m, n, k);
+  }
+#endif
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("cutlass_mxf8_gemm", &cutlass_mxf8_gemm,
+        "CUTLASS SM120 MXFP8 block-scaled GEMM (all {e4m3,e5m2} pairings)");
+}

--- a/maint/gemm/gemm_sm120/cutlass_w4a8_ref.cu
+++ b/maint/gemm/gemm_sm120/cutlass_w4a8_ref.cu
@@ -1,0 +1,172 @@
+// CUTLASS SM120 W4A8 (kind::mxf8f6f4, mixed mxfp4 x mxfp8) reference used
+// by correctness_evaluation_w4a8_vs_cutlass.py. A is mx_float4_t packed
+// e2m1 weights, B is mx_float8_t (e4m3 or e5m2) activations; the tile is
+// 128x128x128 with UE8M0 scales at 32-element granularity.
+#include <torch/extension.h>
+
+#include "cute/tensor.hpp"
+#include "cutlass/cutlass.h"
+
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/util/packed_stride.hpp"
+
+namespace {
+
+using namespace cute;
+
+using ElementC = float;
+using ElementD = float;
+using ElementAccumulator = float;
+using ElementCompute = float;
+
+using LayoutA = cutlass::layout::RowMajor;
+using LayoutB = cutlass::layout::ColumnMajor;
+using LayoutC = cutlass::layout::RowMajor;
+using LayoutD = cutlass::layout::RowMajor;
+
+static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+using TileShape = Shape<_128, _128, _128>;
+using ClusterShape = Shape<_1, _1, _1>;
+
+template <typename ElemB> struct MxW4A8Gemm {
+  using ElemA = cutlass::float_e2m1_t;
+  using ElementPairA = cutlass::mx_float4_t<cutlass::float_e2m1_t>;
+  using ElementPairB = cutlass::mx_float8_t<ElemB>;
+  static constexpr int AlignmentA = 32; // 16 bytes of packed fp4
+  static constexpr int AlignmentB = 16;
+
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp, TileShape,
+          ClusterShape, cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator, ElementCompute, ElementC, LayoutC, AlignmentC,
+          ElementD, LayoutD, AlignmentD,
+          cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp,
+          ElementPairA, LayoutA, AlignmentA, ElementPairB, LayoutB, AlignmentB,
+          ElementAccumulator, TileShape, ClusterShape,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+
+void check_tensor(torch::Tensor const &tensor, char const *name) {
+  TORCH_CHECK(tensor.device().type() == torch::kCUDA, name, " must be on CUDA");
+  TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+template <typename ElemB>
+void run_w4a8_gemm(torch::Tensor A, torch::Tensor B, torch::Tensor SFA,
+                   torch::Tensor SFB, torch::Tensor C, torch::Tensor D,
+                   int64_t m, int64_t n, int64_t k) {
+  using Config = MxW4A8Gemm<ElemB>;
+  using Gemm = typename Config::Gemm;
+  using GemmKernel = typename Config::GemmKernel;
+
+  const int M = static_cast<int>(m);
+  const int N = static_cast<int>(n);
+  const int K = static_cast<int>(k);
+  const int64_t m_pad = (m + 127) / 128 * 128;
+  const int64_t n_pad = (n + 127) / 128 * 128;
+
+  TORCH_CHECK(K % 128 == 0, "K must be a multiple of the CUTLASS tile K=128");
+
+  check_tensor(A, "A");
+  check_tensor(B, "B");
+  check_tensor(SFA, "SFA");
+  check_tensor(SFB, "SFB");
+  check_tensor(C, "C");
+  check_tensor(D, "D");
+
+  TORCH_CHECK(A.numel() == m * k / 2, "A must contain packed FP4 bytes");
+  TORCH_CHECK(B.numel() == n * k, "B must contain FP8 bytes");
+  TORCH_CHECK(SFA.numel() == m_pad * (k / 32),
+              "SFA must be CUTLASS-layout UE8M0 bytes (128-row padded)");
+  TORCH_CHECK(SFB.numel() == n_pad * (k / 32),
+              "SFB must be CUTLASS-layout UE8M0 bytes (128-row padded)");
+  TORCH_CHECK(C.numel() == m * n, "C must be MxN f32");
+  TORCH_CHECK(D.numel() == m * n, "D must be MxN f32");
+
+  auto problem = cute::make_shape(M, N, K, 1);
+  auto stride_A = cutlass::make_cute_packed_stride(
+      typename GemmKernel::StrideA{}, {M, K, 1});
+  auto stride_B = cutlass::make_cute_packed_stride(
+      typename GemmKernel::StrideB{}, {N, K, 1});
+  auto stride_C = cutlass::make_cute_packed_stride(
+      typename GemmKernel::StrideC{}, {M, N, 1});
+  auto stride_D = cutlass::make_cute_packed_stride(
+      typename GemmKernel::StrideD{}, {M, N, 1});
+
+  using Sm1xxBlkScaledConfig =
+      typename GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+  auto layout_SFA = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(problem);
+  auto layout_SFB = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(problem);
+
+  typename Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      problem,
+      {reinterpret_cast<cutlass::float_e2m1_t *>(A.data_ptr()), stride_A,
+       reinterpret_cast<ElemB *>(B.data_ptr()), stride_B,
+       reinterpret_cast<cutlass::float_ue8m0_t *>(SFA.data_ptr()), layout_SFA,
+       reinterpret_cast<cutlass::float_ue8m0_t *>(SFB.data_ptr()), layout_SFB},
+      {{1.0f, 0.0f},
+       reinterpret_cast<ElementC *>(C.data_ptr()),
+       stride_C,
+       reinterpret_cast<ElementD *>(D.data_ptr()),
+       stride_D}};
+
+  Gemm gemm;
+  auto status = gemm.can_implement(arguments);
+  TORCH_CHECK(status == cutlass::Status::kSuccess,
+              "CUTLASS can_implement failed: ", cutlassGetStatusString(status));
+
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+  auto workspace = torch::empty(
+      {static_cast<int64_t>(workspace_size)},
+      torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
+
+  status = gemm.initialize(arguments, workspace.data_ptr());
+  TORCH_CHECK(status == cutlass::Status::kSuccess,
+              "CUTLASS initialize failed: ", cutlassGetStatusString(status));
+
+  status = gemm.run();
+  TORCH_CHECK(status == cutlass::Status::kSuccess,
+              "CUTLASS run failed: ", cutlassGetStatusString(status));
+  TORCH_CHECK(cudaDeviceSynchronize() == cudaSuccess, "CUTLASS kernel failed");
+}
+
+} // namespace
+
+void cutlass_w4a8_gemm(torch::Tensor A, torch::Tensor B, torch::Tensor SFA,
+                       torch::Tensor SFB, torch::Tensor C, torch::Tensor D,
+                       int64_t m, int64_t n, int64_t k, bool b_is_e4m3) {
+#if !(defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) ||                             \
+      defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED))
+  TORCH_CHECK(
+      false,
+      "CUTLASS was not compiled with SM120/SM121 block-scale MMA support");
+#else
+  if (b_is_e4m3) {
+    run_w4a8_gemm<cutlass::float_e4m3_t>(A, B, SFA, SFB, C, D, m, n, k);
+  } else {
+    run_w4a8_gemm<cutlass::float_e5m2_t>(A, B, SFA, SFB, C, D, m, n, k);
+  }
+#endif
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("cutlass_w4a8_gemm", &cutlass_w4a8_gemm,
+        "CUTLASS SM120 W4A8 mixed mxfp4 x mxfp8 block-scaled GEMM");
+}

--- a/maint/gemm/gemm_sm120/cutlass_w6a8_ref.cu
+++ b/maint/gemm/gemm_sm120/cutlass_w6a8_ref.cu
@@ -1,0 +1,174 @@
+// CUTLASS SM120 W6A8 (kind::mxf8f6f4, mixed mxfp8 x mxfp6) reference used
+// by correctness_evaluation_w6a8_vs_cutlass.py, mirroring CUTLASS example
+// 79c. A is mx_float8_t (e4m3 or e5m2) activations, B is mx_float6_t
+// float_e3m2_t packed weights; tile 128x128x128, UE8M0 scales at
+// 32-element granularity.
+#include <torch/extension.h>
+
+#include "cute/tensor.hpp"
+#include "cutlass/cutlass.h"
+
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/util/packed_stride.hpp"
+
+namespace {
+
+using namespace cute;
+
+using ElementC = float;
+using ElementD = float;
+using ElementAccumulator = float;
+using ElementCompute = float;
+
+using LayoutA = cutlass::layout::RowMajor;
+using LayoutB = cutlass::layout::ColumnMajor;
+using LayoutC = cutlass::layout::RowMajor;
+using LayoutD = cutlass::layout::RowMajor;
+
+static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+using TileShape = Shape<_128, _128, _128>;
+using ClusterShape = Shape<_1, _1, _1>;
+
+template <typename ElemA> struct MxW6A8Gemm {
+  using ElementPairA = cutlass::mx_float8_t<ElemA>;
+  using ElementPairB = cutlass::mx_float6_t<cutlass::float_e3m2_t>;
+  static constexpr int AlignmentA = 16;
+  static constexpr int AlignmentB = 128; // packed fp6 (cf. CUTLASS 79c)
+
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp, TileShape,
+          ClusterShape, cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator, ElementCompute, ElementC, LayoutC, AlignmentC,
+          ElementD, LayoutD, AlignmentD,
+          cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp,
+          ElementPairA, LayoutA, AlignmentA, ElementPairB, LayoutB, AlignmentB,
+          ElementAccumulator, TileShape, ClusterShape,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+
+void check_tensor(torch::Tensor const &tensor, char const *name) {
+  TORCH_CHECK(tensor.device().type() == torch::kCUDA, name, " must be on CUDA");
+  TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+template <typename ElemA>
+void run_w6a8_gemm(torch::Tensor A, torch::Tensor B, torch::Tensor SFA,
+                   torch::Tensor SFB, torch::Tensor C, torch::Tensor D,
+                   int64_t m, int64_t n, int64_t k) {
+  using Config = MxW6A8Gemm<ElemA>;
+  using Gemm = typename Config::Gemm;
+  using GemmKernel = typename Config::GemmKernel;
+
+  const int M = static_cast<int>(m);
+  const int N = static_cast<int>(n);
+  const int K = static_cast<int>(k);
+  const int64_t m_pad = (m + 127) / 128 * 128;
+  const int64_t n_pad = (n + 127) / 128 * 128;
+
+  TORCH_CHECK(K % 128 == 0, "K must be a multiple of the CUTLASS tile K=128");
+
+  check_tensor(A, "A");
+  check_tensor(B, "B");
+  check_tensor(SFA, "SFA");
+  check_tensor(SFB, "SFB");
+  check_tensor(C, "C");
+  check_tensor(D, "D");
+
+  TORCH_CHECK(A.numel() == m * k, "A must contain FP8 bytes");
+  TORCH_CHECK(B.numel() == n * k * 3 / 4, "B must contain packed FP6 bytes");
+  TORCH_CHECK(SFA.numel() == m_pad * (k / 32),
+              "SFA must be CUTLASS-layout UE8M0 bytes (128-row padded)");
+  TORCH_CHECK(SFB.numel() == n_pad * (k / 32),
+              "SFB must be CUTLASS-layout UE8M0 bytes (128-row padded)");
+  TORCH_CHECK(C.numel() == m * n, "C must be MxN f32");
+  TORCH_CHECK(D.numel() == m * n, "D must be MxN f32");
+
+  auto problem = cute::make_shape(M, N, K, 1);
+  auto stride_A = cutlass::make_cute_packed_stride(
+      typename GemmKernel::StrideA{}, {M, K, 1});
+  auto stride_B = cutlass::make_cute_packed_stride(
+      typename GemmKernel::StrideB{}, {N, K, 1});
+  auto stride_C = cutlass::make_cute_packed_stride(
+      typename GemmKernel::StrideC{}, {M, N, 1});
+  auto stride_D = cutlass::make_cute_packed_stride(
+      typename GemmKernel::StrideD{}, {M, N, 1});
+
+  using Sm1xxBlkScaledConfig =
+      typename GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+  auto layout_SFA = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(problem);
+  auto layout_SFB = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(problem);
+
+  typename Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      problem,
+      {reinterpret_cast<ElemA *>(A.data_ptr()), stride_A,
+       reinterpret_cast<cutlass::float_e3m2_t *>(B.data_ptr()), stride_B,
+       reinterpret_cast<cutlass::float_ue8m0_t *>(SFA.data_ptr()), layout_SFA,
+       reinterpret_cast<cutlass::float_ue8m0_t *>(SFB.data_ptr()), layout_SFB},
+      {{1.0f, 0.0f},
+       reinterpret_cast<ElementC *>(C.data_ptr()),
+       stride_C,
+       reinterpret_cast<ElementD *>(D.data_ptr()),
+       stride_D}};
+
+  Gemm gemm;
+  auto status = gemm.can_implement(arguments);
+  TORCH_CHECK(status == cutlass::Status::kSuccess,
+              "CUTLASS can_implement failed: ",
+              cutlass::cutlassGetStatusString(status));
+
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+  auto workspace = torch::empty(
+      {static_cast<int64_t>(workspace_size)},
+      torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
+
+  status = gemm.initialize(arguments, workspace.data_ptr());
+  TORCH_CHECK(
+      status == cutlass::Status::kSuccess,
+      "CUTLASS initialize failed: ", cutlass::cutlassGetStatusString(status));
+
+  status = gemm.run();
+  TORCH_CHECK(status == cutlass::Status::kSuccess,
+              "CUTLASS run failed: ", cutlass::cutlassGetStatusString(status));
+  TORCH_CHECK(cudaDeviceSynchronize() == cudaSuccess, "CUTLASS kernel failed");
+}
+
+} // namespace
+
+void cutlass_w6a8_gemm(torch::Tensor A, torch::Tensor B, torch::Tensor SFA,
+                       torch::Tensor SFB, torch::Tensor C, torch::Tensor D,
+                       int64_t m, int64_t n, int64_t k, bool a_is_e4m3) {
+#if !(defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) ||                             \
+      defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED))
+  TORCH_CHECK(
+      false,
+      "CUTLASS was not compiled with SM120/SM121 block-scale MMA support");
+#else
+  if (a_is_e4m3) {
+    run_w6a8_gemm<cutlass::float_e4m3_t>(A, B, SFA, SFB, C, D, m, n, k);
+  } else {
+    run_w6a8_gemm<cutlass::float_e5m2_t>(A, B, SFA, SFB, C, D, m, n, k);
+  }
+#endif
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("cutlass_w6a8_gemm", &cutlass_w6a8_gemm,
+        "CUTLASS SM120 W6A8 mixed mxfp8 x mxfp6 block-scaled GEMM");
+}

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -899,9 +899,17 @@ void CodeGenTileLangCUDA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
     }
     fail = true;
   } else if (t.is_float4_e2m1_unpacked()) {
-    LOG(FATAL) << "float4_e2m1_unpacked is a SMEM/TMA storage tag and must be "
-                  "lowered through shared-memory allocation";
-    return;
+    // 8-bit container storage: the 16U4_ALIGN16B padded-packed smem form
+    // and the SM120 mxf8f6f4 register containers are plain bytes in CUDA.
+    if (t.is_scalar()) {
+      os << "uchar";
+      return;
+    }
+    if (lanes <= 4) {
+      os << "uchar" << lanes;
+      return;
+    }
+    fail = true;
   } else if (t.is_float4_e2m1fn()) {
     enable_fp4_ = true;
     if (t.lanes() <= 64) {
@@ -3280,12 +3288,13 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
                    (scale_vec_size == 2 && scale_type == "ue8m0") ||
                    (scale_vec_size == 4 && scale_type == "ue8m0"));
     } else if (kind == "mxf8f6f4") {
-      auto is_fp8 = [](const std::string &dtype) {
-        return dtype == "e4m3" || dtype == "e5m2";
+      auto in_family = [](const std::string &dtype) {
+        return dtype == "e2m1" || dtype == "e2m3" || dtype == "e3m2" ||
+               dtype == "e4m3" || dtype == "e5m2";
       };
-      supported = supported_common && shape == "m16n8k32" && is_fp8(A_dtype) &&
-                  is_fp8(B_dtype) && scale_vec_size == 1 &&
-                  scale_type == "ue8m0";
+      supported = supported_common && shape == "m16n8k32" &&
+                  in_family(A_dtype) && in_family(B_dtype) &&
+                  scale_vec_size == 1 && scale_type == "ue8m0";
     }
     ICHECK(supported)
         << "Unsupported ptx_mma_block_scale configuration: accum_dtype="
@@ -3326,8 +3335,15 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string operand_args;
     if (kind == "mxf8f6f4") {
       auto operand_enum = [](const std::string &dtype) {
-        return dtype == "e4m3" ? "tl::SM120MmaOperandType::kE4M3"
-                               : "tl::SM120MmaOperandType::kE5M2";
+        if (dtype == "e2m1")
+          return "tl::SM120MmaOperandType::kE2M1";
+        if (dtype == "e2m3")
+          return "tl::SM120MmaOperandType::kE2M3";
+        if (dtype == "e3m2")
+          return "tl::SM120MmaOperandType::kE3M2";
+        if (dtype == "e4m3")
+          return "tl::SM120MmaOperandType::kE4M3";
+        return "tl::SM120MmaOperandType::kE5M2";
       };
       operand_args = std::string(", ") + operand_enum(A_dtype) + ", " +
                      operand_enum(B_dtype);

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -2811,13 +2811,26 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     }
     print_extern_call_stmt(ss.str(), 0, 1);
   } else if (op->op.same_as(tl::ptx_ldmatrix())) {
-    ICHECK_EQ(op->args.size(), 4U);
+    // 4 args: classic m8n8.b16 form. Optional 5th StringImm arg selects a
+    // sub-byte source variant ("su4"/"su6" -> m8n16.b8x16.b4x16_p64 /
+    // b6x16_p32), which unpacks 4-/6-bit elements into 8-bit register
+    // containers and has no trans flavor.
+    ICHECK(op->args.size() == 4U || op->args.size() == 5U);
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
-    std::string func_name = "tl::ptx_ldmatrix_x" + std::to_string(num);
-    if (trans == 1)
-      func_name += "_trans";
-    print_extern_call_stmt(func_name, 2);
+    std::string func_name;
+    if (op->args.size() == 5U) {
+      std::string variant = Downcast<StringImm>(op->args[4])->value;
+      ICHECK(variant == "su4" || variant == "su6")
+          << "Unsupported ptx_ldmatrix variant: " << variant;
+      ICHECK_EQ(trans, 0) << "sub-byte ldmatrix variants have no trans form";
+      func_name = "tl::ptx_ldmatrix_" + variant + "_x" + std::to_string(num);
+    } else {
+      func_name = "tl::ptx_ldmatrix_x" + std::to_string(num);
+      if (trans == 1)
+        func_name += "_trans";
+    }
+    print_extern_call_stmt(func_name, 2, op->args.size() == 5U ? 1 : 0);
   } else if (op->op.same_as(tl::ptx_stmatrix())) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -3257,13 +3257,14 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string scale_b_byte_id = this->PrintExpr(op->args[19]);
     std::string scale_b_thread_id = this->PrintExpr(op->args[20]);
 
-    bool supported_mxf4nvf4_common =
-        accum_dtype == "float32" && shape == "m16n8k64" && A_layout == "row" &&
-        B_layout == "col" && kind == "mxf4nvf4" && A_dtype == "e2m1" &&
-        B_dtype == "e2m1";
-    bool supported_scale_mode = (scale_vec_size == 4 && scale_type == "ue4m3") ||
-                                (scale_vec_size == 2 && scale_type == "ue8m0") ||
-                                (scale_vec_size == 4 && scale_type == "ue8m0");
+    bool supported_mxf4nvf4_common = accum_dtype == "float32" &&
+                                     shape == "m16n8k64" && A_layout == "row" &&
+                                     B_layout == "col" && kind == "mxf4nvf4" &&
+                                     A_dtype == "e2m1" && B_dtype == "e2m1";
+    bool supported_scale_mode =
+        (scale_vec_size == 4 && scale_type == "ue4m3") ||
+        (scale_vec_size == 2 && scale_type == "ue8m0") ||
+        (scale_vec_size == 4 && scale_type == "ue8m0");
     ICHECK(supported_mxf4nvf4_common && supported_scale_mode)
         << "Unsupported ptx_mma_block_scale configuration: accum_dtype="
         << accum_dtype << ", shape=" << shape << ", A_layout=" << A_layout

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -3318,8 +3318,8 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
         << ". Currently supported: f32 m16n8k64 row.col kind::mxf4nvf4 "
            "e2m1.e2m1 f32 with (scale_vec::4X, ue4m3), (scale_vec::2X, "
            "ue8m0), or (scale_vec::4X, ue8m0); f32 m16n8k32 row.col "
-           "kind::mxf8f6f4 {e4m3,e5m2}x{e4m3,e5m2} f32 with (scale_vec::1X, "
-           "ue8m0).";
+           "kind::mxf8f6f4 with any pairing of {e2m1, e2m3, e3m2, e4m3, "
+           "e5m2} and (scale_vec::1X, ue8m0).";
 
     auto resolve_fp4_packed_buffer =
         [&](const PrimExpr &var_expr, std::string &ref, std::string &offset) {

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -3257,18 +3257,22 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string scale_b_byte_id = this->PrintExpr(op->args[19]);
     std::string scale_b_thread_id = this->PrintExpr(op->args[20]);
 
-    bool supported_mxf4nvf4_4x_ue4m3 =
+    bool supported_mxf4nvf4_common =
         accum_dtype == "float32" && shape == "m16n8k64" && A_layout == "row" &&
-        B_layout == "col" && kind == "mxf4nvf4" && scale_vec_size == 4 &&
-        A_dtype == "e2m1" && B_dtype == "e2m1" && scale_type == "ue4m3";
-    ICHECK(supported_mxf4nvf4_4x_ue4m3)
+        B_layout == "col" && kind == "mxf4nvf4" && A_dtype == "e2m1" &&
+        B_dtype == "e2m1";
+    bool supported_scale_mode = (scale_vec_size == 4 && scale_type == "ue4m3") ||
+                                (scale_vec_size == 2 && scale_type == "ue8m0") ||
+                                (scale_vec_size == 4 && scale_type == "ue8m0");
+    ICHECK(supported_mxf4nvf4_common && supported_scale_mode)
         << "Unsupported ptx_mma_block_scale configuration: accum_dtype="
         << accum_dtype << ", shape=" << shape << ", A_layout=" << A_layout
         << ", B_layout=" << B_layout << ", kind=" << kind
         << ", scale_vec_size=" << scale_vec_size << ", A_dtype=" << A_dtype
         << ", B_dtype=" << B_dtype << ", scale_type=" << scale_type
         << ". Currently supported: f32 m16n8k64 row.col kind::mxf4nvf4 "
-           "scale_vec::4X e2m1.e2m1 f32 ue4m3.";
+           "e2m1.e2m1 f32 with (scale_vec::4X, ue4m3), (scale_vec::2X, "
+           "ue8m0), or (scale_vec::4X, ue8m0).";
 
     auto resolve_fp4_packed_buffer =
         [&](const PrimExpr &var_expr, std::string &ref, std::string &offset) {
@@ -3286,7 +3290,9 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     this->PrintIndent();
 
     std::string mma_kind_enum = "tl::SM120MmaBlockScaledKind::kMxf4nvf4";
-    std::string scale_type_enum = "tl::SM120MmaScaleType::kUE4M3";
+    std::string scale_type_enum = scale_type == "ue8m0"
+                                      ? "tl::SM120MmaScaleType::kUE8M0"
+                                      : "tl::SM120MmaScaleType::kUE4M3";
     std::string mma_call =
         "tl::sm120_mma_sync_blockscaled<(MMA_KIND), (SCALE_VEC_SIZE), "
         "(SCALE_TYPE)>("

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -891,6 +891,18 @@ void CodeGenTileLangCUDA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
     enable_fp8_ = true;
     os << GetTileLangFP8Type(t);
     return;
+  } else if (t.is_float6_unpacked()) {
+    // 8-bit container storage (16U6_ALIGN16B smem form / mxf8f6f4 register
+    // containers): plain bytes in CUDA, mirroring the unpacked-fp4 case.
+    if (t.is_scalar()) {
+      os << "uchar";
+      return;
+    }
+    if (lanes <= 4) {
+      os << "uchar" << lanes;
+      return;
+    }
+    fail = true;
   } else if (t.is_float6()) {
     enable_fp6_ = true;
     if (t.lanes() <= 4) {
@@ -2349,7 +2361,8 @@ std::string CodeGenTileLangCUDA::GetBufferRef(DataType t,
     if (!scope.empty() && IsScopePartOfType()) {
       PrintStorageScope(scope, ptr_os);
     }
-    if (pointed_to.is_float4_e2m1_unpacked() &&
+    if ((pointed_to.is_float4_e2m1_unpacked() ||
+         pointed_to.is_float6_unpacked()) &&
         (scope == "shared" || scope == "shared.dyn")) {
       ptr_os << "uint8_t";
     } else {
@@ -5160,7 +5173,8 @@ void CodeGenTileLangCUDA::VisitStmt_(const AllocBufferNode *op) {
   std::string scope = GetPtrStorageScope(op->buffer->data);
   const VarNode *buffer = op->buffer->data.as<VarNode>();
   DataType alloc_dtype = op->buffer->dtype;
-  bool is_float4_unpacked_shared = alloc_dtype.is_float4_e2m1_unpacked() &&
+  bool is_float4_unpacked_shared = (alloc_dtype.is_float4_e2m1_unpacked() ||
+                                    alloc_dtype.is_float6_unpacked()) &&
                                    (scope == "shared" || scope == "shared.dyn");
   if (scope.find("wmma.") == 0) {
     if (scope == "wmma.matrix_a" || scope == "wmma.matrix_b") {

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -3257,15 +3257,24 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string scale_b_byte_id = this->PrintExpr(op->args[19]);
     std::string scale_b_thread_id = this->PrintExpr(op->args[20]);
 
-    bool supported_mxf4nvf4_common = accum_dtype == "float32" &&
-                                     shape == "m16n8k64" && A_layout == "row" &&
-                                     B_layout == "col" && kind == "mxf4nvf4" &&
-                                     A_dtype == "e2m1" && B_dtype == "e2m1";
-    bool supported_scale_mode =
-        (scale_vec_size == 4 && scale_type == "ue4m3") ||
-        (scale_vec_size == 2 && scale_type == "ue8m0") ||
-        (scale_vec_size == 4 && scale_type == "ue8m0");
-    ICHECK(supported_mxf4nvf4_common && supported_scale_mode)
+    bool supported_common =
+        accum_dtype == "float32" && A_layout == "row" && B_layout == "col";
+    bool supported = false;
+    if (kind == "mxf4nvf4") {
+      supported = supported_common && shape == "m16n8k64" &&
+                  A_dtype == "e2m1" && B_dtype == "e2m1" &&
+                  ((scale_vec_size == 4 && scale_type == "ue4m3") ||
+                   (scale_vec_size == 2 && scale_type == "ue8m0") ||
+                   (scale_vec_size == 4 && scale_type == "ue8m0"));
+    } else if (kind == "mxf8f6f4") {
+      auto is_fp8 = [](const std::string &dtype) {
+        return dtype == "e4m3" || dtype == "e5m2";
+      };
+      supported = supported_common && shape == "m16n8k32" && is_fp8(A_dtype) &&
+                  is_fp8(B_dtype) && scale_vec_size == 1 &&
+                  scale_type == "ue8m0";
+    }
+    ICHECK(supported)
         << "Unsupported ptx_mma_block_scale configuration: accum_dtype="
         << accum_dtype << ", shape=" << shape << ", A_layout=" << A_layout
         << ", B_layout=" << B_layout << ", kind=" << kind
@@ -3273,7 +3282,9 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
         << ", B_dtype=" << B_dtype << ", scale_type=" << scale_type
         << ". Currently supported: f32 m16n8k64 row.col kind::mxf4nvf4 "
            "e2m1.e2m1 f32 with (scale_vec::4X, ue4m3), (scale_vec::2X, "
-           "ue8m0), or (scale_vec::4X, ue8m0).";
+           "ue8m0), or (scale_vec::4X, ue8m0); f32 m16n8k32 row.col "
+           "kind::mxf8f6f4 {e4m3,e5m2}x{e4m3,e5m2} f32 with (scale_vec::1X, "
+           "ue8m0).";
 
     auto resolve_fp4_packed_buffer =
         [&](const PrimExpr &var_expr, std::string &ref, std::string &offset) {
@@ -3290,13 +3301,27 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
 
     this->PrintIndent();
 
-    std::string mma_kind_enum = "tl::SM120MmaBlockScaledKind::kMxf4nvf4";
+    std::string mma_kind_enum = kind == "mxf8f6f4"
+                                    ? "tl::SM120MmaBlockScaledKind::kMxf8f6f4"
+                                    : "tl::SM120MmaBlockScaledKind::kMxf4nvf4";
     std::string scale_type_enum = scale_type == "ue8m0"
                                       ? "tl::SM120MmaScaleType::kUE8M0"
                                       : "tl::SM120MmaScaleType::kUE4M3";
+    // The operand-type tail arguments are emitted only for kinds that need
+    // them, keeping mxf4nvf4 kernel source identical to the three-argument
+    // form.
+    std::string operand_args;
+    if (kind == "mxf8f6f4") {
+      auto operand_enum = [](const std::string &dtype) {
+        return dtype == "e4m3" ? "tl::SM120MmaOperandType::kE4M3"
+                               : "tl::SM120MmaOperandType::kE5M2";
+      };
+      operand_args = std::string(", ") + operand_enum(A_dtype) + ", " +
+                     operand_enum(B_dtype);
+    }
     std::string mma_call =
         "tl::sm120_mma_sync_blockscaled<(MMA_KIND), (SCALE_VEC_SIZE), "
-        "(SCALE_TYPE)>("
+        "(SCALE_TYPE)(OPERAND_TYPES)>("
         "reinterpret_cast<float*>((C_ptr) + (C_offset)), "
         "reinterpret_cast<const uint32_t*>((A_ptr) + (A_offset)), "
         "reinterpret_cast<const uint32_t*>((B_ptr) + (B_offset)), "
@@ -3312,6 +3337,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     replacer.register_rule("(MMA_KIND)", mma_kind_enum);
     replacer.register_rule("(SCALE_VEC_SIZE)", std::to_string(scale_vec_size));
     replacer.register_rule("(SCALE_TYPE)", scale_type_enum);
+    replacer.register_rule("(OPERAND_TYPES)", operand_args);
     replacer.register_rule("(A_ptr)", a_ref);
     replacer.register_rule("(A_offset)", a_offset);
     replacer.register_rule("(B_ptr)", b_ref);

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -2056,6 +2056,23 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
 
     desc.global_shape.push_back(global_shape[tma_mode_to_gmode[i]]);
 
+    // Packed-align16 tensor map types (16U4/16U6_ALIGN16B) carry a CUDA
+    // driver rule: the innermost global dimension must be a whole number of
+    // 128-element groups. Enforce it at compile time when the extent is
+    // static; symbolic shapes still hit the runtime descriptor validation.
+    constexpr int kTensorMapDataType16U4Align16B = 14;
+    constexpr int kTensorMapDataType16U6Align16B = 15;
+    if (i == 0 && (desc.data_type == kTensorMapDataType16U4Align16B ||
+                   desc.data_type == kTensorMapDataType16U6Align16B)) {
+      if (auto inner = as_const_int(desc.global_shape[0])) {
+        ICHECK(*inner % 128 == 0)
+            << "packed-align16 TMA (16U4/16U6_ALIGN16B) requires the "
+               "innermost global dimension to be a multiple of 128 elements "
+               "(CUDA driver tensor-map rule); got "
+            << *inner << " for src: " << src->name << ", dst: " << dst->name;
+      }
+    }
+
     PrimExpr elem_stride = global_stride[tma_mode_to_gmode[i]];
     if (i == 0 && !is_one(elem_stride)) {
       DLOG(WARNING)

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -54,6 +54,9 @@ int TMAPayloadElementBits(DataType dtype) {
   if (dtype.is_float4_e2m1_unpacked()) {
     return 4;
   }
+  if (dtype.is_float6_unpacked()) {
+    return 6;
+  }
   return dtype.bits();
 }
 
@@ -159,10 +162,18 @@ int TensorMapDataTypeForTMA(DataType global_dtype, DataType shared_dtype) {
   // (float_e2m1_unpacksmem_t). 16U4_ALIGN8B: packed FP4 for mxf4 / mxf4nvf4
   // (float_e2m1_t).
   constexpr int kTensorMapDataType16U4Align16B = 14;
+  constexpr int kTensorMapDataType16U6Align16B = 15;
   if (shared_dtype.is_float4_e2m1_unpacked()) {
     ICHECK(global_dtype.is_float4_e2m1fn())
         << "FP4 packed global tensor required for unpacked shared TMA copy";
     return kTensorMapDataType16U4Align16B;
+  }
+  if (shared_dtype.is_float6_unpacked()) {
+    ICHECK(IsFP6PackedToUnpackedStorageCopy(global_dtype, shared_dtype))
+        << "matching packed FP6 global tensor required for unpacked shared "
+           "TMA copy, got "
+        << global_dtype << " -> " << shared_dtype;
+    return kTensorMapDataType16U6Align16B;
   }
   return to_CUtensorMapDataType(global_dtype);
 }

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -157,12 +157,15 @@ bool GetIsTmaCopy(const CopyNode &op) {
   return GetBoolAnnotation(op, "is_tma_copy");
 }
 
+// Packed-align16 CUtensorMap data types (kept by CUDA's documented enum
+// order; shared by descriptor construction and compile-time validation).
+constexpr int kTensorMapDataType16U4Align16B = 14;
+constexpr int kTensorMapDataType16U6Align16B = 15;
+
 int TensorMapDataTypeForTMA(DataType global_dtype, DataType shared_dtype) {
   // 16U4_ALIGN16B: f8f6f4 / mxf8f6f4 unpacked FP4 SMEM
   // (float_e2m1_unpacksmem_t). 16U4_ALIGN8B: packed FP4 for mxf4 / mxf4nvf4
   // (float_e2m1_t).
-  constexpr int kTensorMapDataType16U4Align16B = 14;
-  constexpr int kTensorMapDataType16U6Align16B = 15;
   if (shared_dtype.is_float4_e2m1_unpacked()) {
     ICHECK(global_dtype.is_float4_e2m1fn())
         << "FP4 packed global tensor required for unpacked shared TMA copy";
@@ -2071,8 +2074,6 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
     // driver rule: the innermost global dimension must be a whole number of
     // 128-element groups. Enforce it at compile time when the extent is
     // static; symbolic shapes still hit the runtime descriptor validation.
-    constexpr int kTensorMapDataType16U4Align16B = 14;
-    constexpr int kTensorMapDataType16U6Align16B = 15;
     if (i == 0 && (desc.data_type == kTensorMapDataType16U4Align16B ||
                    desc.data_type == kTensorMapDataType16U6Align16B)) {
       if (auto inner = as_const_int(desc.global_shape[0])) {

--- a/src/cuda/op/copy_analysis.cc
+++ b/src/cuda/op/copy_analysis.cc
@@ -387,6 +387,12 @@ bool CanProveCopyInBounds(const CopyNode &op, arith::Analyzer *analyzer) {
 bool CheckBulkLoad1D(const CopyNode &op, Target target,
                      const LayoutMap &layout_map, arith::Analyzer *analyzer,
                      bool emit_diagnostics) {
+  // The 1D bulk path is a descriptorless byte copy: it cannot perform the
+  // packed->unpacked FP4 expansion, so such copies must take the tiled
+  // (descriptor) path where 16U4_ALIGN16B does the unpacking.
+  if (IsFP4UnpackLoad(op.src, op.dst)) {
+    return false;
+  }
   if (!CheckBulkLoad(op, target, analyzer, false, emit_diagnostics)) {
     return false;
   }

--- a/src/cuda/op/copy_analysis.cc
+++ b/src/cuda/op/copy_analysis.cc
@@ -30,6 +30,9 @@ int TMAPayloadElementBits(DataType dtype) {
   if (dtype.is_float4_e2m1_unpacked()) {
     return 4;
   }
+  if (dtype.is_float6_unpacked()) {
+    return 6;
+  }
   return dtype.bits();
 }
 
@@ -390,7 +393,7 @@ bool CheckBulkLoad1D(const CopyNode &op, Target target,
   // The 1D bulk path is a descriptorless byte copy: it cannot perform the
   // packed->unpacked FP4 expansion, so such copies must take the tiled
   // (descriptor) path where 16U4_ALIGN16B does the unpacking.
-  if (IsFP4UnpackLoad(op.src, op.dst)) {
+  if (IsFP4UnpackLoad(op.src, op.dst) || IsFP6UnpackLoad(op.src, op.dst)) {
     return false;
   }
   if (!CheckBulkLoad(op, target, analyzer, false, emit_diagnostics)) {

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -487,6 +487,12 @@ For CopyNode::MakeSIMTLoop(arith::Analyzer *analyzer) const {
                << "T.tma_copy() for FP4 unpack loads (src=" << src->name
                << ", dst=" << dst->name << ").";
   }
+  if (IsFP6UnpackLoad(src, dst)) {
+    LOG(FATAL) << "SIMT copy from packed global float6 to unpacked shared "
+               << "float6_*_unpacked is not supported; use the TMA path for "
+               << "FP6 unpack loads (src=" << src->name << ", dst=" << dst->name
+               << ").";
+  }
 
   Array<IterVar> loop_vars = MakeIterVars();
   bool is_scalar = loop_vars.empty();

--- a/src/op/utils.cc
+++ b/src/op/utils.cc
@@ -204,8 +204,12 @@ int to_CUtensorMapDataType(DataType dtype) {
   // the installed toolkit, so keep the enum value by CUDA's documented order.
   constexpr int kTensorMapDataType16U4Align8B = 13;
   constexpr int kTensorMapDataType16U4Align16B = 14;
+  constexpr int kTensorMapDataType16U6Align16B = 15;
   if (dtype.is_float4_e2m1_unpacked()) {
     return kTensorMapDataType16U4Align16B;
+  }
+  if (dtype.is_float6_unpacked()) {
+    return kTensorMapDataType16U6Align16B;
   }
   if (dtype.is_float4_e2m1fn()) {
     return kTensorMapDataType16U4Align8B;

--- a/src/op/utils.h
+++ b/src/op/utils.h
@@ -120,11 +120,24 @@ inline bool IsFP4PackedToUnpackedStorageCopy(DataType global_dtype,
          shared_dtype.is_float4_e2m1_unpacked();
 }
 
+// True when global packed FP6 is copied into f8f6f4/mxf8f6f4 unpacked FP6
+// SMEM (TMA 16U6_ALIGN16B).
+inline bool IsFP6PackedToUnpackedStorageCopy(DataType global_dtype,
+                                             DataType shared_dtype) {
+  return (global_dtype.is_float6_e2m3fn() &&
+          shared_dtype.is_float6_e2m3fn_unpacked()) ||
+         (global_dtype.is_float6_e3m2fn() &&
+          shared_dtype.is_float6_e3m2fn_unpacked());
+}
+
 inline bool IsValidTMALoadDtypePair(DataType global_dtype,
                                     DataType shared_dtype) {
   if (global_dtype.is_float4_e2m1_unpacked() ||
       shared_dtype.is_float4_e2m1_unpacked()) {
     return IsFP4PackedToUnpackedStorageCopy(global_dtype, shared_dtype);
+  }
+  if (global_dtype.is_float6_unpacked() || shared_dtype.is_float6_unpacked()) {
+    return IsFP6PackedToUnpackedStorageCopy(global_dtype, shared_dtype);
   }
   if (global_dtype == shared_dtype) {
     return true;
@@ -135,7 +148,8 @@ inline bool IsValidTMALoadDtypePair(DataType global_dtype,
 inline bool IsValidTMAStoreDtypePair(DataType global_dtype,
                                      DataType shared_dtype) {
   return global_dtype == shared_dtype &&
-         !shared_dtype.is_float4_e2m1_unpacked();
+         !shared_dtype.is_float4_e2m1_unpacked() &&
+         !shared_dtype.is_float6_unpacked();
 }
 
 inline bool IsValidTMADtypePair(bool is_load, DataType global_dtype,
@@ -157,6 +171,11 @@ inline bool IsValidTMACopyDtypePair(DataType global_dtype,
 inline bool IsFP4UnpackLoad(const Buffer &src, const Buffer &dst) {
   return IsGlobalBuffer(src) && IsSharedBuffer(dst) &&
          IsFP4PackedToUnpackedStorageCopy(src->dtype, dst->dtype);
+}
+
+inline bool IsFP6UnpackLoad(const Buffer &src, const Buffer &dst) {
+  return IsGlobalBuffer(src) && IsSharedBuffer(dst) &&
+         IsFP6PackedToUnpackedStorageCopy(src->dtype, dst->dtype);
 }
 
 } // namespace tl

--- a/src/tl_templates/cuda/instruction/mma_block_scale.h
+++ b/src/tl_templates/cuda/instruction/mma_block_scale.h
@@ -36,6 +36,8 @@ enum class SM120MmaOperandType : int {
   kE2M1 = 0,
   kE4M3 = 1,
   kE5M2 = 2,
+  kE2M3 = 3,
+  kE3M2 = 4,
 };
 
 template <SM120MmaBlockScaledKind Kind, int ScaleVecSize,
@@ -64,15 +66,15 @@ struct SM120MmaBlockScaledConfig<SM120MmaBlockScaledKind::kMxf4nvf4, 4,
   static constexpr bool kSupported = true;
 };
 
-// kind::mxf8f6f4 (m16n8k32): pure-fp8 {e4m3,e5m2}^2 combinations, ue8m0
-// scales at scale_vec::1X only (PTX allows no other scale_vec for this kind).
+// kind::mxf8f6f4 (m16n8k32): every {e2m1, e2m3, e3m2, e4m3, e5m2} A/B
+// pairing (the full f8f6f4 family, 5x5), ue8m0 scales at scale_vec::1X only
+// (PTX allows no other scale_vec for this kind). fp4/fp6 operands live in
+// 8-bit register containers: e2m1 at bits[5:2] (loader shifts <<2), fp6 at
+// bits[5:0].
 template <SM120MmaOperandType AType, SM120MmaOperandType BType>
 struct SM120MmaBlockScaledConfig<SM120MmaBlockScaledKind::kMxf8f6f4, 1,
                                  SM120MmaScaleType::kUE8M0, AType, BType> {
-  static constexpr bool kSupported = (AType == SM120MmaOperandType::kE4M3 ||
-                                      AType == SM120MmaOperandType::kE5M2) &&
-                                     (BType == SM120MmaOperandType::kE4M3 ||
-                                      BType == SM120MmaOperandType::kE5M2);
+  static constexpr bool kSupported = true;
 };
 
 namespace detail {
@@ -220,7 +222,13 @@ TL_DEVICE void sm120_mma_m16n8k64_mxf4nvf4_4x_ue8m0(
 // byte selection is done in software - shift the requested byte into the low
 // half and issue with a hardware byte id of 0, the only form CUTLASS
 // exercises (mma_sm120.hpp SM120_16x8x32_TN_VS, VS=32).
-#define TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(suffix, atype_str, btype_str)    \
+// Dispatch table: one specialization per (AType, BType) pairing, stamped by
+// the macro below together with its asm wrapper.
+template <SM120MmaOperandType AType, SM120MmaOperandType BType>
+struct SM120Mxf8f6f4MmaImpl;
+
+#define TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(suffix, a_enum, b_enum,          \
+                                              atype_str, btype_str)            \
   TL_DEVICE void sm120_mma_m16n8k32_mxf8f6f4_1x_ue8m0_##suffix##_regs(         \
       float *d, uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3,            \
       uint32_t b0, uint32_t b1, const float *c, uint32_t scale_a,              \
@@ -237,7 +245,21 @@ TL_DEVICE void sm120_mma_m16n8k64_mxf4nvf4_4x_ue8m0(
         d, a[0], a[1], a[2], a[3], b[0], b[1], c, scale_a, scale_b,            \
         scale_a_byte_id, scale_a_thread_id, scale_b_byte_id,                   \
         scale_b_thread_id);                                                    \
-  }
+  }                                                                            \
+  template <>                                                                  \
+  struct SM120Mxf8f6f4MmaImpl<SM120MmaOperandType::a_enum,                     \
+                              SM120MmaOperandType::b_enum> {                   \
+    static TL_DEVICE void run(float *d, const uint32_t *a, const uint32_t *b,  \
+                              const float *c, uint32_t scale_a,                \
+                              uint32_t scale_b, uint16_t scale_a_byte_id,      \
+                              uint16_t scale_a_thread_id,                      \
+                              uint16_t scale_b_byte_id,                        \
+                              uint16_t scale_b_thread_id) {                    \
+      sm120_mma_m16n8k32_mxf8f6f4_1x_ue8m0_##suffix(                           \
+          d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,    \
+          scale_b_byte_id, scale_b_thread_id);                                 \
+    }                                                                          \
+  };
 
 #if defined(CUTE_ARCH_MXF8F6F4_MMA_ENABLED) &&                                 \
     defined(CUTLASS_ARCH_MMA_SM120A_ENABLED)
@@ -264,11 +286,27 @@ TL_DEVICE void sm120_mma_m16n8k64_mxf4nvf4_4x_ue8m0(
       "CUDA 12.8 or later");
 #endif
 
-TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(e4m3_e4m3, "e4m3", "e4m3")
-TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(e4m3_e5m2, "e4m3", "e5m2")
-TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(e5m2_e4m3, "e5m2", "e4m3")
-TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(e5m2_e5m2, "e5m2", "e5m2")
+// The full f8f6f4-family 5x5 operand matrix (matches CUTLASS 4.7
+// mma_sm120.hpp SM120_16x8x32_TN_VS specializations).
+#define TL_SM120_FOREACH_MXF8F6F4_B(a_suffix, a_enum, a_str)                   \
+  TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(a_suffix##_e2m1, a_enum, kE2M1, a_str, \
+                                        "e2m1")                                \
+  TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(a_suffix##_e2m3, a_enum, kE2M3, a_str, \
+                                        "e2m3")                                \
+  TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(a_suffix##_e3m2, a_enum, kE3M2, a_str, \
+                                        "e3m2")                                \
+  TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(a_suffix##_e4m3, a_enum, kE4M3, a_str, \
+                                        "e4m3")                                \
+  TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(a_suffix##_e5m2, a_enum, kE5M2, a_str, \
+                                        "e5m2")
 
+TL_SM120_FOREACH_MXF8F6F4_B(e2m1, kE2M1, "e2m1")
+TL_SM120_FOREACH_MXF8F6F4_B(e2m3, kE2M3, "e2m3")
+TL_SM120_FOREACH_MXF8F6F4_B(e3m2, kE3M2, "e3m2")
+TL_SM120_FOREACH_MXF8F6F4_B(e4m3, kE4M3, "e4m3")
+TL_SM120_FOREACH_MXF8F6F4_B(e5m2, kE5M2, "e5m2")
+
+#undef TL_SM120_FOREACH_MXF8F6F4_B
 #undef TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA
 #undef TL_SM120_MXF8F6F4_MMA_BODY
 
@@ -292,26 +330,9 @@ TL_DEVICE void sm120_mma_sync_blockscaled(float *d, const uint32_t *a,
                                           BType>::kSupported,
                 "Unsupported sm120 mma.block_scale configuration");
   if constexpr (Kind == SM120MmaBlockScaledKind::kMxf8f6f4) {
-    if constexpr (AType == SM120MmaOperandType::kE4M3 &&
-                  BType == SM120MmaOperandType::kE4M3) {
-      detail::sm120_mma_m16n8k32_mxf8f6f4_1x_ue8m0_e4m3_e4m3(
-          d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
-          scale_b_byte_id, scale_b_thread_id);
-    } else if constexpr (AType == SM120MmaOperandType::kE4M3 &&
-                         BType == SM120MmaOperandType::kE5M2) {
-      detail::sm120_mma_m16n8k32_mxf8f6f4_1x_ue8m0_e4m3_e5m2(
-          d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
-          scale_b_byte_id, scale_b_thread_id);
-    } else if constexpr (AType == SM120MmaOperandType::kE5M2 &&
-                         BType == SM120MmaOperandType::kE4M3) {
-      detail::sm120_mma_m16n8k32_mxf8f6f4_1x_ue8m0_e5m2_e4m3(
-          d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
-          scale_b_byte_id, scale_b_thread_id);
-    } else {
-      detail::sm120_mma_m16n8k32_mxf8f6f4_1x_ue8m0_e5m2_e5m2(
-          d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
-          scale_b_byte_id, scale_b_thread_id);
-    }
+    detail::SM120Mxf8f6f4MmaImpl<AType, BType>::run(
+        d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
+        scale_b_byte_id, scale_b_thread_id);
   } else if constexpr (ScaleVecSize == 4 &&
                        SType == SM120MmaScaleType::kUE4M3) {
     detail::sm120_mma_m16n8k64_mxf4nvf4_4x_ue4m3(

--- a/src/tl_templates/cuda/instruction/mma_block_scale.h
+++ b/src/tl_templates/cuda/instruction/mma_block_scale.h
@@ -21,6 +21,7 @@ namespace tl {
 
 enum class SM120MmaBlockScaledKind : int {
   kMxf4nvf4 = 0,
+  kMxf8f6f4 = 1,
 };
 
 enum class SM120MmaScaleType : int {
@@ -28,8 +29,19 @@ enum class SM120MmaScaleType : int {
   kUE8M0 = 1,
 };
 
+// Operand element types of the block-scaled MMA family. The tail template
+// parameters below default to kE2M1 so every existing mxf4nvf4 instantiation
+// (and its generated kernel source) stays unchanged.
+enum class SM120MmaOperandType : int {
+  kE2M1 = 0,
+  kE4M3 = 1,
+  kE5M2 = 2,
+};
+
 template <SM120MmaBlockScaledKind Kind, int ScaleVecSize,
-          SM120MmaScaleType SType>
+          SM120MmaScaleType SType,
+          SM120MmaOperandType AType = SM120MmaOperandType::kE2M1,
+          SM120MmaOperandType BType = SM120MmaOperandType::kE2M1>
 struct SM120MmaBlockScaledConfig {
   static constexpr bool kSupported = false;
 };
@@ -50,6 +62,17 @@ template <>
 struct SM120MmaBlockScaledConfig<SM120MmaBlockScaledKind::kMxf4nvf4, 4,
                                  SM120MmaScaleType::kUE8M0> {
   static constexpr bool kSupported = true;
+};
+
+// kind::mxf8f6f4 (m16n8k32): pure-fp8 {e4m3,e5m2}^2 combinations, ue8m0
+// scales at scale_vec::1X only (PTX allows no other scale_vec for this kind).
+template <SM120MmaOperandType AType, SM120MmaOperandType BType>
+struct SM120MmaBlockScaledConfig<SM120MmaBlockScaledKind::kMxf8f6f4, 1,
+                                 SM120MmaScaleType::kUE8M0, AType, BType> {
+  static constexpr bool kSupported = (AType == SM120MmaOperandType::kE4M3 ||
+                                      AType == SM120MmaOperandType::kE5M2) &&
+                                     (BType == SM120MmaOperandType::kE4M3 ||
+                                      BType == SM120MmaOperandType::kE5M2);
 };
 
 namespace detail {
@@ -187,10 +210,74 @@ TL_DEVICE void sm120_mma_m16n8k64_mxf4nvf4_4x_ue8m0(
       scale_a_byte_id, scale_a_thread_id, scale_b_byte_id, scale_b_thread_id);
 }
 
+// SM120a MXFP8 block-scaled warp MMA family:
+// mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X
+//   .f32.<atype>.<btype>.f32.ue8m0
+//
+// Register skeleton is identical to the k64 mxf4nvf4 wrappers above (4x b32
+// A, 2x b32 B, 4x f32 C/D, per-matrix {scale, byte_id, thread_id} operands).
+// scale_vec::1X consumes one ue8m0 byte per matrix; as with the 2X wrapper,
+// byte selection is done in software - shift the requested byte into the low
+// half and issue with a hardware byte id of 0, the only form CUTLASS
+// exercises (mma_sm120.hpp SM120_16x8x32_TN_VS, VS=32).
+#define TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(suffix, atype_str, btype_str)    \
+  TL_DEVICE void sm120_mma_m16n8k32_mxf8f6f4_1x_ue8m0_##suffix##_regs(         \
+      float *d, uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3,            \
+      uint32_t b0, uint32_t b1, const float *c, uint32_t scale_a,              \
+      uint32_t scale_b, uint16_t scale_a_byte_id = 0,                          \
+      uint16_t scale_a_thread_id = 0, uint16_t scale_b_byte_id = 0,            \
+      uint16_t scale_b_thread_id =                                             \
+          0){TL_SM120_MXF8F6F4_MMA_BODY(atype_str, btype_str)} TL_DEVICE void  \
+      sm120_mma_m16n8k32_mxf8f6f4_1x_ue8m0_##suffix(                           \
+          float *d, const uint32_t *a, const uint32_t *b, const float *c,      \
+          uint32_t scale_a, uint32_t scale_b, uint16_t scale_a_byte_id = 0,    \
+          uint16_t scale_a_thread_id = 0, uint16_t scale_b_byte_id = 0,        \
+          uint16_t scale_b_thread_id = 0) {                                    \
+    sm120_mma_m16n8k32_mxf8f6f4_1x_ue8m0_##suffix##_regs(                      \
+        d, a[0], a[1], a[2], a[3], b[0], b[1], c, scale_a, scale_b,            \
+        scale_a_byte_id, scale_a_thread_id, scale_b_byte_id,                   \
+        scale_b_thread_id);                                                    \
+  }
+
+#if defined(CUTE_ARCH_MXF8F6F4_MMA_ENABLED) &&                                 \
+    defined(CUTLASS_ARCH_MMA_SM120A_ENABLED)
+#define TL_SM120_MXF8F6F4_MMA_BODY(atype_str, btype_str)                       \
+  uint32_t sa = scale_a >> (scale_a_byte_id * 8);                              \
+  uint32_t sb = scale_b >> (scale_b_byte_id * 8);                              \
+  asm volatile("mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale." \
+               "scale_vec::1X.f32." atype_str "." btype_str ".f32.ue8m0 "      \
+               "{%0, %1, %2, %3}, "                                            \
+               "{%4, %5, %6, %7}, "                                            \
+               "{%8, %9}, "                                                    \
+               "{%10, %11, %12, %13}, "                                        \
+               "{%14}, {%15, %16}, "                                           \
+               "{%17}, {%18, %19};\n"                                          \
+               : "=f"(d[0]), "=f"(d[1]), "=f"(d[2]), "=f"(d[3])                \
+               : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1),         \
+                 "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]), "r"(sa),          \
+                 "h"(uint16_t(0)), "h"(scale_a_thread_id), "r"(sb),            \
+                 "h"(uint16_t(0)), "h"(scale_b_thread_id));
+#else
+#define TL_SM120_MXF8F6F4_MMA_BODY(atype_str, btype_str)                       \
+  CUTE_INVALID_CONTROL_PATH(                                                   \
+      "tl::sm120_mma_sync_blockscaled kind::mxf8f6f4 requires sm_120a and "    \
+      "CUDA 12.8 or later");
+#endif
+
+TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(e4m3_e4m3, "e4m3", "e4m3")
+TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(e4m3_e5m2, "e4m3", "e5m2")
+TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(e5m2_e4m3, "e5m2", "e4m3")
+TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA(e5m2_e5m2, "e5m2", "e5m2")
+
+#undef TL_SM120_DEFINE_MXF8F6F4_1X_UE8M0_MMA
+#undef TL_SM120_MXF8F6F4_MMA_BODY
+
 } // namespace detail
 
 template <SM120MmaBlockScaledKind Kind, int ScaleVecSize,
-          SM120MmaScaleType SType>
+          SM120MmaScaleType SType,
+          SM120MmaOperandType AType = SM120MmaOperandType::kE2M1,
+          SM120MmaOperandType BType = SM120MmaOperandType::kE2M1>
 TL_DEVICE void sm120_mma_sync_blockscaled(float *d, const uint32_t *a,
                                           const uint32_t *b, const float *c,
                                           uint32_t scale_a, uint32_t scale_b,
@@ -198,12 +285,35 @@ TL_DEVICE void sm120_mma_sync_blockscaled(float *d, const uint32_t *a,
                                           uint16_t scale_a_thread_id = 0,
                                           uint16_t scale_b_byte_id = 0,
                                           uint16_t scale_b_thread_id = 0) {
-  static_assert(Kind == SM120MmaBlockScaledKind::kMxf4nvf4,
-                "Only kind::mxf4nvf4 is supported");
-  static_assert(
-      SM120MmaBlockScaledConfig<Kind, ScaleVecSize, SType>::kSupported,
-      "Unsupported sm120 mma.block_scale configuration");
-  if constexpr (ScaleVecSize == 4 && SType == SM120MmaScaleType::kUE4M3) {
+  static_assert(Kind == SM120MmaBlockScaledKind::kMxf4nvf4 ||
+                    Kind == SM120MmaBlockScaledKind::kMxf8f6f4,
+                "Only kind::mxf4nvf4 and kind::mxf8f6f4 are supported");
+  static_assert(SM120MmaBlockScaledConfig<Kind, ScaleVecSize, SType, AType,
+                                          BType>::kSupported,
+                "Unsupported sm120 mma.block_scale configuration");
+  if constexpr (Kind == SM120MmaBlockScaledKind::kMxf8f6f4) {
+    if constexpr (AType == SM120MmaOperandType::kE4M3 &&
+                  BType == SM120MmaOperandType::kE4M3) {
+      detail::sm120_mma_m16n8k32_mxf8f6f4_1x_ue8m0_e4m3_e4m3(
+          d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
+          scale_b_byte_id, scale_b_thread_id);
+    } else if constexpr (AType == SM120MmaOperandType::kE4M3 &&
+                         BType == SM120MmaOperandType::kE5M2) {
+      detail::sm120_mma_m16n8k32_mxf8f6f4_1x_ue8m0_e4m3_e5m2(
+          d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
+          scale_b_byte_id, scale_b_thread_id);
+    } else if constexpr (AType == SM120MmaOperandType::kE5M2 &&
+                         BType == SM120MmaOperandType::kE4M3) {
+      detail::sm120_mma_m16n8k32_mxf8f6f4_1x_ue8m0_e5m2_e4m3(
+          d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
+          scale_b_byte_id, scale_b_thread_id);
+    } else {
+      detail::sm120_mma_m16n8k32_mxf8f6f4_1x_ue8m0_e5m2_e5m2(
+          d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
+          scale_b_byte_id, scale_b_thread_id);
+    }
+  } else if constexpr (ScaleVecSize == 4 &&
+                       SType == SM120MmaScaleType::kUE4M3) {
     detail::sm120_mma_m16n8k64_mxf4nvf4_4x_ue4m3(
         d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
         scale_b_byte_id, scale_b_thread_id);

--- a/src/tl_templates/cuda/instruction/mma_block_scale.h
+++ b/src/tl_templates/cuda/instruction/mma_block_scale.h
@@ -7,6 +7,16 @@
 #include <cstdint>
 #endif
 
+// The vendored CUTLASS predates the mxf4nvf4 4X+ue8m0 arch gate (added in
+// CUTLASS 4.6 for CUDA 13.1); mirror that condition so the instruction is
+// usable with either CUTLASS tree once the toolchain allows it.
+#if defined(CUTE_ARCH_MXF4NVF4_4X_UE8M0_MMA_ENABLED) ||                        \
+    (defined(CUTLASS_ARCH_MMA_SM120A_ENABLED) &&                               \
+     (__CUDACC_VER_MAJOR__ > 13 ||                                             \
+      (__CUDACC_VER_MAJOR__ == 13 && __CUDACC_VER_MINOR__ >= 1)))
+#define TL_SM120_MXF4NVF4_4X_UE8M0_MMA_ENABLED 1
+#endif
+
 namespace tl {
 
 enum class SM120MmaBlockScaledKind : int {
@@ -15,6 +25,7 @@ enum class SM120MmaBlockScaledKind : int {
 
 enum class SM120MmaScaleType : int {
   kUE4M3 = 0,
+  kUE8M0 = 1,
 };
 
 template <SM120MmaBlockScaledKind Kind, int ScaleVecSize,
@@ -26,6 +37,18 @@ struct SM120MmaBlockScaledConfig {
 template <>
 struct SM120MmaBlockScaledConfig<SM120MmaBlockScaledKind::kMxf4nvf4, 4,
                                  SM120MmaScaleType::kUE4M3> {
+  static constexpr bool kSupported = true;
+};
+
+template <>
+struct SM120MmaBlockScaledConfig<SM120MmaBlockScaledKind::kMxf4nvf4, 2,
+                                 SM120MmaScaleType::kUE8M0> {
+  static constexpr bool kSupported = true;
+};
+
+template <>
+struct SM120MmaBlockScaledConfig<SM120MmaBlockScaledKind::kMxf4nvf4, 4,
+                                 SM120MmaScaleType::kUE8M0> {
   static constexpr bool kSupported = true;
 };
 
@@ -71,6 +94,94 @@ TL_DEVICE void sm120_mma_m16n8k64_mxf4nvf4_4x_ue4m3(
       scale_a_byte_id, scale_a_thread_id, scale_b_byte_id, scale_b_thread_id);
 }
 
+// SM120a MXFP4 block-scaled warp MMA (PTX ISA operand order):
+// mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::2X.m16n8k64...ue8m0
+//
+// The PTX scale operand register stays b32 but the instruction consumes only
+// 16 bits of it. CUTLASS drives this form exclusively with byte_id = 0 and a
+// uint16 SF fragment (mma_sm120.hpp SM120_16x8x64_TN_VS, VS=32), so byte
+// selection is done in software here: shift the requested byte pair into the
+// low half and issue with a hardware byte id of 0. thread_id keeps its
+// hardware lane-select semantics, which the 4X path already exercises.
+TL_DEVICE void sm120_mma_m16n8k64_mxf4nvf4_2x_ue8m0_regs(
+    float *d, uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3, uint32_t b0,
+    uint32_t b1, const float *c, uint32_t scale_a, uint32_t scale_b,
+    uint16_t scale_a_byte_id = 0, uint16_t scale_a_thread_id = 0,
+    uint16_t scale_b_byte_id = 0, uint16_t scale_b_thread_id = 0) {
+#if defined(CUTE_ARCH_MXF4NVF4_2X_UE8M0_MMA_ENABLED) &&                        \
+    defined(CUTLASS_ARCH_MMA_SM120A_ENABLED)
+  uint32_t sa = scale_a >> (scale_a_byte_id * 8);
+  uint32_t sb = scale_b >> (scale_b_byte_id * 8);
+  asm volatile(
+      "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::2X.m16n8k64.row."
+      "col.f32.e2m1.e2m1.f32.ue8m0 "
+      "{%0, %1, %2, %3}, "
+      "{%4, %5, %6, %7}, "
+      "{%8, %9}, "
+      "{%10, %11, %12, %13}, "
+      "{%14}, {%15, %16}, "
+      "{%17}, {%18, %19};\n"
+      : "=f"(d[0]), "=f"(d[1]), "=f"(d[2]), "=f"(d[3])
+      : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "f"(c[0]),
+        "f"(c[1]), "f"(c[2]), "f"(c[3]), "r"(sa), "h"(uint16_t(0)),
+        "h"(scale_a_thread_id), "r"(sb), "h"(uint16_t(0)),
+        "h"(scale_b_thread_id));
+#else
+  CUTE_INVALID_CONTROL_PATH(
+      "tl::sm120_mma_sync_blockscaled scale_vec::2X ue8m0 requires sm_120a "
+      "and CUDA 12.8 or later");
+#endif
+}
+
+TL_DEVICE void sm120_mma_m16n8k64_mxf4nvf4_2x_ue8m0(
+    float *d, const uint32_t *a, const uint32_t *b, const float *c,
+    uint32_t scale_a, uint32_t scale_b, uint16_t scale_a_byte_id = 0,
+    uint16_t scale_a_thread_id = 0, uint16_t scale_b_byte_id = 0,
+    uint16_t scale_b_thread_id = 0) {
+  sm120_mma_m16n8k64_mxf4nvf4_2x_ue8m0_regs(
+      d, a[0], a[1], a[2], a[3], b[0], b[1], c, scale_a, scale_b,
+      scale_a_byte_id, scale_a_thread_id, scale_b_byte_id, scale_b_thread_id);
+}
+
+// SM120a NVF4-granularity ue8m0 variant (scale_vec::4X, CUDA 13.1+). Full
+// 4-byte scale-word consumption, same operand semantics as the ue4m3 form.
+TL_DEVICE void sm120_mma_m16n8k64_mxf4nvf4_4x_ue8m0_regs(
+    float *d, uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3, uint32_t b0,
+    uint32_t b1, const float *c, uint32_t scale_a, uint32_t scale_b,
+    uint16_t scale_a_byte_id = 0, uint16_t scale_a_thread_id = 0,
+    uint16_t scale_b_byte_id = 0, uint16_t scale_b_thread_id = 0) {
+#if defined(TL_SM120_MXF4NVF4_4X_UE8M0_MMA_ENABLED)
+  asm volatile(
+      "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row."
+      "col.f32.e2m1.e2m1.f32.ue8m0 "
+      "{%0, %1, %2, %3}, "
+      "{%4, %5, %6, %7}, "
+      "{%8, %9}, "
+      "{%10, %11, %12, %13}, "
+      "{%14}, {%15, %16}, "
+      "{%17}, {%18, %19};\n"
+      : "=f"(d[0]), "=f"(d[1]), "=f"(d[2]), "=f"(d[3])
+      : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "f"(c[0]),
+        "f"(c[1]), "f"(c[2]), "f"(c[3]), "r"(scale_a), "h"(scale_a_byte_id),
+        "h"(scale_a_thread_id), "r"(scale_b), "h"(scale_b_byte_id),
+        "h"(scale_b_thread_id));
+#else
+  CUTE_INVALID_CONTROL_PATH(
+      "tl::sm120_mma_sync_blockscaled scale_vec::4X ue8m0 requires sm_120a "
+      "and CUDA 13.1 or later");
+#endif
+}
+
+TL_DEVICE void sm120_mma_m16n8k64_mxf4nvf4_4x_ue8m0(
+    float *d, const uint32_t *a, const uint32_t *b, const float *c,
+    uint32_t scale_a, uint32_t scale_b, uint16_t scale_a_byte_id = 0,
+    uint16_t scale_a_thread_id = 0, uint16_t scale_b_byte_id = 0,
+    uint16_t scale_b_thread_id = 0) {
+  sm120_mma_m16n8k64_mxf4nvf4_4x_ue8m0_regs(
+      d, a[0], a[1], a[2], a[3], b[0], b[1], c, scale_a, scale_b,
+      scale_a_byte_id, scale_a_thread_id, scale_b_byte_id, scale_b_thread_id);
+}
+
 } // namespace detail
 
 template <SM120MmaBlockScaledKind Kind, int ScaleVecSize,
@@ -84,15 +195,23 @@ TL_DEVICE void sm120_mma_sync_blockscaled(float *d, const uint32_t *a,
                                           uint16_t scale_b_thread_id = 0) {
   static_assert(Kind == SM120MmaBlockScaledKind::kMxf4nvf4,
                 "Only kind::mxf4nvf4 is supported");
-  static_assert(ScaleVecSize == 4, "Only scale_vec::4X is supported");
-  static_assert(SType == SM120MmaScaleType::kUE4M3,
-                "kind::mxf4nvf4 only supports ue4m3 scale factors");
   static_assert(
       SM120MmaBlockScaledConfig<Kind, ScaleVecSize, SType>::kSupported,
       "Unsupported sm120 mma.block_scale configuration");
-  detail::sm120_mma_m16n8k64_mxf4nvf4_4x_ue4m3(
-      d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
-      scale_b_byte_id, scale_b_thread_id);
+  if constexpr (ScaleVecSize == 4 && SType == SM120MmaScaleType::kUE4M3) {
+    detail::sm120_mma_m16n8k64_mxf4nvf4_4x_ue4m3(
+        d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
+        scale_b_byte_id, scale_b_thread_id);
+  } else if constexpr (ScaleVecSize == 2 &&
+                       SType == SM120MmaScaleType::kUE8M0) {
+    detail::sm120_mma_m16n8k64_mxf4nvf4_2x_ue8m0(
+        d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
+        scale_b_byte_id, scale_b_thread_id);
+  } else {
+    detail::sm120_mma_m16n8k64_mxf4nvf4_4x_ue8m0(
+        d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
+        scale_b_byte_id, scale_b_thread_id);
+  }
 }
 
 } // namespace tl

--- a/src/tl_templates/cuda/instruction/mma_block_scale.h
+++ b/src/tl_templates/cuda/instruction/mma_block_scale.h
@@ -94,8 +94,13 @@ TL_DEVICE void sm120_mma_m16n8k64_mxf4nvf4_4x_ue4m3(
       scale_a_byte_id, scale_a_thread_id, scale_b_byte_id, scale_b_thread_id);
 }
 
-// SM120a MXFP4 block-scaled warp MMA (PTX ISA operand order):
+// SM120a MXFP4 block-scaled warp MMA:
 // mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::2X.m16n8k64...ue8m0
+//
+// The qualifier order (kind before shape) follows the PTX ISA block-scale
+// grammar and CUTLASS cute/arch/mma_sm120.hpp (SM120_16x8x64_TN_VS); ptxas
+// accepts it from CUDA 12.8 on. The legacy 4X ue4m3 wrapper above keeps its
+// original shape-first spelling, which ptxas also accepts.
 //
 // The PTX scale operand register stays b32 but the instruction consumes only
 // 16 bits of it. CUTLASS drives this form exclusively with byte_id = 0 and a
@@ -208,9 +213,17 @@ TL_DEVICE void sm120_mma_sync_blockscaled(float *d, const uint32_t *a,
         d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
         scale_b_byte_id, scale_b_thread_id);
   } else {
+#if defined(TL_SM120_MXF4NVF4_4X_UE8M0_MMA_ENABLED)
     detail::sm120_mma_m16n8k64_mxf4nvf4_4x_ue8m0(
         d, a, b, c, scale_a, scale_b, scale_a_byte_id, scale_a_thread_id,
         scale_b_byte_id, scale_b_thread_id);
+#else
+    // Instantiated only when a kernel actually selects 4X+ue8m0: fail the
+    // JIT compile with a clear message instead of trapping at runtime.
+    static_assert(ScaleVecSize != 4,
+                  "mxf4nvf4 scale_vec::4X with ue8m0 scale factors requires "
+                  "CUDA 13.1 or later");
+#endif
   }
 }
 

--- a/src/tl_templates/cuda/instruction/mma_block_scale.h
+++ b/src/tl_templates/cuda/instruction/mma_block_scale.h
@@ -95,12 +95,12 @@ TL_DEVICE void sm120_mma_m16n8k64_mxf4nvf4_4x_ue4m3(
 }
 
 // SM120a MXFP4 block-scaled warp MMA:
-// mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::2X.m16n8k64...ue8m0
+// mma.sync.aligned.m16n8k64.row.col.kind::mxf4nvf4.block_scale.scale_vec::2X
+// ...ue8m0
 //
-// The qualifier order (kind before shape) follows the PTX ISA block-scale
-// grammar and CUTLASS cute/arch/mma_sm120.hpp (SM120_16x8x64_TN_VS); ptxas
-// accepts it from CUDA 12.8 on. The legacy 4X ue4m3 wrapper above keeps its
-// original shape-first spelling, which ptxas also accepts.
+// Spelled shape-first to match the documented PTX grammar and the 4X ue4m3
+// wrapper above. (CUTLASS cute/arch/mma_sm120.hpp spells the same
+// instruction kind-first; ptxas accepts both spellings.)
 //
 // The PTX scale operand register stays b32 but the instruction consumes only
 // 16 bits of it. CUTLASS drives this form exclusively with byte_id = 0 and a
@@ -118,8 +118,8 @@ TL_DEVICE void sm120_mma_m16n8k64_mxf4nvf4_2x_ue8m0_regs(
   uint32_t sa = scale_a >> (scale_a_byte_id * 8);
   uint32_t sb = scale_b >> (scale_b_byte_id * 8);
   asm volatile(
-      "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::2X.m16n8k64.row."
-      "col.f32.e2m1.e2m1.f32.ue8m0 "
+      "mma.sync.aligned.m16n8k64.row.col.kind::mxf4nvf4.block_scale.scale_vec::"
+      "2X.f32.e2m1.e2m1.f32.ue8m0 "
       "{%0, %1, %2, %3}, "
       "{%4, %5, %6, %7}, "
       "{%8, %9}, "
@@ -157,8 +157,8 @@ TL_DEVICE void sm120_mma_m16n8k64_mxf4nvf4_4x_ue8m0_regs(
     uint16_t scale_b_byte_id = 0, uint16_t scale_b_thread_id = 0) {
 #if defined(TL_SM120_MXF4NVF4_4X_UE8M0_MMA_ENABLED)
   asm volatile(
-      "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row."
-      "col.f32.e2m1.e2m1.f32.ue8m0 "
+      "mma.sync.aligned.m16n8k64.row.col.kind::mxf4nvf4.block_scale.scale_vec::"
+      "4X.f32.e2m1.e2m1.f32.ue8m0 "
       "{%0, %1, %2, %3}, "
       "{%4, %5, %6, %7}, "
       "{%8, %9}, "

--- a/src/tl_templates/cuda/ldsm.h
+++ b/src/tl_templates/cuda/ldsm.h
@@ -192,4 +192,58 @@ TL_DEVICE void ptx_stmatrix_x4_trans(void const *const smem_ptr,
   ptx_stmatrix_m8n8_x4_trans(smem_ptr, value0, value1, value2, value3);
 }
 
+// Sub-byte ldmatrix variants (SM100/SM120 family, CUDA 12.8+): each m8n16
+// source row is one 16-byte unit holding 16 packed 4-bit (b4x16_p64: 8B
+// payload + 8B padding) or 6-bit (b6x16_p32: 12B payload + 4B padding)
+// elements; the instruction zero-extends every element into an 8-bit
+// register container (value at bits[3:0] / bits[5:0]). No trans forms
+// exist. Byte footprint per matrix equals the classic m8n8.b16 form, so
+// lane addressing is shared with the 8-bit path.
+#define TL_DEFINE_PTX_LDMATRIX_SUB_BYTE(variant, ptx_suffix)                   \
+  TL_DEVICE void ptx_ldmatrix_##variant##_x1(void const *const smem_ptr,       \
+                                             void *const local_ptr) {          \
+    uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);                        \
+    int32_t *value = reinterpret_cast<int32_t *>(local_ptr);                   \
+    asm volatile("ldmatrix.sync.aligned.m8n16.x1.shared.b8x16." ptx_suffix     \
+                 " {%0}, [%1];\n"                                              \
+                 : "=r"(value[0])                                              \
+                 : "r"(smem_int_ptr));                                         \
+  }                                                                            \
+  TL_DEVICE void ptx_ldmatrix_##variant##_x2(void const *const smem_ptr,       \
+                                             void *const local_ptr) {          \
+    uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);                        \
+    int32_t *value = reinterpret_cast<int32_t *>(local_ptr);                   \
+    asm volatile("ldmatrix.sync.aligned.m8n16.x2.shared.b8x16." ptx_suffix     \
+                 " {%0, %1}, [%2];\n"                                          \
+                 : "=r"(value[0]), "=r"(value[1])                              \
+                 : "r"(smem_int_ptr));                                         \
+  }                                                                            \
+  TL_DEVICE void ptx_ldmatrix_##variant##_x4(void const *const smem_ptr,       \
+                                             void *const local_ptr) {          \
+    uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);                        \
+    int32_t *value = reinterpret_cast<int32_t *>(local_ptr);                   \
+    asm volatile("ldmatrix.sync.aligned.m8n16.x4.shared.b8x16." ptx_suffix     \
+                 " {%0, %1, %2, %3}, [%4];\n"                                  \
+                 : "=r"(value[0]), "=r"(value[1]), "=r"(value[2]),             \
+                   "=r"(value[3])                                              \
+                 : "r"(smem_int_ptr));                                         \
+  }
+
+TL_DEFINE_PTX_LDMATRIX_SUB_BYTE(su4, "b4x16_p64")
+TL_DEFINE_PTX_LDMATRIX_SUB_BYTE(su6, "b6x16_p32")
+
+#undef TL_DEFINE_PTX_LDMATRIX_SUB_BYTE
+
+// Shift zero-extended e2m1 containers (bits[3:0]) up to the bits[5:2]
+// position kind::mxf8f6f4 expects. Safe as a whole-word shift: b4x16_p64
+// zero-extension guarantees bits[7:4] of every byte are zero, so nothing
+// crosses byte boundaries. fp6 containers need no shift (bits[5:0]).
+TL_DEVICE void fp4_e2m1_container_shift(void *const local_ptr, int num_words) {
+  uint32_t *words = reinterpret_cast<uint32_t *>(local_ptr);
+#pragma unroll
+  for (int i = 0; i < num_words; ++i) {
+    words[i] <<= 2;
+  }
+}
+
 } // namespace tl

--- a/src/transform/tvm_ffi_binder.cc
+++ b/src/transform/tvm_ffi_binder.cc
@@ -596,9 +596,11 @@ void TVMFFIABIBuilder::BindDLTensors(
     // runtime shape [m, 8]. We need to solve for symbolic variables from
     // this packed shape.
     if (data_is_subtype) {
-      // For subtype, bind symbolic variables from the packed shape.
-      // Number of logical elements packed into one byte-sized storage unit.
-      int pack_factor = 8 / logical_element_bits;
+      // For subtype, bind symbolic variables from the packed shape. The
+      // runtime last dimension counts 8-bit storage units, so
+      // logical_last = runtime_last * 8 / logical_bits. Integer division is
+      // exact whenever the total-bits assert above holds (fp4: *2; fp6:
+      // *8/6 - NOT expressible as an integer pack factor).
 
       // Build a mapping from logical shape dimensions to runtime shape
       // expressions For all dimensions except the last, runtime_shape[k] ==
@@ -618,9 +620,9 @@ void TVMFFIABIBuilder::BindDLTensors(
         PrimExpr logical_shape_val;
         bool is_last_dim = (k == buffer->shape.size() - 1);
         if (is_last_dim) {
-          logical_shape_val =
-              runtime_shape_val *
-              make_const(runtime_shape_val.dtype(), pack_factor);
+          logical_shape_val = indexdiv(
+              runtime_shape_val * make_const(runtime_shape_val.dtype(), 8),
+              make_const(runtime_shape_val.dtype(), logical_element_bits));
         } else {
           logical_shape_val = runtime_shape_val;
         }
@@ -790,7 +792,6 @@ void TVMFFIABIBuilder::BindDLTensors(
       // For subtype, only process strides if there are explicit strides
       // with symbolic variables that need binding
       if (!buffer->strides.empty()) {
-        int pack_factor = 8 / logical_element_bits;
 
         Buffer buf_strides =
             decl_buffer({IntImm(DataType::Int(32), buffer->strides.size())},
@@ -827,8 +828,11 @@ void TVMFFIABIBuilder::BindDLTensors(
           if (is_last_dim) {
             logical_stride_val = runtime_stride;
           } else {
+            // Runtime strides count 8-bit storage units; exact whenever the
+            // enclosing shape/total-bits constraints hold (fp4 *2, fp6 *8/6).
             logical_stride_val =
-                runtime_stride * make_const(stride_dtype, pack_factor);
+                indexdiv(runtime_stride * make_const(stride_dtype, 8),
+                         make_const(stride_dtype, logical_element_bits));
           }
 
           // Relax stride check: if the expected stride is 0, allow any actual

--- a/testing/python/language/test_tilelang_language_fp6_unpacked_dtype.py
+++ b/testing/python/language/test_tilelang_language_fp6_unpacked_dtype.py
@@ -1,0 +1,98 @@
+"""Tests for the FP6 unpacked shared-memory dtypes (16U6_ALIGN16B storage).
+
+Mirrors the fp4 unpacked dtype tests: these are 8-bit-container storage tags
+(CUTLASS ``float_e2m3_unpacksmem_t`` / ``float_e3m2_unpacksmem_t``) for the
+f8f6f4 / mxf8f6f4 smem forms, not general register dtypes.
+"""
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+def test_float6_unpacked_dtype_properties():
+    e2m3 = T.float6_e2m3fn_unpacked
+    e3m2 = T.float6_e3m2fn_unpacked
+    assert e2m3.bits == 8
+    assert e3m2.bits == 8
+    assert int(e2m3.type_code) == 132
+    assert int(e3m2.type_code) == 133
+    assert str(e2m3) == "custom[float6_e2m3fn_unpacked]8"
+    assert str(e3m2) == "custom[float6_e3m2fn_unpacked]8"
+    assert e2m3.lanes == 1 and e3m2.lanes == 1
+    assert e2m3 != e3m2
+
+
+def test_float6_unpacked_distinct_from_packed():
+    assert T.float6_e2m3fn.bits == 6
+    assert T.float6_e3m2fn.bits == 6
+    assert T.float6_e2m3fn != T.float6_e2m3fn_unpacked
+    assert T.float6_e3m2fn != T.float6_e3m2fn_unpacked
+
+
+def test_float6_unpacked_dtype_helpers():
+    from tilelang.language.dtypes import is_float6_unpacked
+
+    e2m3 = T.float6_e2m3fn_unpacked
+    e3m2 = T.float6_e3m2fn_unpacked
+    assert e2m3.is_float6_e2m3fn_unpacked()
+    assert not e2m3.is_float6_e3m2fn_unpacked()
+    assert e2m3.is_float6_unpacked()
+    assert e3m2.is_float6_e3m2fn_unpacked()
+    assert e3m2.is_float6_unpacked()
+    assert not T.float6_e2m3fn.is_float6_unpacked()
+    assert is_float6_unpacked("custom[float6_e2m3fn_unpacked]8")
+    assert not is_float6_unpacked(T.float16)
+
+
+def test_float6_unpacked_in_f8f6f4_family():
+    """The family predicate must see the custom-registered names.
+
+    This was a latent bug: the predicate was string-prefix based and
+    ``custom[...]`` names never match ``float6``/``float8`` prefixes.
+    """
+    from tilelang.language.dtypes import is_f8f6f4_family
+
+    assert is_f8f6f4_family(T.float6_e2m3fn_unpacked)
+    assert is_f8f6f4_family(T.float6_e3m2fn_unpacked)
+    assert is_f8f6f4_family(T.float4_e2m1_unpacked)
+    assert is_f8f6f4_family(T.float8_e4m3fn)
+    assert not is_f8f6f4_family(T.bfloat16)
+    assert not is_f8f6f4_family(T.int8)
+
+
+def test_float6_unpacked_tir_dtype_tag():
+    @T.prim_func
+    def main():
+        T.evaluate(T.float6_e2m3fn_unpacked(0.0))
+
+    assert main.body.value.dtype.is_float6_e2m3fn_unpacked()
+
+
+def test_float6_unpacked_mma_abbrev():
+    from tilelang.cuda.intrinsics.macro.mma_macro_generator import TensorCoreIntrinEmitter
+
+    abbrv = TensorCoreIntrinEmitter.dtype_abbrv
+    assert abbrv["custom[float6_e2m3fn_unpacked]8"] == "e2m3"
+    assert abbrv["custom[float6_e3m2fn_unpacked]8"] == "e3m2"
+
+
+@tilelang.testing.requires_cuda
+def test_float6_unpacked_shared_alloc_prints_bytes():
+    """An unpacked-fp6 shared buffer must lower to plain byte storage."""
+
+    @T.prim_func
+    def main(OUT: T.Tensor((64,), T.uint8)):
+        with T.Kernel(1, threads=64) as _:
+            tx = T.get_thread_binding()
+            smem = T.alloc_shared((64,), T.float6_e3m2fn_unpacked, scope="shared.dyn")
+            smem[tx] = T.reinterpret(T.float6_e3m2fn_unpacked, T.uint8(0))
+            OUT[tx] = T.reinterpret(T.uint8, smem[tx])
+
+    kernel = tilelang.compile(main, target="cuda", out_idx=[0])
+    src = kernel.get_kernel_source()
+    assert "__nv_fp6" not in src  # never the packed register type
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_ldmatrix_sub_byte.py
+++ b/testing/python/language/test_tilelang_language_ldmatrix_sub_byte.py
@@ -1,0 +1,122 @@
+"""White-box tests for the sub-byte ldmatrix variants (su4 / su6).
+
+``ldmatrix.m8n16.x4.shared.b8x16.b4x16_p64`` / ``b6x16_p32`` unpack 16
+packed 4-/6-bit elements per 16-byte source row into 8-bit register
+containers. Hardware semantics pinned here (verified on RTX PRO 6000,
+matching a raw-CUDA probe):
+
+- destination fragment layout is identical to the classic ``m8n8.b16``
+  form: lane ``l`` holds bytes ``4*(l%4)..4*(l%4)+3`` of row ``l//4``,
+  register ``r`` is matrix ``r`` - so the 8-bit lane-offset functions are
+  shared;
+- su4 payload: 8 bytes, element 0 in the LOW nibble; 8 padding bytes
+  ignored;
+- su6 payload: 12 bytes, LSB-first 6-bit stream; 4 padding bytes ignored;
+- values are zero-extended (su4: bits[3:0], su6: bits[5:0]).
+"""
+
+import pytest
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.transform import simplify_prim_func
+
+
+@simplify_prim_func
+def _make_ldmatrix_probe_kernel(variant: str):
+    @T.prim_func
+    def main(
+        SRC: T.Tensor((512,), T.uint8),
+        OUT: T.Tensor((32, 16), T.uint8),
+    ):
+        with T.Kernel(1, threads=32) as _:
+            tx = T.get_thread_binding()
+            smem = T.alloc_shared((512,), T.uint8, scope="shared.dyn")
+            regs = T.alloc_local((16,), T.uint8)
+
+            for i in T.serial(16):
+                smem[tx * 16 + i] = SRC[tx * 16 + i]
+            T.sync_threads()
+
+            T.ptx_ldmatrix(
+                T.bool(False),
+                4,
+                T.access_ptr(smem[(tx % 8) * 16 + (tx // 8) * 128], "r", extent=16),
+                T.access_ptr(regs[0], "w", extent=16),
+                variant=variant,
+            )
+
+            for i in T.serial(16):
+                OUT[tx, i] = regs[i]
+
+    return main
+
+
+def _pack_su4(elements):
+    """elements: (4 matrices, 8 rows, 16 elems) -> 512 source bytes."""
+    import torch
+
+    src = torch.full((512,), 0xEE, dtype=torch.uint8)  # padding sentinel
+    for mat in range(4):
+        for row in range(8):
+            base = mat * 128 + row * 16
+            for j in range(8):
+                e0 = int(elements[mat, row, 2 * j])
+                e1 = int(elements[mat, row, 2 * j + 1])
+                src[base + j] = e0 | (e1 << 4)
+    return src
+
+
+def _pack_su6(elements):
+    import torch
+
+    src = torch.full((512,), 0xEE, dtype=torch.uint8)
+    for mat in range(4):
+        for row in range(8):
+            base = mat * 128 + row * 16
+            payload = bytearray(12)
+            for i in range(16):
+                v = int(elements[mat, row, i])
+                bit = 6 * i
+                for b in range(6):
+                    if v & (1 << b):
+                        payload[(bit + b) // 8] |= 1 << ((bit + b) % 8)
+            for j in range(12):
+                src[base + j] = payload[j]
+    return src
+
+
+def _expected_fragment(elements):
+    """Classic m8n8.b16-shaped fragment: lane l -> row l//4, 4 bytes at 4*(l%4)."""
+    import torch
+
+    out = torch.zeros((32, 16), dtype=torch.uint8)
+    for lane in range(32):
+        row = lane // 4
+        col0 = 4 * (lane % 4)
+        for mat in range(4):
+            for j in range(4):
+                out[lane, mat * 4 + j] = elements[mat, row, col0 + j]
+    return out
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize("variant,max_value,pack", [("su4", 16, _pack_su4), ("su6", 64, _pack_su6)])
+def test_ldmatrix_sub_byte_lane_mapping(variant, max_value, pack):
+    import torch
+
+    torch.manual_seed(0)
+    kernel = tilelang.compile(_make_ldmatrix_probe_kernel(variant), target="cuda", out_idx=[1])
+    src = kernel.get_kernel_source()
+    assert f"tl::ptx_ldmatrix_{variant}_x4" in src
+
+    elements = torch.randint(0, max_value, (4, 8, 16), dtype=torch.int64)
+    out = kernel(pack(elements).cuda())
+    expected = _expected_fragment(elements)
+    assert torch.equal(out.cpu(), expected)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
@@ -365,5 +365,233 @@ def test_mxf8f6f4_many_tiles_many_stages_correctness():
     torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_mxf8f6f4_kmajor_matches_rowmajor_bitwise_full_domain():
+    """Order pin for the kmajor fulltile path.
+
+    Full-entropy e5m2 data makes every fp32 partial sum order-sensitive, so
+    bitwise agreement between the kmajor fulltile pipeline and the rowmajor
+    serial path pins their per-element K-atom accumulation order to be
+    identical. The rowmajor path is itself pinned bitwise against CUTLASS
+    on this band (see the maint evaluation), so the pin is transitive.
+    Exact-sum data (the other kmajor tests) is blind to any reordering by
+    construction - this test is the one that would catch it.
+    """
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 256
+    K = 512
+    block_K = 128
+
+    A = torch.randint(0, 256, (M, K), device="cuda", dtype=torch.uint8).view(torch.float8_e5m2)
+    B = torch.randint(0, 256, (N, K), device="cuda", dtype=torch.uint8).view(torch.float8_e5m2)
+    sfa_bytes = _make_varying_scale_bytes(M, K)
+    sfb_bytes = _make_varying_scale_bytes(N, K)
+
+    rowmajor = tilelang.compile(
+        _make_mxf8_matmul_kernel(M, N, K, T.float8_e5m2, T.float8_e5m2, block_K=block_K),
+        target="cuda",
+        out_idx=[4],
+    )
+    C_row = rowmajor(A, B, _pack_scale_words(sfa_bytes), _pack_scale_words(sfb_bytes))
+
+    module, kmajor = _example_kmajor_kernel(M, N, K, block_K, "e5m2")
+    words = block_K // 128
+    SFA_km = module.swizzle_blockscaled_chunk_kmajor_scale_words(_pack_scale_words(sfa_bytes), block_words=words).reshape(-1, words)
+    SFB_km = module.swizzle_blockscaled_chunk_kmajor_scale_words(_pack_scale_words(sfb_bytes), block_words=words).reshape(-1, words)
+    C_km = torch.empty((M, N), device="cuda", dtype=torch.float32)
+    kmajor(A, B, SFA_km, SFB_km, C_km)
+
+    # Strict integer-view equality: identical instruction and atom order
+    # must reproduce NaN payloads too.
+    assert torch.equal(C_row.view(torch.int32), C_km.view(torch.int32))
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize(
+    "sfa_byte,sfb_byte,expected_bits",
+    [
+        # scale product 2^127 * 2^127 = 2^254 overflows fp32 -> +Inf.
+        (0xFE, 0xFE, 0x7F800000),
+        # 2^127 * 1 stays at the top of the normal range, exact.
+        (0xFE, 0x7F, 0x7F000000),
+        # 2^-127 * 1 lands in the fp32 SUBNORMAL range and is preserved
+        # exactly - the datapath does NOT flush to zero.
+        (0x00, 0x7F, 0x00400000),
+        # 2^-127 * 2^-127 = 2^-254 underflows to +0.
+        (0x00, 0x00, 0x00000000),
+        # 2^-126 * 1: the smallest normal, exact.
+        (0x01, 0x7F, 0x00800000),
+    ],
+)
+def test_mxf8f6f4_extreme_scale_semantics(sfa_byte, sfb_byte, expected_bits):
+    """Recorded datapath behavior at the UE8M0 extremes.
+
+    A single a=1, b=1 product isolates the scale product itself. Every
+    expected bit pattern below was cross-checked bitwise against CUTLASS
+    4.7.0 on RTX PRO 6000 (full-matrix integer-view equality), including
+    the subnormal-preservation case. Note UE8M0 cannot encode zero: 0x00
+    is 2^-127, not 0.
+    """
+    import torch
+
+    M = N = 128
+    K = 128
+    kernel = tilelang.compile(
+        _make_mxf8_matmul_kernel(M, N, K, T.float8_e4m3fn, T.float8_e4m3fn),
+        target="cuda",
+        out_idx=[4],
+    )
+    A = torch.zeros(M, K, device="cuda").to(torch.float8_e4m3fn)
+    B = torch.zeros(N, K, device="cuda").to(torch.float8_e4m3fn)
+    A[0, 0] = 1.0
+    B[0, 0] = 1.0
+    sfa = torch.full((M, K // 32), 127, device="cuda", dtype=torch.uint8)
+    sfb = torch.full((N, K // 32), 127, device="cuda", dtype=torch.uint8)
+    sfa[0, 0] = sfa_byte
+    sfb[0, 0] = sfb_byte
+    C = kernel(A, B, _pack_scale_words(sfa), _pack_scale_words(sfb))
+    assert (C[0, 0].view(torch.int32).item() & 0xFFFFFFFF) == expected_bits
+    assert bool((C.flatten()[1:] == 0).all())
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize("a_name,min_subnormal", [("e4m3", 2.0**-9), ("e5m2", 2.0**-16)])
+def test_mxf8f6f4_subnormal_inputs_exact(a_name, min_subnormal):
+    """Deterministic fp8-subnormal coverage (only statistical before).
+
+    Subnormal x subnormal products land far below the fp8 normal range but
+    stay exact in fp32; with power-of-two scales every partial sum is exact
+    too, so the python reference holds at atol=0.
+    """
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 128
+    K = 128
+    dtype = getattr(T, _FP8_TORCH_DTYPES[a_name])
+    kernel = tilelang.compile(_make_mxf8_matmul_kernel(M, N, K, dtype, dtype), target="cuda", out_idx=[4])
+    # Rows mixing subnormals (1x..3x the minimum) with small normals.
+    steps = torch.randint(1, 4, (M, K), device="cuda", dtype=torch.int64)
+    A = (steps.to(torch.float32) * min_subnormal).to(_torch_fp8(a_name))
+    B = torch.randint(-2, 3, (N, K), device="cuda", dtype=torch.int64).to(torch.float32).to(_torch_fp8(a_name))
+    sfa_bytes = _make_varying_scale_bytes(M, K)
+    sfb_bytes = _make_varying_scale_bytes(N, K)
+    C = kernel(A, B, _pack_scale_words(sfa_bytes), _pack_scale_words(sfb_bytes))
+    ref = _reference_scaled_gemm(A, B, sfa_bytes, sfb_bytes)
+    torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_mxf8f6f4_scale_byte_0xff_on_b_side():
+    """The B-operand twin of the A-side 0xFF recording (distinct registers)."""
+    import torch
+
+    M = N = 128
+    K = 128
+    kernel = tilelang.compile(
+        _make_mxf8_matmul_kernel(M, N, K, T.float8_e4m3fn, T.float8_e4m3fn),
+        target="cuda",
+        out_idx=[4],
+    )
+    A, B = _make_controlled_fp8_inputs(M, N, K, "e4m3", "e4m3")
+    sfa_bytes = torch.full((M, K // 32), 127, device="cuda", dtype=torch.uint8)
+    sfb_bytes = sfa_bytes.clone()
+    sfb_bytes[7, 2] = 0xFF
+    C = kernel(A, B, _pack_scale_words(sfa_bytes), _pack_scale_words(sfb_bytes))
+    assert bool(torch.isnan(C[:, 7]).all())
+    mask = torch.ones(N, dtype=torch.bool)
+    mask[7] = False
+    assert bool(torch.isfinite(C[:, mask]).all())
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_mxf8f6f4_e4m3_nan_propagation():
+    """e4m3 has no Inf; its only special value (NaN, byte 0x7F) must poison."""
+    import torch
+
+    M = N = 128
+    K = 128
+    kernel = tilelang.compile(
+        _make_mxf8_matmul_kernel(M, N, K, T.float8_e4m3fn, T.float8_e4m3fn),
+        target="cuda",
+        out_idx=[4],
+    )
+    A = torch.ones((M, K), device="cuda", dtype=torch.float32).to(torch.float8_e4m3fn)
+    B = torch.ones((N, K), device="cuda", dtype=torch.float32).to(torch.float8_e4m3fn)
+    A[2, 9] = float("nan")
+    unit = torch.full((M, K // 128), 0x7F7F7F7F, device="cuda", dtype=torch.int64).to(torch.uint32)
+    C = kernel(A, B, unit, unit.clone())
+    assert bool(torch.isnan(C[2]).all())
+    mask = torch.ones(M, dtype=torch.bool)
+    mask[2] = False
+    assert bool(torch.isfinite(C[mask]).all())
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_mxf8f6f4_inf_minus_inf_yields_nan():
+    """Deterministic Inf + (-Inf) collision inside one accumulator chain."""
+    import torch
+
+    M = N = 128
+    K = 128
+    kernel = tilelang.compile(
+        _make_mxf8_matmul_kernel(M, N, K, T.float8_e5m2, T.float8_e5m2),
+        target="cuda",
+        out_idx=[4],
+    )
+    A = torch.ones((M, K), device="cuda", dtype=torch.float32).to(torch.float8_e5m2)
+    B = torch.ones((N, K), device="cuda", dtype=torch.float32).to(torch.float8_e5m2)
+    # Opposite-sign infinities in different k32 atoms of the same row.
+    A[0, 5] = float("inf")
+    A[0, 40] = float("-inf")
+    unit = torch.full((M, K // 128), 0x7F7F7F7F, device="cuda", dtype=torch.int64).to(torch.uint32)
+    C = kernel(A, B, unit, unit.clone())
+    assert bool(torch.isnan(C[0]).all())
+    assert bool(torch.isfinite(C[1:]).all())
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize("dtype_name", ["e4m3", "e5m2"])
+def test_mxf8f6f4_quantize_roundtrip_gemm(dtype_name):
+    """End-to-end plumbing pin: bf16 -> quantizer -> packed scales -> GEMM.
+
+    This is a tolerance test by necessity: real quantized data has mixed
+    magnitudes, so fp32 partial sums are rounded and the python reference
+    (torch matmul) does not share the MMA's intra-atom summation tree. The
+    tolerance is set for fp32 rounding-order noise only (~K * 2^-24
+    relative); any packing/layout mistake produces O(1) errors and fails.
+    """
+    import torch
+
+    from examples.dequantize_gemm.quantize import quantize_bf16_to_mxfp8_blockscaled
+
+    torch.manual_seed(0)
+    M = N = 128
+    K = 256
+    dtype = getattr(T, _FP8_TORCH_DTYPES[dtype_name])
+    kernel = tilelang.compile(_make_mxf8_matmul_kernel(M, N, K, dtype, dtype, block_K=128), target="cuda", out_idx=[4])
+
+    x_a = (torch.randn(M, K, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+    x_b = (torch.randn(N, K, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+    A, _, sfa_bytes = quantize_bf16_to_mxfp8_blockscaled(x_a, dtype=dtype_name, return_scale_bytes=True)
+    B, _, sfb_bytes = quantize_bf16_to_mxfp8_blockscaled(x_b, dtype=dtype_name, return_scale_bytes=True)
+
+    C = kernel(A, B, _pack_scale_words(sfa_bytes), _pack_scale_words(sfb_bytes))
+    ref = _reference_scaled_gemm(A, B, sfa_bytes, sfb_bytes)
+    # Measured rounding-order noise at this size/seed: max abs 1.5e-5 with
+    # 3.5% of entries differing; 1e-3 keeps ~60x headroom while a swapped
+    # scale byte or packing mistake still fails by orders of magnitude.
+    torch.testing.assert_close(C, ref, rtol=1e-5, atol=1e-3)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
@@ -221,7 +221,7 @@ def test_mxf8f6f4_unit_scale_matches_plain_fp8_gemm_bitwise(a_name, b_name):
     assert torch.equal(C_scaled.view(torch.int32), C_plain.view(torch.int32))
 
 
-def _example_kmajor_kernel(M, N, K, block_K, in_dtype_name, num_stages=2):
+def _example_kmajor_kernel(M, N, K, block_K, in_dtype_name, num_stages=2, b_dtype_name=None):
     import importlib.util
     from pathlib import Path
 
@@ -229,8 +229,35 @@ def _example_kmajor_kernel(M, N, K, block_K, in_dtype_name, num_stages=2):
     spec = importlib.util.spec_from_file_location("sm120_mxfp8_blockscaled_gemm_example", path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    kernel = module.sm120_mxfp8_blockscaled_gemm(M, N, K, 128, 128, block_K, num_stages, in_dtype_name, T.float32)
+    kernel = module.sm120_mxfp8_blockscaled_gemm(M, N, K, 128, 128, block_K, num_stages, in_dtype_name, T.float32, b_dtype_name)
     return module, kernel
+
+
+def _make_codec_discriminating_inputs(M, N, K):
+    """A/B values exact in exactly one fp8 format each.
+
+    A holds {9, 11, 13, 15} * signs: their mantissas need e4m3's third bit,
+    so the same bytes decode to different values under the e5m2 codec.
+    B holds {1024, 1280, 1536, 1792} * signs: above e4m3's 448 max, exact
+    only in e5m2. Any A/B dtype-mnemonic swap changes the decode and the
+    result; the [-4, 4] controlled band is blind to that by construction
+    (its bytes decode identically under both codecs).
+    """
+    import torch
+
+    a_vals = torch.tensor([9.0, 11.0, 13.0, 15.0, -9.0, -11.0, -13.0, -15.0], device="cuda")
+    b_vals = torch.tensor([1024.0, 1280.0, 1536.0, 1792.0, -1024.0, -1280.0, -1536.0, -1792.0], device="cuda")
+    a_floats = a_vals[torch.randint(0, 8, (M, K), device="cuda")]
+    b_floats = b_vals[torch.randint(0, 8, (N, K), device="cuda")]
+    A = a_floats.to(torch.float8_e4m3fn)
+    B = b_floats.to(torch.float8_e5m2)
+    # The values must round-trip exactly in their own format...
+    assert torch.equal(A.to(torch.float32), a_floats)
+    assert torch.equal(B.to(torch.float32), b_floats)
+    # ...and the same bytes must decode differently under the swapped codec.
+    assert not torch.equal(A.view(torch.uint8).view(torch.float8_e5m2).to(torch.float32), a_floats)
+    assert not torch.equal(B.view(torch.uint8).view(torch.float8_e4m3fn).to(torch.float32), b_floats)
+    return A, B
 
 
 @tilelang.testing.requires_cuda
@@ -619,6 +646,48 @@ def test_mxf8f6f4_rejects_out_of_family_operand_pairs():
     for a_dtype, b_dtype, pattern, _layer in cases:
         with pytest.raises(Exception, match=re.escape(pattern)):
             tilelang.compile(_make_mxf8_matmul_kernel(128, 128, 128, a_dtype, b_dtype), target="cuda", out_idx=[4])
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize("orientation", ["e4m3_x_e5m2", "e5m2_x_e4m3"])
+@pytest.mark.parametrize("path", ["rowmajor", "kmajor"])
+def test_mxf8f6f4_mixed_pair_codec_discrimination(orientation, path):
+    """Swap-mnemonic discrimination for the mixed fp8 pairs.
+
+    Scales stay in {1, 2} so every partial sum is an exact fp32 integer
+    (max |sum| ~ 13.8M < 2^24) and the python reference holds at atol=0.
+    """
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 256
+    K = 128
+    A, B = _make_codec_discriminating_inputs(M, N, K)
+    if orientation == "e5m2_x_e4m3":
+        # Swap roles: the e5m2-only values feed A, the e4m3-only values B.
+        A, B = B[:M].contiguous(), A[:N].contiguous()
+    a_name = "e4m3" if orientation == "e4m3_x_e5m2" else "e5m2"
+    b_name = "e5m2" if orientation == "e4m3_x_e5m2" else "e4m3"
+    sfa_bytes = (torch.randint(0, 2, (M, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+    sfb_bytes = (torch.randint(0, 2, (N, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+
+    if path == "rowmajor":
+        kernel = tilelang.compile(
+            _make_mxf8_matmul_kernel(M, N, K, getattr(T, _FP8_TORCH_DTYPES[a_name]), getattr(T, _FP8_TORCH_DTYPES[b_name])),
+            target="cuda",
+            out_idx=[4],
+        )
+        C = kernel(A, B, _pack_scale_words(sfa_bytes), _pack_scale_words(sfb_bytes))
+    else:
+        module, kernel = _example_kmajor_kernel(M, N, K, 128, a_name, b_dtype_name=b_name)
+        SFA = module.swizzle_blockscaled_chunk_kmajor_scale_words(_pack_scale_words(sfa_bytes), block_words=1).reshape(-1, 1)
+        SFB = module.swizzle_blockscaled_chunk_kmajor_scale_words(_pack_scale_words(sfb_bytes), block_words=1).reshape(-1, 1)
+        C = torch.empty((M, N), device="cuda", dtype=torch.float32)
+        kernel(A, B, SFA, SFB, C)
+
+    ref = _reference_scaled_gemm(A, B, sfa_bytes, sfb_bytes)
+    torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
 
 
 if __name__ == "__main__":

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
@@ -640,7 +640,10 @@ def test_mxf8f6f4_rejects_out_of_family_operand_pairs():
         # (a_dtype, b_dtype, error pattern, rejecting layer)
         (T.float8_e4m3fn, T.bfloat16, "f8f6f4 family", "gemm-base family check"),
         (T.float8_e4m3fn, T.int8, "f8f6f4 family", "gemm-base family check"),
-        (T.float8_e4m3fn, T.float4_e2m1fn, "same operand width family", "lowering width check"),
+        # PACKED fp4 stays rejected as an mxf8f6f4 partner - fp4 must use
+        # its unpacked smem form there (accepted, covered by the
+        # subbyte-operands test file).
+        (T.float8_e4m3fn, T.float4_e2m1fn, "packed float4_e2m1fn pair", "lowering kind inference"),
         (T.int8, T.int8, "expects a_dtype in", "emitter operand whitelist"),
     ]
     for a_dtype, b_dtype, pattern, _layer in cases:

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
@@ -644,7 +644,10 @@ def test_mxf8f6f4_rejects_out_of_family_operand_pairs():
         # its unpacked smem form there (accepted, covered by the
         # subbyte-operands test file).
         (T.float8_e4m3fn, T.float4_e2m1fn, "packed float4_e2m1fn pair", "lowering kind inference"),
-        (T.int8, T.int8, "expects a_dtype in", "emitter operand whitelist"),
+        # Since the slice-2 kind-inference rework, same-width non-family
+        # pairs are rejected one layer earlier (the emitter whitelist is now
+        # fully shadowed by lowering inference).
+        (T.int8, T.int8, "packed float4_e2m1fn pair", "lowering kind inference"),
     ]
     for a_dtype, b_dtype, pattern, _layer in cases:
         with pytest.raises(Exception, match=re.escape(pattern)):

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
@@ -1,0 +1,225 @@
+"""SM120 ``kind::mxf8f6f4`` (MXFP8) block-scaled MMA tests.
+
+Test data contract (two bands, both mandatory):
+
+- Controlled band: small-integer fp8 values and a narrow power-of-two scale
+  window, so every product and partial sum is exactly representable in fp32
+  (K * dynamic-range << 2^24) and assertions run at ``atol=0``.
+- Full code domain: random raw bytes, which for e5m2 naturally include
+  Inf/NaN. Assertions on that band are masked (isnan/isinf handled
+  separately); never shrink the data window to make an assertion pass.
+"""
+
+import pytest
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.transform import simplify_prim_func
+
+
+_FP8_TORCH_DTYPES = {"e4m3": "float8_e4m3fn", "e5m2": "float8_e5m2"}
+
+
+def _torch_fp8(name):
+    import torch
+
+    return {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}[name]
+
+
+@simplify_prim_func
+def _make_mxf8_matmul_kernel(
+    M,
+    N,
+    K,
+    a_dtype,
+    b_dtype,
+    num_stages=1,
+    *,
+    block_M=64,
+    block_N=64,
+    block_K=128,
+):
+    accum_dtype = T.float32
+    scale_words_per_block_k = block_K // 128
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), a_dtype),
+        B: T.Tensor((N, K), b_dtype),
+        SFA: T.Tensor((M, K // 128), T.uint32),
+        SFB: T.Tensor((N, K // 128), T.uint32),
+        C: T.Tensor((M, N), accum_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), a_dtype, scope="shared.dyn")
+            B_shared = T.alloc_shared((block_N, block_K), b_dtype, scope="shared.dyn")
+            SFA_shared = T.alloc_shared((block_M, scale_words_per_block_k), T.uint32, scope="shared.dyn")
+            SFB_shared = T.alloc_shared((block_N, scale_words_per_block_k), T.uint32, scope="shared.dyn")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            if K // block_K > 1:
+                T.clear(C_local)
+            for ko in T.Pipelined((K // block_K), num_stages=num_stages):
+                for i, k in T.Parallel(block_M, block_K):
+                    A_shared[i, k] = A[by * block_M + i, ko * block_K + k]
+                for j, k in T.Parallel(block_N, block_K):
+                    B_shared[j, k] = B[bx * block_N + j, ko * block_K + k]
+                for i, k in T.Parallel(block_M, scale_words_per_block_k):
+                    SFA_shared[i, k] = SFA[by * block_M + i, ko * scale_words_per_block_k + k]
+                for j, k in T.Parallel(block_N, scale_words_per_block_k):
+                    SFB_shared[j, k] = SFB[bx * block_N + j, ko * scale_words_per_block_k + k]
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=(K // block_K == 1),
+                    # rowmajor scale addressing is relative to the staged
+                    # per-ko slice (buffer-local).
+                    k_start=0,
+                    sf_a_granularity_k=32,
+                    sf_b_granularity_k=32,
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+@simplify_prim_func
+def _make_plain_fp8_matmul_kernel(M, N, K, a_dtype, b_dtype, *, block_M=64, block_N=64, block_K=128):
+    accum_dtype = T.float32
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), a_dtype),
+        B: T.Tensor((N, K), b_dtype),
+        C: T.Tensor((M, N), accum_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), a_dtype, scope="shared.dyn")
+            B_shared = T.alloc_shared((block_N, block_K), b_dtype, scope="shared.dyn")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            T.clear(C_local)
+            for ko in T.Pipelined((K // block_K), num_stages=1):
+                for i, k in T.Parallel(block_M, block_K):
+                    A_shared[i, k] = A[by * block_M + i, ko * block_K + k]
+                for j, k in T.Parallel(block_N, block_K):
+                    B_shared[j, k] = B[bx * block_N + j, ko * block_K + k]
+                T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _pack_scale_words(scale_bytes):
+    import torch
+
+    s = scale_bytes.to(torch.int64).reshape(scale_bytes.shape[0], -1, 4)
+    w = s[:, :, 0] | (s[:, :, 1] << 8) | (s[:, :, 2] << 16) | (s[:, :, 3] << 24)
+    return w.to(torch.uint32).contiguous()
+
+
+def _make_controlled_fp8_inputs(M, N, K, a_name, b_name):
+    """Small integers, exactly representable in both fp8 formats."""
+    import torch
+
+    A = torch.randint(-4, 5, (M, K), device="cuda", dtype=torch.float32).to(_torch_fp8(a_name))
+    B = torch.randint(-4, 5, (N, K), device="cuda", dtype=torch.float32).to(_torch_fp8(b_name))
+    return A, B
+
+
+def _make_varying_scale_bytes(rows, K):
+    """UE8M0 bytes from {0x7E, 0x7F, 0x80} = scales {0.5, 1, 2}."""
+    import torch
+
+    return (torch.randint(-1, 2, (rows, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+
+
+def _reference_scaled_gemm(A, B, sfa_bytes, sfb_bytes):
+    import torch
+
+    sa = torch.pow(2.0, sfa_bytes.to(torch.int32).float() - 127).repeat_interleave(32, dim=1)
+    sb = torch.pow(2.0, sfb_bytes.to(torch.int32).float() - 127).repeat_interleave(32, dim=1)
+    return (A.to(torch.float32) * sa) @ (B.to(torch.float32) * sb).T
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize("a_name,b_name", [("e4m3", "e4m3"), ("e4m3", "e5m2"), ("e5m2", "e4m3"), ("e5m2", "e5m2")])
+def test_mxf8f6f4_mma_block_scale_codegen(a_name, b_name):
+    kernel = tilelang.compile(
+        _make_mxf8_matmul_kernel(128, 128, 128, getattr(T, _FP8_TORCH_DTYPES[a_name]), getattr(T, _FP8_TORCH_DTYPES[b_name])),
+        target="cuda",
+        out_idx=[4],
+    )
+    src = kernel.get_kernel_source()
+    assert "tl::SM120MmaBlockScaledKind::kMxf8f6f4" in src
+    assert "tl::SM120MmaScaleType::kUE8M0" in src
+    enum_of = {"e4m3": "kE4M3", "e5m2": "kE5M2"}
+    assert f"tl::SM120MmaOperandType::{enum_of[a_name]}, tl::SM120MmaOperandType::{enum_of[b_name]}>" in src
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize("a_name,b_name", [("e4m3", "e4m3"), ("e4m3", "e5m2"), ("e5m2", "e4m3"), ("e5m2", "e5m2")])
+@pytest.mark.parametrize("K,block_K", [(128, 128), (256, 128), (512, 256)])
+def test_mxf8f6f4_mma_block_scale_rowmajor_correctness(a_name, b_name, K, block_K):
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 128
+    kernel = tilelang.compile(
+        _make_mxf8_matmul_kernel(M, N, K, getattr(T, _FP8_TORCH_DTYPES[a_name]), getattr(T, _FP8_TORCH_DTYPES[b_name]), block_K=block_K),
+        target="cuda",
+        out_idx=[4],
+    )
+    A, B = _make_controlled_fp8_inputs(M, N, K, a_name, b_name)
+    sfa_bytes = _make_varying_scale_bytes(M, K)
+    sfb_bytes = _make_varying_scale_bytes(N, K)
+    C = kernel(A, B, _pack_scale_words(sfa_bytes), _pack_scale_words(sfb_bytes))
+    ref = _reference_scaled_gemm(A, B, sfa_bytes, sfb_bytes)
+    torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+# Same-dtype pairs only: the generic T.gemm still rejects mixed fp8
+# operands, so mixed pairs have no plain-MMA oracle; they are covered by the
+# controlled-band python-reference tests above.
+@pytest.mark.parametrize("a_name,b_name", [("e4m3", "e4m3"), ("e5m2", "e5m2")])
+def test_mxf8f6f4_unit_scale_matches_plain_fp8_gemm_bitwise(a_name, b_name):
+    """The unit-scale (SF = 0x7F = 1.0) fast-path oracle.
+
+    kind::mxf8f6f4.block_scale with unit scales is numerically identical to
+    the plain fp8 MMA the generic T.gemm emits, and both paths accumulate K
+    in the same order, so the comparison is bitwise. Data is the full fp8
+    code domain (random raw bytes; e5m2 includes Inf/NaN), compared through
+    an integer view so NaN bit patterns participate.
+    """
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 128
+    K = 256
+    a_dtype = getattr(T, _FP8_TORCH_DTYPES[a_name])
+    b_dtype = getattr(T, _FP8_TORCH_DTYPES[b_name])
+    scaled = tilelang.compile(_make_mxf8_matmul_kernel(M, N, K, a_dtype, b_dtype), target="cuda", out_idx=[4])
+    plain = tilelang.compile(_make_plain_fp8_matmul_kernel(M, N, K, a_dtype, b_dtype), target="cuda", out_idx=[2])
+
+    A = torch.randint(0, 256, (M, K), device="cuda", dtype=torch.uint8).view(_torch_fp8(a_name))
+    B = torch.randint(0, 256, (N, K), device="cuda", dtype=torch.uint8).view(_torch_fp8(b_name))
+    unit = torch.full((M, K // 128), 0x7F7F7F7F, device="cuda", dtype=torch.int64).to(torch.uint32)
+
+    C_scaled = scaled(A, B, unit, torch.full((N, K // 128), 0x7F7F7F7F, device="cuda", dtype=torch.int64).to(torch.uint32))
+    C_plain = plain(A, B)
+    assert torch.equal(C_scaled.view(torch.int32), C_plain.view(torch.int32))
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
@@ -221,5 +221,149 @@ def test_mxf8f6f4_unit_scale_matches_plain_fp8_gemm_bitwise(a_name, b_name):
     assert torch.equal(C_scaled.view(torch.int32), C_plain.view(torch.int32))
 
 
+def _example_kmajor_kernel(M, N, K, block_K, in_dtype_name, num_stages=2):
+    import importlib.util
+    from pathlib import Path
+
+    path = Path(__file__).resolve().parents[3] / "examples/gemm_sm120/sm120_mxfp8_blockscaled_gemm.py"
+    spec = importlib.util.spec_from_file_location("sm120_mxfp8_blockscaled_gemm_example", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    kernel = module.sm120_mxfp8_blockscaled_gemm(M, N, K, 128, 128, block_K, num_stages, in_dtype_name, T.float32)
+    return module, kernel
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize("in_dtype_name", ["e4m3", "e5m2"])
+def test_mxf8f6f4_kmajor_fulltile_correctness(in_dtype_name):
+    """The performance path: blockscaled_chunk_kmajor fulltile, packed scales."""
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 256
+    K = 512
+    block_K = 128
+    module, kernel = _example_kmajor_kernel(M, N, K, block_K, in_dtype_name)
+
+    A = module._make_fp8(M, K, in_dtype_name, seed=0)
+    B = module._make_fp8(N, K, in_dtype_name, seed=1)
+    SFA_semantic = module._make_pow2_scale_words(M, K, seed=100)
+    SFB_semantic = module._make_pow2_scale_words(N, K, seed=200)
+    words = block_K // 128
+    SFA = module.swizzle_blockscaled_chunk_kmajor_scale_words(SFA_semantic, block_words=words).reshape(-1, words)
+    SFB = module.swizzle_blockscaled_chunk_kmajor_scale_words(SFB_semantic, block_words=words).reshape(-1, words)
+    C = torch.empty((M, N), device="cuda", dtype=torch.float32)
+    kernel(A, B, SFA, SFB, C)
+    module._verify(A, B, SFA_semantic, SFB_semantic, C, torch.float32)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_mxf8f6f4_kmajor_scale_byte_literal_sequence():
+    """Self-failing sentinel for the fulltile scale-byte stride.
+
+    scale_vec::1X consumes one byte per k32 block, so the four unrolled
+    kblocks of a K=128 word must select bytes exactly (0, 1, 2, 3). The
+    pre-fix hardcoded ``* 2`` stride would produce (0, 2, 4, 6) and fail
+    both assertions below.
+    """
+    import re
+
+    _, kernel = _example_kmajor_kernel(128, 128, 128, 128, "e4m3")
+    src = kernel.get_kernel_source()
+    calls = re.findall(r"kMxf8f6f4[^;]+;", src)
+    assert calls, "no mxf8f6f4 mma calls found in the generated source"
+    for call in calls:
+        args = re.findall(r"static_cast<uint16_t>\((.*?)\)[,)]", " ".join(call.split()))
+        assert len(args) == 4, call  # byte_a, tid_a, byte_b, tid_b
+        byte_expr = args[0]
+        assert byte_expr == args[2]
+        # The non-greedy capture can trim trailing parens; rebalance.
+        byte_expr += ")" * (byte_expr.count("(") - byte_expr.count(")"))
+        # The byte id is an expression in the kblock loop variable; evaluate
+        # it over the four kblocks of one K=128 scale word.
+        symbols = set(re.findall(r"[A-Za-z_]\w*", byte_expr))
+        assert len(symbols) == 1, byte_expr
+        (kvar,) = symbols
+        seq = tuple(eval(byte_expr, {"__builtins__": {}}, {kvar: kb}) for kb in range(4))
+        assert seq == (0, 1, 2, 3), seq
+        assert max(seq) < 4
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_mxf8f6f4_e5m2_inf_nan_propagation():
+    """Full-code-domain band: e5m2 Inf/NaN must propagate through the MMA."""
+    import torch
+
+    M = N = 128
+    K = 128
+    kernel = tilelang.compile(
+        _make_mxf8_matmul_kernel(M, N, K, T.float8_e5m2, T.float8_e5m2),
+        target="cuda",
+        out_idx=[4],
+    )
+    A = torch.ones((M, K), device="cuda", dtype=torch.float32).to(torch.float8_e5m2)
+    B = torch.ones((N, K), device="cuda", dtype=torch.float32).to(torch.float8_e5m2)
+    A[0, 5] = float("inf")
+    A[1, 7] = float("nan")
+    unit = torch.full((M, K // 128), 0x7F7F7F7F, device="cuda", dtype=torch.int64).to(torch.uint32)
+    C = kernel(A, B, unit, unit.clone())
+    assert bool(torch.isinf(C[0]).all())  # inf * 1 accumulates to inf
+    assert bool(torch.isnan(C[1]).all())  # nan poisons the whole row
+    assert bool(torch.isfinite(C[2:]).all())
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_mxf8f6f4_scale_byte_0xff_yields_nan():
+    """Recorded behavior: UE8M0 0xFF is the NaN scale encoding.
+
+    The instruction propagates it as NaN into every product of the scaled
+    block, poisoning the affected accumulator rows.
+    """
+    import torch
+
+    M = N = 128
+    K = 128
+    kernel = tilelang.compile(
+        _make_mxf8_matmul_kernel(M, N, K, T.float8_e4m3fn, T.float8_e4m3fn),
+        target="cuda",
+        out_idx=[4],
+    )
+    A, B = _make_controlled_fp8_inputs(M, N, K, "e4m3", "e4m3")
+    sfa_bytes = torch.full((M, K // 32), 127, device="cuda", dtype=torch.uint8)
+    sfb_bytes = sfa_bytes.clone()
+    sfa_bytes[3, 1] = 0xFF
+    C = kernel(A, B, _pack_scale_words(sfa_bytes), _pack_scale_words(sfb_bytes))
+    assert bool(torch.isnan(C[3]).all())
+    mask = torch.ones(M, dtype=torch.bool)
+    mask[3] = False
+    assert bool(torch.isfinite(C[mask]).all())
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_mxf8f6f4_many_tiles_many_stages_correctness():
+    """Scale coverage: total_tiles (1024) > SM count, k stages > 2."""
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 2048
+    K = 384
+    kernel = tilelang.compile(
+        _make_mxf8_matmul_kernel(M, N, K, T.float8_e4m3fn, T.float8_e4m3fn, num_stages=3, block_K=128),
+        target="cuda",
+        out_idx=[4],
+    )
+    A, B = _make_controlled_fp8_inputs(M, N, K, "e4m3", "e4m3")
+    sfa_bytes = _make_varying_scale_bytes(M, K)
+    sfb_bytes = _make_varying_scale_bytes(N, K)
+    C = kernel(A, B, _pack_scale_words(sfa_bytes), _pack_scale_words(sfb_bytes))
+    ref = _reference_scaled_gemm(A, B, sfa_bytes, sfb_bytes)
+    torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
@@ -564,11 +564,14 @@ def test_mxf8f6f4_inf_minus_inf_yields_nan():
 def test_mxf8f6f4_quantize_roundtrip_gemm(dtype_name):
     """End-to-end plumbing pin: bf16 -> quantizer -> packed scales -> GEMM.
 
-    This is a tolerance test by necessity: real quantized data has mixed
-    magnitudes, so fp32 partial sums are rounded and the python reference
-    (torch matmul) does not share the MMA's intra-atom summation tree. The
-    tolerance is set for fp32 rounding-order noise only (~K * 2^-24
-    relative); any packing/layout mistake produces O(1) errors and fails.
+    A tolerance test, because the only oracle available in CI is a torch
+    matmul, which does not share the MMA's intra-atom summation tree on
+    real (mixed-magnitude) quantized data. The exact version of this check
+    is the "quantized band" in correctness_evaluation_mxf8_vs_cutlass.py:
+    the same quantizer output through both engines is bitwise-equal, no
+    tolerance involved. Here the tolerance is sized for fp32
+    rounding-order noise only; any packing/layout mistake produces O(1)
+    errors and fails.
     """
     import torch
 

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_mma_block_scale.py
@@ -596,5 +596,30 @@ def test_mxf8f6f4_quantize_roundtrip_gemm(dtype_name):
     torch.testing.assert_close(C, ref, rtol=1e-5, atol=1e-3)
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_mxf8f6f4_rejects_out_of_family_operand_pairs():
+    """Negative pins for the mixed-dtype guards (three layers).
+
+    allow_f8f6f4_mixed_dtypes opens the door for {e4m3, e5m2} pairings
+    only in effect: out-of-family partners must still be rejected -
+    by the gemm-base family check (bf16, int8), by the lowering
+    same-width check (fp8 x fp4), or by the emitter operand whitelist
+    (same-width non-fp8 pairs).
+    """
+    import re
+
+    cases = [
+        # (a_dtype, b_dtype, error pattern, rejecting layer)
+        (T.float8_e4m3fn, T.bfloat16, "f8f6f4 family", "gemm-base family check"),
+        (T.float8_e4m3fn, T.int8, "f8f6f4 family", "gemm-base family check"),
+        (T.float8_e4m3fn, T.float4_e2m1fn, "same operand width family", "lowering width check"),
+        (T.int8, T.int8, "expects a_dtype in", "emitter operand whitelist"),
+    ]
+    for a_dtype, b_dtype, pattern, _layer in cases:
+        with pytest.raises(Exception, match=re.escape(pattern)):
+            tilelang.compile(_make_mxf8_matmul_kernel(128, 128, 128, a_dtype, b_dtype), target="cuda", out_idx=[4])
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
@@ -870,11 +870,12 @@ def test_w6a8_example_synthetic_band_bitwise(a_name, b_flavor, shape):
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_eq(12, 0)
 def test_w6a8_example_su6_engaged_and_compression():
-    """W6A8 acceptance A3 + A4: su6 path engaged (no shift call), 0.75 B/elem."""
+    """W6A8 acceptance A3 + A4: TMA + su6 engaged (no shift), 0.75 B/elem."""
     module = _load_w6a8_example()
     M = N = K = 256
     kernel, A, B, _, _, _ = _w6a8_example_run(module, M, N, K)
     src = kernel.get_kernel_source()
+    assert "tl::tma_load" in src  # 16U6_ALIGN16B producer engaged
     assert "tl::ptx_ldmatrix_su6_x" in src
     assert "tl::fp4_e2m1_container_shift" not in src  # fp6 containers need no shift
     assert ", tl::SM120MmaOperandType::kE3M2>" in src
@@ -916,3 +917,85 @@ def test_w6a8_example_quantize_band():
     b_dec = module._decode_fp6_blob(B_cpu.cuda(), N, K, "e3m2")
     ref = (A.to(torch.float32) * scale(sfa_bytes)) @ (b_dec * scale(sfb_bytes).cuda()).T
     torch.testing.assert_close(C, ref, rtol=1e-5, atol=1e-3)
+
+
+@simplify_prim_func
+def _make_a8w6_tma_matmul_kernel(M, N, K, a_dtype, num_stages=2, *, block_M=64, block_N=64, block_K=128):
+    """A8W6 with the 16U6_ALIGN16B TMA producer on the fp6 B operand.
+
+    B is declared as a packed float6 GLOBAL tensor (fed as a uint8 blob of
+    N*K*3/4 bytes through the sub-byte binder bypass); the TMA unpacks it
+    into the padded smem form the su6 ldmatrix consumes.
+    """
+    accum_dtype = T.float32
+    scale_words = block_K // 128
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), a_dtype),
+        B: T.Tensor((N, K), T.float6_e3m2fn),
+        SFA: T.Tensor((M, K // 128), T.uint32),
+        SFB: T.Tensor((N, K // 128), T.uint32),
+        C: T.Tensor((M, N), accum_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), a_dtype, scope="shared.dyn")
+            B_shared = T.alloc_shared((block_N, block_K), T.float6_e3m2fn_unpacked, scope="shared.dyn")
+            SFA_shared = T.alloc_shared((block_M, scale_words), T.uint32, scope="shared.dyn")
+            SFB_shared = T.alloc_shared((block_N, scale_words), T.uint32, scope="shared.dyn")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            if K // block_K > 1:
+                T.clear(C_local)
+            for ko in T.Pipelined((K // block_K), num_stages=num_stages):
+                T.copy(A[by * block_M, ko * block_K], A_shared)
+                T.copy(B[bx * block_N, ko * block_K], B_shared)
+                for i, w in T.Parallel(block_M, scale_words):
+                    SFA_shared[i, w] = SFA[by * block_M + i, ko * scale_words + w]
+                for j, w in T.Parallel(block_N, scale_words):
+                    SFB_shared[j, w] = SFB[bx * block_N + j, ko * scale_words + w]
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=(K // block_K == 1),
+                    k_start=0,
+                    sf_a_granularity_k=32,
+                    sf_b_granularity_k=32,
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_a8w6_tma_producer_matches_simt_producer_bitwise():
+    """S9 acceptance: the 16U6_ALIGN16B TMA unpack must stage byte-identical
+    smem to the SIMT padded-group fp6 producer."""
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 128
+    K = 256
+    tma = tilelang.compile(_make_a8w6_tma_matmul_kernel(M, N, K, T.float8_e4m3fn), target="cuda", out_idx=[4])
+    device_src = tma.get_kernel_source()
+    assert "tl::tma_load" in device_src
+    assert "tl::ptx_ldmatrix_su6_x" in device_src
+
+    simt = tilelang.compile(_make_family_matmul_kernel(M, N, K, "e4m3", "e3m2"), target="cuda", out_idx=[4])
+
+    A = torch.randint(-4, 5, (M, K), device="cuda", dtype=torch.float32).to(torch.float8_e4m3fn)
+    B_blob = torch.randint(0, 256, (N, K * 3 // 4), device="cuda", dtype=torch.uint8)
+    sfa_bytes = (torch.randint(0, 2, (M, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+    sfb_bytes = (torch.randint(0, 2, (N, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+    SFA = _pack_scale_words(sfa_bytes)
+    SFB = _pack_scale_words(sfb_bytes)
+
+    C_tma = tma(A, B_blob.view(torch.int8), SFA, SFB)
+    C_simt = simt(A, B_blob, SFA, SFB)
+    assert torch.equal(C_tma.view(torch.int32), C_simt.view(torch.int32))

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
@@ -378,10 +378,6 @@ def test_w4a4_mxf8f6f4_rowmajor_correctness():
     torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
 
 
-if __name__ == "__main__":
-    tilelang.testing.main()
-
-
 @simplify_prim_func
 def _make_fp4_unpack_copy_kernel(rows, k_global, k_copy):
     @T.prim_func
@@ -873,7 +869,7 @@ def test_w6a8_example_su6_engaged_and_compression():
     """W6A8 acceptance A3 + A4: TMA + su6 engaged (no shift), 0.75 B/elem."""
     module = _load_w6a8_example()
     M = N = K = 256
-    kernel, A, B, _, _, _ = _w6a8_example_run(module, M, N, K)
+    kernel, _, B, _, _, _ = _w6a8_example_run(module, M, N, K)
     src = kernel.get_kernel_source()
     assert "tl::tma_load" in src  # 16U6_ALIGN16B producer engaged
     assert "tl::ptx_ldmatrix_su6_x" in src
@@ -999,3 +995,7 @@ def test_a8w6_tma_producer_matches_simt_producer_bitwise():
     C_tma = tma(A, B_blob.view(torch.int8), SFA, SFB)
     C_simt = simt(A, B_blob, SFA, SFB)
     assert torch.equal(C_tma.view(torch.int32), C_simt.view(torch.int32))
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
@@ -563,3 +563,74 @@ def test_w4a8_example_perf_smoke():
     ms = do_bench(lambda: kernel(A, B, SFA, SFB, C), warmup=10, rep=20)
     tflops = 2.0 * M * N * K / (ms * 1e-3) / 1e12
     assert tflops > 0
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_w4a8_kmajor_matches_rowmajor_bitwise_full_domain():
+    """Order pin for the W4A8 kmajor fulltile path.
+
+    Full-entropy data (random fp4 bytes x random e5m2 bytes incl. Inf/NaN)
+    makes every partial sum order-sensitive; strict integer-view equality
+    between the kmajor example kernel (TMA producer) and the rowmajor
+    serial kernel (SIMT producer) pins the K-atom accumulation order and
+    the NaN payloads across both pipelines and both producers at once.
+    """
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 256
+    K = 512
+    module = _load_w4a8_example()
+
+    A_bytes = torch.randint(0, 256, (M, K // 2), device="cuda", dtype=torch.uint8)
+    B = torch.randint(0, 256, (N, K), device="cuda", dtype=torch.uint8).view(torch.float8_e5m2)
+    sfa_bytes = (torch.randint(-1, 2, (M, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+    sfb_bytes = (torch.randint(-1, 2, (N, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+
+    rowmajor = tilelang.compile(_make_w4a8_matmul_kernel(M, N, K, T.float8_e5m2), target="cuda", out_idx=[4])
+    C_row = rowmajor(A_bytes, B, _pack_scale_words(sfa_bytes), _pack_scale_words(sfb_bytes))
+
+    kernel = module.sm120_w4a8_mxf8f6f4_gemm(M, N, K, 128, 128, 128, 2, "e5m2", T.float32)
+    SFA_km = module.swizzle_blockscaled_chunk_kmajor_scale_words(_pack_scale_words(sfa_bytes), block_words=1).reshape(-1, 1)
+    SFB_km = module.swizzle_blockscaled_chunk_kmajor_scale_words(_pack_scale_words(sfb_bytes), block_words=1).reshape(-1, 1)
+    C_km = torch.empty((M, N), device="cuda", dtype=torch.float32)
+    kernel(A_bytes.view(torch.int8), B, SFA_km, SFB_km, C_km)
+
+    assert torch.equal(C_row.view(torch.int32), C_km.view(torch.int32))
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize(
+    "sfa_byte,sfb_byte,expected_bits",
+    [
+        (0xFE, 0xFE, 0x7F800000),
+        (0xFE, 0x7F, 0x7F000000),
+        (0x00, 0x7F, 0x00400000),
+        (0x00, 0x00, 0x00000000),
+        (0x01, 0x7F, 0x00800000),
+    ],
+)
+def test_w4a8_extreme_scale_semantics(sfa_byte, sfb_byte, expected_bits):
+    """The UE8M0 extreme-scale recordings re-run with an fp4 A operand.
+
+    Same expected table as the pure-fp8 recordings (the scale datapath is
+    operand-format independent) - re-measured here rather than assumed.
+    """
+    import torch
+
+    M = N = 128
+    K = 128
+    kernel = tilelang.compile(_make_w4a8_matmul_kernel(M, N, K, T.float8_e4m3fn), target="cuda", out_idx=[4])
+    A_bytes = torch.zeros((M, K // 2), device="cuda", dtype=torch.uint8)
+    A_bytes[0, 0] = 0x02  # element k=0 (low nibble) = e2m1 code for 1.0
+    B = torch.zeros((N, K), device="cuda", dtype=torch.float32).to(torch.float8_e4m3fn)
+    B[0, 0] = 1.0
+    sfa = torch.full((M, K // 32), 127, device="cuda", dtype=torch.uint8)
+    sfb = torch.full((N, K // 32), 127, device="cuda", dtype=torch.uint8)
+    sfa[0, 0] = sfa_byte
+    sfb[0, 0] = sfb_byte
+    C = kernel(A_bytes, B, _pack_scale_words(sfa), _pack_scale_words(sfb))
+    assert (C[0, 0].view(torch.int32).item() & 0xFFFFFFFF) == expected_bits
+    assert bool((C.flatten()[1:] == 0).all())

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
@@ -634,3 +634,285 @@ def test_w4a8_extreme_scale_semantics(sfa_byte, sfb_byte, expected_bits):
     C = kernel(A_bytes, B, _pack_scale_words(sfa), _pack_scale_words(sfb))
     assert (C[0, 0].view(torch.int32).item() & 0xFFFFFFFF) == expected_bits
     assert bool((C.flatten()[1:] == 0).all())
+
+
+_FAMILY_SPECS = {
+    # name -> (tilelang smem dtype attr, global form, torch feed)
+    "e4m3": ("float8_e4m3fn", "fp8", None),
+    "e5m2": ("float8_e5m2", "fp8", None),
+    "e2m1": ("float4_e2m1_unpacked", "fp4_blob", None),
+    "e2m3": ("float6_e2m3fn_unpacked", "fp6_blob", None),
+    "e3m2": ("float6_e3m2fn_unpacked", "fp6_blob", None),
+}
+
+
+@simplify_prim_func
+def _make_family_matmul_kernel(M, N, K, a_spec, b_spec, *, block_M=64, block_N=64, block_K=128):
+    """Rowmajor kernel over any f8f6f4-family operand pair.
+
+    fp8 operands are normal fp8 tensors; fp4 is a packed uint8 blob (2
+    elems/byte -> 8-byte payload per 16-element smem group); fp6 is a packed
+    uint8 blob (LSB-first 6-bit stream, 4 elems/3 bytes -> 12-byte payload
+    per group). SIMT producers write the b4x16_p64 / b6x16_p32 padded forms.
+    """
+    accum_dtype = T.float32
+    scale_words = block_K // 128
+
+    def global_decl(name, rows, spec):
+        form = _FAMILY_SPECS[spec][1]
+        if form == "fp8":
+            return T.Tensor((rows, K), getattr(T, _FAMILY_SPECS[spec][0]))
+        if form == "fp4_blob":
+            return T.Tensor((rows, K // 2), T.uint8)
+        return T.Tensor((rows, K * 3 // 4), T.uint8)
+
+    a_smem_dtype = getattr(T, _FAMILY_SPECS[a_spec][0])
+    b_smem_dtype = getattr(T, _FAMILY_SPECS[b_spec][0])
+    a_form = _FAMILY_SPECS[a_spec][1]
+    b_form = _FAMILY_SPECS[b_spec][1]
+
+    @T.prim_func
+    def main(
+        A: global_decl("A", M, a_spec),
+        B: global_decl("B", N, b_spec),
+        SFA: T.Tensor((M, K // 128), T.uint32),
+        SFB: T.Tensor((N, K // 128), T.uint32),
+        C: T.Tensor((M, N), accum_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), a_smem_dtype, scope="shared.dyn")
+            B_shared = T.alloc_shared((block_N, block_K), b_smem_dtype, scope="shared.dyn")
+            SFA_shared = T.alloc_shared((block_M, scale_words), T.uint32, scope="shared.dyn")
+            SFB_shared = T.alloc_shared((block_N, scale_words), T.uint32, scope="shared.dyn")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            if K // block_K > 1:
+                T.clear(C_local)
+            for ko in T.Pipelined((K // block_K), num_stages=1):
+                if a_form == "fp8":
+                    for i, k in T.Parallel(block_M, block_K):
+                        A_shared[i, k] = A[by * block_M + i, ko * block_K + k]
+                elif a_form == "fp4_blob":
+                    for i, g, j in T.Parallel(block_M, block_K // 16, 8):
+                        A_shared[i, 16 * g + j] = T.reinterpret(a_smem_dtype, A[by * block_M + i, ko * (block_K // 2) + 8 * g + j])
+                else:
+                    for i, g, j in T.Parallel(block_M, block_K // 16, 12):
+                        A_shared[i, 16 * g + j] = T.reinterpret(a_smem_dtype, A[by * block_M + i, ko * (block_K * 3 // 4) + 12 * g + j])
+                if b_form == "fp8":
+                    for i, k in T.Parallel(block_N, block_K):
+                        B_shared[i, k] = B[bx * block_N + i, ko * block_K + k]
+                elif b_form == "fp4_blob":
+                    for i, g, j in T.Parallel(block_N, block_K // 16, 8):
+                        B_shared[i, 16 * g + j] = T.reinterpret(b_smem_dtype, B[bx * block_N + i, ko * (block_K // 2) + 8 * g + j])
+                else:
+                    for i, g, j in T.Parallel(block_N, block_K // 16, 12):
+                        B_shared[i, 16 * g + j] = T.reinterpret(b_smem_dtype, B[bx * block_N + i, ko * (block_K * 3 // 4) + 12 * g + j])
+                for i, w in T.Parallel(block_M, scale_words):
+                    SFA_shared[i, w] = SFA[by * block_M + i, ko * scale_words + w]
+                for j, w in T.Parallel(block_N, scale_words):
+                    SFB_shared[j, w] = SFB[bx * block_N + j, ko * scale_words + w]
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=(K // block_K == 1),
+                    k_start=0,
+                    sf_a_granularity_k=32,
+                    sf_b_granularity_k=32,
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _family_data(spec, rows, K, controlled=True):
+    """Returns (feed_tensor, decoded_float32) for one operand."""
+    import torch
+
+    from examples.dequantize_gemm.quantize import decode_fp6_values, unpack_fp6_bytes
+
+    form = _FAMILY_SPECS[spec][1]
+    if form == "fp8":
+        tdt = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}[spec]
+        t = torch.randint(-4, 5, (rows, K), device="cuda", dtype=torch.float32).to(tdt)
+        return t, t.to(torch.float32)
+    if form == "fp4_blob":
+        blob = torch.randint(0, 256, (rows, K // 2), device="cuda", dtype=torch.uint8)
+        return blob, _decode_packed_fp4(blob, rows, K)
+    blob = torch.randint(0, 256, (rows, K * 3 // 4), device="cuda", dtype=torch.uint8)
+    codes = unpack_fp6_bytes(blob.cpu(), K)
+    return blob, decode_fp6_values(codes, spec).cuda()
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize(
+    "a_spec,b_spec",
+    [
+        ("e4m3", "e2m3"),
+        ("e4m3", "e3m2"),
+        ("e5m2", "e3m2"),
+        ("e2m3", "e4m3"),
+        ("e3m2", "e3m2"),
+        ("e2m3", "e3m2"),
+        ("e3m2", "e2m1"),
+        ("e2m1", "e2m3"),
+    ],
+)
+def test_fp6_family_rowmajor_correctness(a_spec, b_spec):
+    """fp6 operands in every direction: vs fp8, fp6, and fp4 partners."""
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 128
+    K = 128
+    kernel = tilelang.compile(_make_family_matmul_kernel(M, N, K, a_spec, b_spec), target="cuda", out_idx=[4])
+    src = kernel.get_kernel_source()
+    enum_of = {"e2m1": "kE2M1", "e2m3": "kE2M3", "e3m2": "kE3M2", "e4m3": "kE4M3", "e5m2": "kE5M2"}
+    assert f"tl::SM120MmaOperandType::{enum_of[a_spec]}, tl::SM120MmaOperandType::{enum_of[b_spec]}>" in src
+    if "e2m3" in (a_spec, b_spec) or "e3m2" in (a_spec, b_spec):
+        assert "tl::ptx_ldmatrix_su6_x" in src
+
+    A, a_dec = _family_data(a_spec, M, K)
+    B, b_dec = _family_data(b_spec, N, K)
+    sfa_bytes = (torch.randint(0, 2, (M, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+    sfb_bytes = (torch.randint(0, 2, (N, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+    C = kernel(A, B, _pack_scale_words(sfa_bytes), _pack_scale_words(sfb_bytes))
+
+    sa = torch.pow(2.0, sfa_bytes.to(torch.int32).float() - 127).repeat_interleave(32, dim=1)
+    sb = torch.pow(2.0, sfb_bytes.to(torch.int32).float() - 127).repeat_interleave(32, dim=1)
+    ref = (a_dec * sa) @ (b_dec * sb).T
+    torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_fp6_flavor_codec_discrimination():
+    """e2m3 x e3m2 with values exact in exactly one flavor.
+
+    A carries 7.5-family values (need e2m3's third mantissa bit; e3m2
+    rounds them), B carries 16..28 (beyond e2m3's 7.5 max). A swapped
+    flavor mnemonic changes the decode and fails the bitwise assert.
+    """
+    import torch
+
+    from examples.dequantize_gemm.quantize import decode_fp6_values, encode_fp6_values, pack_fp6_codes
+
+    torch.manual_seed(0)
+    M = N = 128
+    K = 128
+    a_vals = torch.tensor([7.5, 6.5, 5.5, -7.5, -6.5, -5.5, 3.75, -3.75], dtype=torch.float32)
+    b_vals = torch.tensor([16.0, 20.0, 24.0, 28.0, -16.0, -20.0, -24.0, -28.0], dtype=torch.float32)
+    # Self-check the discriminating power under the swapped codec.
+    assert not torch.equal(
+        decode_fp6_values(encode_fp6_values(a_vals, "e2m3"), "e2m3"), decode_fp6_values(encode_fp6_values(a_vals, "e2m3"), "e3m2")
+    )
+    assert torch.equal(decode_fp6_values(encode_fp6_values(a_vals, "e2m3"), "e2m3"), a_vals)
+    assert torch.equal(decode_fp6_values(encode_fp6_values(b_vals, "e3m2"), "e3m2"), b_vals)
+
+    a_floats = a_vals[torch.randint(0, 8, (M, K))]
+    b_floats = b_vals[torch.randint(0, 8, (N, K))]
+    A_blob = pack_fp6_codes(encode_fp6_values(a_floats, "e2m3")).cuda()
+    B_blob = pack_fp6_codes(encode_fp6_values(b_floats, "e3m2")).cuda()
+
+    kernel = tilelang.compile(_make_family_matmul_kernel(M, N, K, "e2m3", "e3m2"), target="cuda", out_idx=[4])
+    unit = torch.full((M, K // 128), 0x7F7F7F7F, device="cuda", dtype=torch.int64).to(torch.uint32)
+    C = kernel(A_blob, B_blob, unit, unit.clone())
+    ref = a_floats.cuda() @ b_floats.cuda().T
+    torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
+
+
+def _load_w6a8_example():
+    import importlib.util
+    from pathlib import Path
+
+    path = Path(__file__).resolve().parents[3] / "examples/gemm_sm120/sm120_w6a8_mxf8f6f4_gemm.py"
+    spec = importlib.util.spec_from_file_location("sm120_w6a8_mxf8f6f4_gemm_example", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _w6a8_example_run(module, M, N, K, a_name="e4m3", b_flavor="e3m2", seed=0):
+    import torch
+
+    kernel = module.sm120_w6a8_mxf8f6f4_gemm(M, N, K, 128, 128, 128, 2, a_name, b_flavor, T.float32)
+    A = module._make_fp8(M, K, a_name, seed=seed)
+    B = module._make_packed_fp6(N, K, seed=seed + 1)
+    SFA_semantic = module._make_pow2_scale_words(M, K, seed=seed + 100)
+    SFB_semantic = module._make_pow2_scale_words(N, K, seed=seed + 200)
+    SFA = module.swizzle_blockscaled_chunk_kmajor_scale_words(SFA_semantic, block_words=1).reshape(-1, 1)
+    SFB = module.swizzle_blockscaled_chunk_kmajor_scale_words(SFB_semantic, block_words=1).reshape(-1, 1)
+    C = torch.empty((M, N), device="cuda", dtype=torch.float32)
+    kernel(A, B, SFA, SFB, C)
+    return kernel, A, B, SFA_semantic, SFB_semantic, C
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize("a_name,b_flavor", [("e4m3", "e3m2"), ("e5m2", "e3m2"), ("e4m3", "e2m3")])
+@pytest.mark.parametrize("shape", [(1024, 1024, 1024), (768, 1024, 1536)])
+def test_w6a8_example_synthetic_band_bitwise(a_name, b_flavor, shape):
+    """W6A8 acceptance A1: default band, square and non-square, atol=0."""
+    import torch
+
+    torch.manual_seed(0)
+    module = _load_w6a8_example()
+    M, N, K = shape
+    _, A, B, SFA_semantic, SFB_semantic, C = _w6a8_example_run(module, M, N, K, a_name, b_flavor)
+    module._verify(A, B, SFA_semantic, SFB_semantic, C, torch.float32, b_flavor)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_w6a8_example_su6_engaged_and_compression():
+    """W6A8 acceptance A3 + A4: su6 path engaged (no shift call), 0.75 B/elem."""
+    module = _load_w6a8_example()
+    M = N = K = 256
+    kernel, A, B, _, _, _ = _w6a8_example_run(module, M, N, K)
+    src = kernel.get_kernel_source()
+    assert "tl::ptx_ldmatrix_su6_x" in src
+    assert "tl::fp4_e2m1_container_shift" not in src  # fp6 containers need no shift
+    assert ", tl::SM120MmaOperandType::kE3M2>" in src
+    assert B.element_size() * B.numel() == N * K * 3 // 4
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_w6a8_example_rejects_non_multiple_of_128_k():
+    """W6A8 acceptance A5."""
+    module = _load_w6a8_example()
+    with pytest.raises(Exception, match="multiple of 128"):
+        module.sm120_w6a8_mxf8f6f4_gemm(128, 128, 192, 128, 128, 64, 2, "e4m3", "e3m2", T.float32)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_w6a8_example_quantize_band():
+    """W6A8 acceptance A2: mxfp8 + mxfp6 quantizers end to end (CI form)."""
+    import torch
+
+    from examples.dequantize_gemm.quantize import (
+        quantize_bf16_to_mxfp6_blockscaled,
+        quantize_bf16_to_mxfp8_blockscaled,
+    )
+
+    torch.manual_seed(0)
+    module = _load_w6a8_example()
+    M = N = K = 512
+    kernel = module.sm120_w6a8_mxf8f6f4_gemm(M, N, K, 128, 128, 128, 2, "e4m3", "e3m2", T.float32)
+    x_a = (torch.randn(M, K, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+    x_b = torch.randn(N, K, dtype=torch.float32) * 2.0
+    A, SFA_packed, sfa_bytes = quantize_bf16_to_mxfp8_blockscaled(x_a, block_words=1, return_scale_bytes=True)
+    B_cpu, SFB_packed, sfb_bytes = quantize_bf16_to_mxfp6_blockscaled(x_b, dtype="e3m2", block_words=1, return_scale_bytes=True)
+    C = torch.empty((M, N), device="cuda", dtype=torch.float32)
+    kernel(A, B_cpu.cuda(), SFA_packed.reshape(-1, 1), SFB_packed.cuda().reshape(-1, 1), C)
+
+    scale = lambda b: torch.pow(2.0, (b.to(torch.int32) - 127).to(torch.float32)).repeat_interleave(32, dim=1)  # noqa: E731
+    b_dec = module._decode_fp6_blob(B_cpu.cuda(), N, K, "e3m2")
+    ref = (A.to(torch.float32) * scale(sfa_bytes)) @ (b_dec * scale(sfb_bytes).cuda()).T
+    torch.testing.assert_close(C, ref, rtol=1e-5, atol=1e-3)

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
@@ -1,0 +1,292 @@
+"""fp4/fp6 operands inside kind::mxf8f6f4 (W4A8-style mixed GEMMs).
+
+Global storage stays PACKED (fp4: 2 elems/byte - the compression invariant);
+shared memory holds the 16U4_ALIGN16B padded-packed form (16 elements = 8B
+payload + 8B padding), which the su4 ldmatrix unpacks into 8-bit register
+containers, shifted to the bits[5:2] position the MMA expects.
+"""
+
+import pytest
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.transform import simplify_prim_func
+
+
+_FP4_E2M1_VALUES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0)
+
+
+@simplify_prim_func
+def _make_w4a8_matmul_kernel(M, N, K, b_dtype, num_stages=1, *, block_M=64, block_N=64, block_K=128):
+    accum_dtype = T.float32
+    scale_words = block_K // 128
+
+    @T.prim_func
+    def main(
+        A_packed: T.Tensor((M, K // 2), T.uint8),
+        B: T.Tensor((N, K), b_dtype),
+        SFA: T.Tensor((M, K // 128), T.uint32),
+        SFB: T.Tensor((N, K // 128), T.uint32),
+        C: T.Tensor((M, N), accum_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), T.float4_e2m1_unpacked, scope="shared.dyn")
+            B_shared = T.alloc_shared((block_N, block_K), b_dtype, scope="shared.dyn")
+            SFA_shared = T.alloc_shared((block_M, scale_words), T.uint32, scope="shared.dyn")
+            SFB_shared = T.alloc_shared((block_N, scale_words), T.uint32, scope="shared.dyn")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            if K // block_K > 1:
+                T.clear(C_local)
+            for ko in T.Pipelined((K // block_K), num_stages=num_stages):
+                # SIMT producer of the 16U4_ALIGN16B padded-packed form:
+                # bytes [0..7] of each 16-slot group carry the 16 packed
+                # nibbles, bytes [8..15] are padding the ldmatrix ignores.
+                for i, g, j in T.Parallel(block_M, block_K // 16, 8):
+                    A_shared[i, 16 * g + j] = T.reinterpret(
+                        T.float4_e2m1_unpacked, A_packed[by * block_M + i, ko * (block_K // 2) + 8 * g + j]
+                    )
+                for j, k in T.Parallel(block_N, block_K):
+                    B_shared[j, k] = B[bx * block_N + j, ko * block_K + k]
+                for i, w in T.Parallel(block_M, scale_words):
+                    SFA_shared[i, w] = SFA[by * block_M + i, ko * scale_words + w]
+                for j, w in T.Parallel(block_N, scale_words):
+                    SFB_shared[j, w] = SFB[bx * block_N + j, ko * scale_words + w]
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=(K // block_K == 1),
+                    k_start=0,
+                    sf_a_granularity_k=32,
+                    sf_b_granularity_k=32,
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _decode_packed_fp4(packed, rows, cols):
+    import torch
+
+    lut = torch.tensor(_FP4_E2M1_VALUES, device=packed.device, dtype=torch.float32)
+    out = torch.empty((rows, cols), device=packed.device, dtype=torch.float32)
+    out[:, 0::2] = lut[(packed & 0x0F).long()]
+    out[:, 1::2] = lut[((packed >> 4) & 0x0F).long()]
+    return out
+
+
+def _pack_scale_words(scale_bytes):
+    import torch
+
+    s = scale_bytes.to(torch.int64).reshape(scale_bytes.shape[0], -1, 4)
+    w = s[:, :, 0] | (s[:, :, 1] << 8) | (s[:, :, 2] << 16) | (s[:, :, 3] << 24)
+    return w.to(torch.uint32).contiguous()
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize("b_name", ["e4m3", "e5m2"])
+@pytest.mark.parametrize("K,block_K", [(128, 128), (256, 128), (512, 256)])
+def test_w4a8_mxf8f6f4_rowmajor_correctness(b_name, K, block_K):
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 128
+    b_dtype = {"e4m3": T.float8_e4m3fn, "e5m2": T.float8_e5m2}[b_name]
+    kernel = tilelang.compile(_make_w4a8_matmul_kernel(M, N, K, b_dtype, block_K=block_K), target="cuda", out_idx=[4])
+    src = kernel.get_kernel_source()
+    assert "tl::ptx_ldmatrix_su4_x4" in src
+    assert "tl::fp4_e2m1_container_shift" in src
+    assert "tl::SM120MmaOperandType::kE2M1, tl::SM120MmaOperandType::k" in src
+
+    A_packed = torch.randint(0, 256, (M, K // 2), device="cuda", dtype=torch.uint8)
+    B = torch.randint(-4, 5, (N, K), device="cuda", dtype=torch.float32).to(
+        {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}[b_name]
+    )
+    sfa_bytes = (torch.randint(-1, 2, (M, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+    sfb_bytes = (torch.randint(-1, 2, (N, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+
+    C = kernel(A_packed, B, _pack_scale_words(sfa_bytes), _pack_scale_words(sfb_bytes))
+
+    sa = torch.pow(2.0, sfa_bytes.to(torch.int32).float() - 127).repeat_interleave(32, dim=1)
+    sb = torch.pow(2.0, sfb_bytes.to(torch.int32).float() - 127).repeat_interleave(32, dim=1)
+    ref = (_decode_packed_fp4(A_packed, M, K) * sa) @ (B.to(torch.float32) * sb).T
+    torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
+
+
+@simplify_prim_func
+def _make_a8w4_matmul_kernel(M, N, K, a_dtype, *, block_M=64, block_N=64, block_K=128, a_is_fp4=False):
+    """A fp8 (or fp4 when a_is_fp4) x B packed-fp4: exercises the B-side su4 path."""
+    accum_dtype = T.float32
+    scale_words = block_K // 128
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), a_dtype),
+        B_packed: T.Tensor((N, K // 2), T.uint8),
+        SFA: T.Tensor((M, K // 128), T.uint32),
+        SFB: T.Tensor((N, K // 128), T.uint32),
+        C: T.Tensor((M, N), accum_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), a_dtype, scope="shared.dyn")
+            B_shared = T.alloc_shared((block_N, block_K), T.float4_e2m1_unpacked, scope="shared.dyn")
+            SFA_shared = T.alloc_shared((block_M, scale_words), T.uint32, scope="shared.dyn")
+            SFB_shared = T.alloc_shared((block_N, scale_words), T.uint32, scope="shared.dyn")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            if K // block_K > 1:
+                T.clear(C_local)
+            for ko in T.Pipelined((K // block_K), num_stages=1):
+                for i, k in T.Parallel(block_M, block_K):
+                    A_shared[i, k] = A[by * block_M + i, ko * block_K + k]
+                for j, g, b in T.Parallel(block_N, block_K // 16, 8):
+                    B_shared[j, 16 * g + b] = T.reinterpret(
+                        T.float4_e2m1_unpacked, B_packed[bx * block_N + j, ko * (block_K // 2) + 8 * g + b]
+                    )
+                for i, w in T.Parallel(block_M, scale_words):
+                    SFA_shared[i, w] = SFA[by * block_M + i, ko * scale_words + w]
+                for j, w in T.Parallel(block_N, scale_words):
+                    SFB_shared[j, w] = SFB[bx * block_N + j, ko * scale_words + w]
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=(K // block_K == 1),
+                    k_start=0,
+                    sf_a_granularity_k=32,
+                    sf_b_granularity_k=32,
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize("a_name", ["e4m3", "e5m2"])
+def test_a8w4_mxf8f6f4_rowmajor_correctness(a_name):
+    """B-side su4 path: fp8 activations x packed-fp4 weights."""
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 128
+    K = 256
+    a_dtype = {"e4m3": T.float8_e4m3fn, "e5m2": T.float8_e5m2}[a_name]
+    kernel = tilelang.compile(_make_a8w4_matmul_kernel(M, N, K, a_dtype), target="cuda", out_idx=[4])
+    src = kernel.get_kernel_source()
+    assert "tl::ptx_ldmatrix_su4_x4" in src
+    assert ", tl::SM120MmaOperandType::kE2M1>" in src
+
+    A = torch.randint(-4, 5, (M, K), device="cuda", dtype=torch.float32).to(
+        {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}[a_name]
+    )
+    B_packed = torch.randint(0, 256, (N, K // 2), device="cuda", dtype=torch.uint8)
+    sfa_bytes = (torch.randint(-1, 2, (M, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+    sfb_bytes = (torch.randint(-1, 2, (N, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+
+    C = kernel(A, B_packed, _pack_scale_words(sfa_bytes), _pack_scale_words(sfb_bytes))
+
+    sa = torch.pow(2.0, sfa_bytes.to(torch.int32).float() - 127).repeat_interleave(32, dim=1)
+    sb = torch.pow(2.0, sfb_bytes.to(torch.int32).float() - 127).repeat_interleave(32, dim=1)
+    ref = (A.to(torch.float32) * sa) @ (_decode_packed_fp4(B_packed, N, K) * sb).T
+    torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
+
+
+@simplify_prim_func
+def _make_w4a4_k32_matmul_kernel(M, N, K, *, block_M=64, block_N=64, block_K=128):
+    """Both operands packed fp4 under kind::mxf8f6f4 (k32 atoms, 32-elem scales)."""
+    accum_dtype = T.float32
+    scale_words = block_K // 128
+
+    @T.prim_func
+    def main(
+        A_packed: T.Tensor((M, K // 2), T.uint8),
+        B_packed: T.Tensor((N, K // 2), T.uint8),
+        SFA: T.Tensor((M, K // 128), T.uint32),
+        SFB: T.Tensor((N, K // 128), T.uint32),
+        C: T.Tensor((M, N), accum_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), T.float4_e2m1_unpacked, scope="shared.dyn")
+            B_shared = T.alloc_shared((block_N, block_K), T.float4_e2m1_unpacked, scope="shared.dyn")
+            SFA_shared = T.alloc_shared((block_M, scale_words), T.uint32, scope="shared.dyn")
+            SFB_shared = T.alloc_shared((block_N, scale_words), T.uint32, scope="shared.dyn")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            if K // block_K > 1:
+                T.clear(C_local)
+            for ko in T.Pipelined((K // block_K), num_stages=1):
+                for i, g, b in T.Parallel(block_M, block_K // 16, 8):
+                    A_shared[i, 16 * g + b] = T.reinterpret(
+                        T.float4_e2m1_unpacked, A_packed[by * block_M + i, ko * (block_K // 2) + 8 * g + b]
+                    )
+                for j, g, b in T.Parallel(block_N, block_K // 16, 8):
+                    B_shared[j, 16 * g + b] = T.reinterpret(
+                        T.float4_e2m1_unpacked, B_packed[bx * block_N + j, ko * (block_K // 2) + 8 * g + b]
+                    )
+                for i, w in T.Parallel(block_M, scale_words):
+                    SFA_shared[i, w] = SFA[by * block_M + i, ko * scale_words + w]
+                for j, w in T.Parallel(block_N, scale_words):
+                    SFB_shared[j, w] = SFB[bx * block_N + j, ko * scale_words + w]
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=(K // block_K == 1),
+                    k_start=0,
+                    sf_a_granularity_k=32,
+                    sf_b_granularity_k=32,
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_w4a4_mxf8f6f4_rowmajor_correctness():
+    """fp4 x fp4 under kind::mxf8f6f4: unpacked containers on BOTH operands.
+
+    Note this is a different instruction than the packed mxf4nvf4 kind
+    (k32 vs k64 atoms), so its oracle is the python reference, not the
+    mxf4nvf4 path.
+    """
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 128
+    K = 256
+    kernel = tilelang.compile(_make_w4a4_k32_matmul_kernel(M, N, K), target="cuda", out_idx=[4])
+    src = kernel.get_kernel_source()
+    assert "tl::SM120MmaOperandType::kE2M1, tl::SM120MmaOperandType::kE2M1>" in src
+
+    A_packed = torch.randint(0, 256, (M, K // 2), device="cuda", dtype=torch.uint8)
+    B_packed = torch.randint(0, 256, (N, K // 2), device="cuda", dtype=torch.uint8)
+    sfa_bytes = (torch.randint(-1, 2, (M, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+    sfb_bytes = (torch.randint(-1, 2, (N, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+
+    C = kernel(A_packed, B_packed, _pack_scale_words(sfa_bytes), _pack_scale_words(sfb_bytes))
+
+    sa = torch.pow(2.0, sfa_bytes.to(torch.int32).float() - 127).repeat_interleave(32, dim=1)
+    sb = torch.pow(2.0, sfb_bytes.to(torch.int32).float() - 127).repeat_interleave(32, dim=1)
+    ref = (_decode_packed_fp4(A_packed, M, K) * sa) @ (_decode_packed_fp4(B_packed, N, K) * sb).T
+    torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
@@ -445,3 +445,121 @@ def test_fp4_unpack_copy_never_takes_the_1d_bulk_path():
         return  # loud failure is acceptable; silent 1D byte copy is not
     src = kernel.get_kernel_source()
     assert "tma_load_1d" not in src and "cp.async.bulk.global.shared" not in src
+
+
+def _load_w4a8_example():
+    import importlib.util
+    from pathlib import Path
+
+    path = Path(__file__).resolve().parents[3] / "examples/gemm_sm120/sm120_w4a8_mxf8f6f4_gemm.py"
+    spec = importlib.util.spec_from_file_location("sm120_w4a8_mxf8f6f4_gemm_example", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _w4a8_example_run(module, M, N, K, b_name="e4m3", seed=0):
+    import torch
+
+    kernel = module.sm120_w4a8_mxf8f6f4_gemm(M, N, K, 128, 128, 128, 2, b_name, T.float32)
+    A = module._make_packed_fp4(M, K, seed=seed)
+    B = module._make_fp8(N, K, b_name, seed=seed + 1)
+    SFA_semantic = module._make_pow2_scale_words(M, K, seed=seed + 100)
+    SFB_semantic = module._make_pow2_scale_words(N, K, seed=seed + 200)
+    SFA = module.swizzle_blockscaled_chunk_kmajor_scale_words(SFA_semantic, block_words=1).reshape(-1, 1)
+    SFB = module.swizzle_blockscaled_chunk_kmajor_scale_words(SFB_semantic, block_words=1).reshape(-1, 1)
+    C = torch.empty((M, N), device="cuda", dtype=torch.float32)
+    kernel(A, B, SFA, SFB, C)
+    return kernel, A, B, SFA_semantic, SFB_semantic, C
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize("b_name", ["e4m3", "e5m2"])
+@pytest.mark.parametrize("shape", [(1024, 1024, 1024), (768, 1024, 1536)])
+def test_w4a8_example_synthetic_band_bitwise(b_name, shape):
+    """Acceptance A1: default band, square and non-square, atol=0."""
+    import torch
+
+    torch.manual_seed(0)
+    module = _load_w4a8_example()
+    M, N, K = shape
+    _, A, B, SFA_semantic, SFB_semantic, C = _w4a8_example_run(module, M, N, K, b_name)
+    module._verify(A, B, SFA_semantic, SFB_semantic, C, torch.float32)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_w4a8_example_quantize_band():
+    """Acceptance A2: bf16 -> mxfp4/mxfp8 quantizers -> GEMM, tolerance form.
+
+    The bitwise (engine-vs-engine) version of this band is the maint CUTLASS
+    comparison; this pins the CI-runnable plumbing.
+    """
+    import torch
+
+    from examples.dequantize_gemm.quantize import (
+        quantize_bf16_to_mxfp4_blockscaled,
+        quantize_bf16_to_mxfp8_blockscaled,
+    )
+
+    torch.manual_seed(0)
+    module = _load_w4a8_example()
+    M = N = K = 512
+    kernel = module.sm120_w4a8_mxf8f6f4_gemm(M, N, K, 128, 128, 128, 2, "e4m3", T.float32)
+    x_a = (torch.randn(M, K, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+    x_b = (torch.randn(N, K, device="cuda", dtype=torch.float32) * 2.0).to(torch.bfloat16)
+    A, SFA_packed, sfa_bytes = quantize_bf16_to_mxfp4_blockscaled(x_a, block_words=1, return_scale_bytes=True)
+    B, SFB_packed, sfb_bytes = quantize_bf16_to_mxfp8_blockscaled(x_b, block_words=1, return_scale_bytes=True)
+    C = torch.empty((M, N), device="cuda", dtype=torch.float32)
+    kernel(A, B, SFA_packed.reshape(-1, 1), SFB_packed.reshape(-1, 1), C)
+
+    scale = lambda b: torch.pow(2.0, (b.to(torch.int32) - 127).to(torch.float32)).repeat_interleave(32, dim=1)  # noqa: E731
+    ref = (module._decode_rowmajor_fp4(A, M, K) * scale(sfa_bytes)) @ (B.to(torch.float32) * scale(sfb_bytes)).T
+    # f32 output: only summation rounding-order noise remains.
+    torch.testing.assert_close(C, ref, rtol=1e-5, atol=1e-3)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_w4a8_example_tma_engaged_and_compression():
+    """Acceptance A3 + A4: TMA actually engaged; packed global compression."""
+    module = _load_w4a8_example()
+    M = N = K = 256
+    kernel, A, _, _, _, _ = _w4a8_example_run(module, M, N, K)
+    device_src = kernel.get_kernel_source()
+    assert "tl::tma_load" in device_src, "A staging silently fell back off the TMA path"
+    assert "tl::ptx_ldmatrix_su4_x4" in device_src
+    assert "tl::fp4_e2m1_container_shift" in device_src
+    host_src = kernel.get_host_source()
+    assert "__tvm_tensormap_create_tiled" in host_src
+    # A4: the weights the example materializes are exactly M*K/2 bytes.
+    assert A.element_size() * A.numel() == M * K // 2
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_w4a8_example_rejects_non_multiple_of_128_k():
+    """Acceptance A5: the TMA legality rule surfaces as a friendly error."""
+    module = _load_w4a8_example()
+    with pytest.raises(Exception, match="multiple of 128"):
+        module.sm120_w4a8_mxf8f6f4_gemm(128, 128, 192, 128, 128, 64, 2, "e4m3", T.float32)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_w4a8_example_perf_smoke():
+    """Acceptance A6: the bench path runs and reports a sane number."""
+    import torch
+
+    from tilelang.profiler import do_bench
+
+    module = _load_w4a8_example()
+    M = N = K = 1024
+    kernel, A, B, _, _, C = _w4a8_example_run(module, M, N, K)
+    SFA = module.swizzle_blockscaled_chunk_kmajor_scale_words(module._make_pow2_scale_words(M, K, seed=100), block_words=1).reshape(-1, 1)
+    SFB = module.swizzle_blockscaled_chunk_kmajor_scale_words(module._make_pow2_scale_words(N, K, seed=200), block_words=1).reshape(-1, 1)
+    C = torch.empty((M, N), device="cuda", dtype=torch.float32)
+    ms = do_bench(lambda: kernel(A, B, SFA, SFB, C), warmup=10, rep=20)
+    tflops = 2.0 * M * N * K / (ms * 1e-3) / 1e12
+    assert tflops > 0

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
@@ -121,6 +121,96 @@ def test_w4a8_mxf8f6f4_rowmajor_correctness(b_name, K, block_K):
 
 
 @simplify_prim_func
+def _make_w4a8_tma_matmul_kernel(M, N, K, b_dtype, num_stages=2, *, block_M=64, block_N=64, block_K=128):
+    """W4A8 with the TMA producer: A is a packed-fp4 GLOBAL tensor and the
+    16U4_ALIGN16B bulk-TMA path unpacks it into the padded smem form (the
+    same byte layout the SIMT producer writes - pinned by the equivalence
+    test below)."""
+    accum_dtype = T.float32
+    scale_words = block_K // 128
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), T.float4_e2m1fn),
+        B: T.Tensor((N, K), b_dtype),
+        SFA: T.Tensor((M, K // 128), T.uint32),
+        SFB: T.Tensor((N, K // 128), T.uint32),
+        C: T.Tensor((M, N), accum_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), T.float4_e2m1_unpacked, scope="shared.dyn")
+            B_shared = T.alloc_shared((block_N, block_K), b_dtype, scope="shared.dyn")
+            SFA_shared = T.alloc_shared((block_M, scale_words), T.uint32, scope="shared.dyn")
+            SFB_shared = T.alloc_shared((block_N, scale_words), T.uint32, scope="shared.dyn")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            if K // block_K > 1:
+                T.clear(C_local)
+            for ko in T.Pipelined((K // block_K), num_stages=num_stages):
+                T.copy(A[by * block_M, ko * block_K], A_shared)
+                T.copy(B[bx * block_N, ko * block_K], B_shared)
+                for i, w in T.Parallel(block_M, scale_words):
+                    SFA_shared[i, w] = SFA[by * block_M + i, ko * scale_words + w]
+                for j, w in T.Parallel(block_N, scale_words):
+                    SFB_shared[j, w] = SFB[bx * block_N + j, ko * scale_words + w]
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=(K // block_K == 1),
+                    k_start=0,
+                    sf_a_granularity_k=32,
+                    sf_b_granularity_k=32,
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_w4a8_tma_producer_matches_simt_producer_bitwise():
+    """Producer-equivalence pin: the 16U4_ALIGN16B TMA unpack must stage
+    byte-identical smem to the SIMT padded-group producer, so the two
+    kernels' outputs must be bitwise equal on identical inputs."""
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 128
+    K = 256
+    tma = tilelang.compile(_make_w4a8_tma_matmul_kernel(M, N, K, T.float8_e4m3fn), target="cuda", out_idx=[4])
+    simt = tilelang.compile(_make_w4a8_matmul_kernel(M, N, K, T.float8_e4m3fn), target="cuda", out_idx=[4])
+
+    # The TMA producer must actually engage - a silent SIMT fallback would
+    # make this test vacuous.
+    device_src = tma.get_kernel_source()
+    assert "tl::tma_load" in device_src
+    host_src = tma.get_host_source()
+    assert "__tvm_tensormap_create_tiled" in host_src
+
+    A_bytes = torch.randint(0, 256, (M, K // 2), device="cuda", dtype=torch.uint8)
+    B = torch.randint(-4, 5, (N, K), device="cuda", dtype=torch.float32).to(torch.float8_e4m3fn)
+    sfa_bytes = (torch.randint(-1, 2, (M, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+    sfb_bytes = (torch.randint(-1, 2, (N, K // 32), device="cuda", dtype=torch.int64) + 127).to(torch.uint8)
+    SFA = _pack_scale_words(sfa_bytes)
+    SFB = _pack_scale_words(sfb_bytes)
+
+    C_tma = tma(A_bytes.view(torch.int8), B, SFA, SFB)
+    C_simt = simt(A_bytes, B, SFA, SFB)
+    assert torch.equal(C_tma.view(torch.int32), C_simt.view(torch.int32))
+
+    # And both agree with the dequantized reference at atol=0.
+    sa = torch.pow(2.0, sfa_bytes.to(torch.int32).float() - 127).repeat_interleave(32, dim=1)
+    sb = torch.pow(2.0, sfb_bytes.to(torch.int32).float() - 127).repeat_interleave(32, dim=1)
+    ref = (_decode_packed_fp4(A_bytes, M, K) * sa) @ (B.to(torch.float32) * sb).T
+    torch.testing.assert_close(C_tma, ref, rtol=0.0, atol=0.0)
+
+
+@simplify_prim_func
 def _make_a8w4_matmul_kernel(M, N, K, a_dtype, *, block_M=64, block_N=64, block_K=128, a_is_fp4=False):
     """A fp8 (or fp4 when a_is_fp4) x B packed-fp4: exercises the B-side su4 path."""
     accum_dtype = T.float32

--- a/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
+++ b/testing/python/language/test_tilelang_language_mxf8f6f4_subbyte_operands.py
@@ -380,3 +380,68 @@ def test_w4a4_mxf8f6f4_rowmajor_correctness():
 
 if __name__ == "__main__":
     tilelang.testing.main()
+
+
+@simplify_prim_func
+def _make_fp4_unpack_copy_kernel(rows, k_global, k_copy):
+    @T.prim_func
+    def main(
+        A: T.Tensor((rows, k_global), T.float4_e2m1fn),
+        OUT: T.Tensor((rows,), T.uint8),
+    ):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((rows, k_copy), T.float4_e2m1_unpacked, scope="shared.dyn")
+            T.copy(A[0, 0], A_shared, prefer_instruction="tma")
+            for i in T.Parallel(rows):
+                OUT[i] = T.reinterpret(T.uint8, A_shared[i, 0])
+
+    return main
+
+
+@simplify_prim_func
+def _make_fp4_unpack_copy_1d_kernel(n):
+    @T.prim_func
+    def main(
+        A: T.Tensor((n,), T.float4_e2m1fn),
+        OUT: T.Tensor((1,), T.uint8),
+    ):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((n,), T.float4_e2m1_unpacked, scope="shared.dyn")
+            T.copy(A, A_shared, prefer_instruction="tma")
+            OUT[0] = T.reinterpret(T.uint8, A_shared[0])
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_fp4_unpack_tma_rejects_non_multiple_of_128_global_dim():
+    """The CUDA driver requires globalDim[0] % 128 == 0 for 16U4_ALIGN16B.
+
+    Before the guard this only exploded at kernel launch (runtime tensor-map
+    validation); now static shapes fail at compile time with a message
+    naming the rule.
+    """
+    with pytest.raises(Exception, match="multiple of 128 elements"):
+        tilelang.compile(_make_fp4_unpack_copy_kernel(128, 192, 128), target="cuda", out_idx=[1])
+    # Control: a 128-multiple global dim compiles.
+    tilelang.compile(_make_fp4_unpack_copy_kernel(128, 256, 128), target="cuda", out_idx=[1])
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_fp4_unpack_copy_never_takes_the_1d_bulk_path():
+    """The descriptorless 1D bulk path cannot unpack packed fp4.
+
+    Before the guard, a 1D-shaped unpack copy would classify as BulkLoad1D
+    and silently emit a raw byte copy (no unpacking, inconsistent sizing).
+    With the guard it is diverted off the 1D path; wherever it lands it
+    must either be a descriptor TMA (correct) or fail loudly - never a
+    silent 1D byte copy.
+    """
+    try:
+        kernel = tilelang.compile(_make_fp4_unpack_copy_1d_kernel(4096), target="cuda", out_idx=[1])
+    except Exception:
+        return  # loud failure is acceptable; silent 1D byte copy is not
+    src = kernel.get_kernel_source()
+    assert "tma_load_1d" not in src and "cp.async.bulk.global.shared" not in src

--- a/testing/python/language/test_tilelang_language_nvf4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_nvf4_mma_block_scale.py
@@ -170,6 +170,7 @@ def _make_nvf4_matmul_codegen_kernel(
     warp_row_tiles=32,
     warp_col_tiles=32,
     sf_layout=None,
+    block_K=None,
 ):
     assert K % 64 == 0
     in_dtype = T.float4_e2m1fn
@@ -178,7 +179,7 @@ def _make_nvf4_matmul_codegen_kernel(
 
     micro_size_k = 64
 
-    chunk = K
+    chunk = block_K if block_K is not None else K
     shared_scope = "shared.dyn"
 
     block_M = block_row_warps * warp_row_tiles
@@ -216,6 +217,11 @@ def _make_nvf4_matmul_codegen_kernel(
             C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
             T.use_swizzle(panel_size=10)
 
+            # clear_accum zeroes the accumulator on every gemm call, so a
+            # multi-ko loop must hoist the clear out of the loop instead.
+            if K // block_K > 1:
+                T.clear(C_local)
+
             for ko in T.Pipelined((K // block_K), num_stages=num_stages):
                 for i, k in T.Parallel(block_M, block_K):
                     A_shared[i, k] = A[by * block_M + i, ko * block_K + k]
@@ -236,8 +242,10 @@ def _make_nvf4_matmul_codegen_kernel(
                     SFA_shared,
                     SFB_shared,
                     transpose_B=True,
-                    clear_accum=True,
-                    k_start=ko * block_K,
+                    clear_accum=(K // block_K == 1),
+                    # rowmajor addresses scales relative to the staged slice
+                    # (buffer-local); kmajor ignores k_start in the fulltile path.
+                    k_start=(ko * block_K) if sf_layout is not None else 0,
                     sf_a_granularity_k=16,
                     sf_b_granularity_k=16,
                     sf_layout=sf_layout,
@@ -372,6 +380,7 @@ def _make_mxf4_matmul_codegen_kernel(
     block_col_warps=2,
     warp_row_tiles=32,
     warp_col_tiles=32,
+    block_K=None,
 ):
     assert K % 64 == 0
     in_dtype = T.float4_e2m1fn
@@ -380,7 +389,7 @@ def _make_mxf4_matmul_codegen_kernel(
 
     word_span = sf_granularity_k * 4
 
-    chunk = K
+    chunk = block_K if block_K is not None else K
     shared_scope = "shared.dyn"
 
     block_M = block_row_warps * warp_row_tiles
@@ -418,6 +427,11 @@ def _make_mxf4_matmul_codegen_kernel(
             C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
             T.use_swizzle(panel_size=10)
 
+            # clear_accum zeroes the accumulator on every gemm call, so a
+            # multi-ko loop must hoist the clear out of the loop instead.
+            if K // block_K > 1:
+                T.clear(C_local)
+
             for ko in T.Pipelined((K // block_K), num_stages=num_stages):
                 for i, k in T.Parallel(block_M, block_K):
                     A_shared[i, k] = A[by * block_M + i, ko * block_K + k]
@@ -438,8 +452,10 @@ def _make_mxf4_matmul_codegen_kernel(
                     SFA_shared,
                     SFB_shared,
                     transpose_B=True,
-                    clear_accum=True,
-                    k_start=ko * block_K,
+                    clear_accum=(K // block_K == 1),
+                    # rowmajor addresses scales relative to the staged slice
+                    # (buffer-local); kmajor ignores k_start in the fulltile path.
+                    k_start=(ko * block_K) if sf_layout is not None else 0,
                     sf_a_granularity_k=sf_granularity_k,
                     sf_b_granularity_k=sf_granularity_k,
                     sf_layout=sf_layout,
@@ -1121,6 +1137,55 @@ def test_mxf4nvf4_4x_ue8m0_varying_scale_correctness():
     C = kernel(A, B, SFA, SFB)
     ref = _reference_ue8m0_blockscaled_gemm(A, B, sfa_bytes, sfb_bytes, M, N, K, 16)
     torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize("block_K", [128, 256])
+def test_nvf4_mma_block_scale_rowmajor_multi_k_stage_correctness(block_K):
+    # Rowmajor with block_K < K stages a per-ko scale slice, so scale
+    # addressing is buffer-local (k_start=0). This path was never covered
+    # before; a global k_start here silently reads out of the staged slice.
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 128
+    K = 512
+    kernel = tilelang.compile(
+        _make_nvf4_matmul_codegen_kernel(M, N, K, block_K=block_K),
+        target="cuda",
+        out_idx=[4],
+    )
+
+    A, B = _make_packed_fp4_inputs(M, N, K, "random")
+    SFA, sfa_bytes = _make_varying_power_of_two_scale_words(M, K)
+    SFB, sfb_bytes = _make_varying_power_of_two_scale_words(N, K)
+
+    C = kernel(A, B, SFA, SFB)
+    ref = _reference_blockscaled_gemm(A, B, sfa_bytes, sfb_bytes, M, N, K)
+    torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.skipif(_cuda_toolkit_below(13, 1), reason="scale_vec::4X with ue8m0 needs CUDA 13.1+")
+def test_mxf4nvf4_4x_ue8m0_kmajor_codegen():
+    kernel = tilelang.compile(
+        _make_mxf4_matmul_codegen_kernel(
+            128,
+            128,
+            256,
+            sf_granularity_k=16,
+            sf_layout="blockscaled_chunk_kmajor",
+            warp_row_tiles=64,
+            warp_col_tiles=64,
+        ),
+        target="cuda",
+        out_idx=[4],
+    )
+    src = kernel.get_kernel_source()
+    assert "SM120MmaScaleType::kUE8M0" in src
+    assert "tl::sm120_mma_sync_blockscaled<" in src
 
 
 # ---------------------------------------------------------------------------

--- a/testing/python/language/test_tilelang_language_nvf4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_nvf4_mma_block_scale.py
@@ -522,16 +522,44 @@ def test_sm120_fulltile_package_contract_supports_k128_path():
 
 
 def test_sm120_fulltile_package_contract_derives_arbitrary_reasonable_block_shape():
-    contract = _make_sm120_fulltile_contract(
-        chunk=192,
-        warp_row_tiles=32,
-        warp_col_tiles=96,
-    )
+    contract = _make_sm120_fulltile_contract(chunk=192)
 
-    assert (contract.tile_m, contract.tile_n, contract.tile_k) == (64, 192, 192)
-    assert (contract.warp_rows, contract.warp_cols, contract.kblocks) == (2, 6, 3)
-    assert (contract.sfa_words, contract.sfb_words) == (1, 3)
-    assert (contract.warp_issues, contract.warpgroup_issues) == (24, 96)
+    assert (contract.tile_m, contract.tile_n, contract.tile_k) == (128, 128, 192)
+    assert (contract.warp_rows, contract.warp_cols, contract.kblocks) == (4, 4, 3)
+    assert (contract.sfa_words, contract.sfb_words) == (2, 2)
+    assert (contract.warp_issues, contract.warpgroup_issues) == (32, 128)
+
+
+def test_sm120_fulltile_package_contract_rejects_non_atom_multiple_tiles():
+    # The kmajor scale source stacks 128-row BlockScaledBasicChunk atoms, so a
+    # staged tile must cover whole atoms; 64x192 was silently mis-addressed
+    # before the packer-atom fix.
+    with pytest.raises(ValueError, match="multiples of 128"):
+        _make_sm120_fulltile_contract(chunk=192, warp_row_tiles=32, warp_col_tiles=96)
+
+
+def test_sm120_fulltile_contract_scale_words_follow_packer_atoms_for_tile_m_256():
+    # tile_m=256 stacks two 128-row packer atoms. The flat word offset must
+    # follow the host packer (atom index = row // 128, fixed 4-group split
+    # inside the atom), not a tile_rows-wide group split.
+    contract = _make_sm120_fulltile_contract(warp_row_tiles=128)
+
+    assert (contract.tile_m, contract.tile_n) == (256, 128)
+    assert (contract.sfa_words, contract.sfb_words) == (4, 2)
+    assert contract.words_per_stage == contract.kblocks
+
+    for lane in (0, 1, 2, 17, 31):
+        for warp_m in range(contract.block_row_warps):
+            for warp_n in range(contract.block_col_warps):
+                sfa_rows, sfb_rows = contract.compact_selector_scale_rows(lane, warp_m, warp_n)
+                for kblock in range(contract.kblocks):
+                    sfa_offsets, sfb_offsets = contract.compact_selector_scale_word_offsets(lane, warp_m, warp_n, kblock)
+                    for row, flat in zip(sfa_rows, sfa_offsets):
+                        atom_base = (row // 128) * (contract.words_per_stage * 128)
+                        assert flat == atom_base + _oracle_blockscaled_chunk_kmajor_flat_word(row % 128, kblock)
+                    for row, flat in zip(sfb_rows, sfb_offsets):
+                        # tile_n=128 stays inside a single atom.
+                        assert flat == _oracle_blockscaled_chunk_kmajor_flat_word(row, kblock)
 
 
 def test_sm120_fulltile_package_contract_describes_compact_selector_copy_view():
@@ -693,7 +721,7 @@ def test_nvf4_mma_block_scale_rejects_legacy_cutlass_128x4_layout_alias():
     [
         (128, 128, 64, 64, 64),
         (128, 128, 128, 64, 64),
-        (64, 192, 192, 32, 96),
+        (128, 128, 192, 64, 64),
         (128, 128, 256, 64, 64),
     ],
 )

--- a/testing/python/language/test_tilelang_language_nvf4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_nvf4_mma_block_scale.py
@@ -733,10 +733,10 @@ def test_sm120_fulltile_contract_scale_words_follow_packer_atoms_for_tile_m_256(
                 sfa_rows, sfb_rows = contract.compact_selector_scale_rows(lane, warp_m, warp_n)
                 for kblock in range(contract.kblocks):
                     sfa_offsets, sfb_offsets = contract.compact_selector_scale_word_offsets(lane, warp_m, warp_n, kblock)
-                    for row, flat in zip(sfa_rows, sfa_offsets):
+                    for row, flat in zip(sfa_rows, sfa_offsets, strict=True):
                         atom_base = (row // 128) * (contract.words_per_stage * 128)
                         assert flat == atom_base + _oracle_blockscaled_chunk_kmajor_flat_word(row % 128, kblock)
-                    for row, flat in zip(sfb_rows, sfb_offsets):
+                    for row, flat in zip(sfb_rows, sfb_offsets, strict=True):
                         # tile_n=128 stays inside a single atom.
                         assert flat == _oracle_blockscaled_chunk_kmajor_flat_word(row, kblock)
 
@@ -1087,8 +1087,18 @@ def test_mxf4_mma_block_scale_varying_scale_correctness(K, sf_layout):
     torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
 
 
+def _cuda_toolkit_below(major: int, minor: int) -> bool:
+    try:
+        from tilelang.contrib import nvcc as _nvcc
+
+        return _nvcc.get_cuda_version() < (major, minor)
+    except Exception:
+        return False
+
+
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.skipif(_cuda_toolkit_below(13, 1), reason="scale_vec::4X with ue8m0 needs CUDA 13.1+")
 def test_mxf4nvf4_4x_ue8m0_varying_scale_correctness():
     # granularity 16 + ue8m0: the CUDA 13.1 scale_vec::4X.ue8m0 instruction.
     import torch

--- a/testing/python/language/test_tilelang_language_nvf4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_nvf4_mma_block_scale.py
@@ -447,6 +447,29 @@ def test_nvf4_mma_block_scale_rejects_unsupported_configs(kwargs):
         )
 
 
+def test_sm120_mma_and_ldscale_reject_chunk_kmajor_scale_layout():
+    # The chunk-kmajor scale layout is served exclusively by
+    # mma_blockscaled_fulltile; the per-word mma()/ldscale() paths only
+    # understand rowmajor scale addressing.
+    emitter = TensorCoreIntrinEmitterSM120(
+        is_blockscaled=True,
+        a_dtype=T.float4_e2m1fn,
+        b_dtype=T.float4_e2m1fn,
+        accum_dtype=T.float32,
+        a_transposed=False,
+        b_transposed=True,
+        block_row_warps=2,
+        block_col_warps=2,
+        warp_row_tiles=32,
+        warp_col_tiles=32,
+        chunk=256,
+    )
+    with pytest.raises(ValueError, match="mma_blockscaled_fulltile"):
+        emitter.mma(None, None, None, 0, SFA_buf=object(), SFB_buf=object(), sf_layout="blockscaled_chunk_kmajor")
+    with pytest.raises(ValueError, match="mma_blockscaled_fulltile"):
+        emitter.ldscale(None, None, None, None, None, sf_layout="blockscaled_chunk_kmajor")
+
+
 @pytest.mark.parametrize(
     "dtype_kwargs",
     [

--- a/testing/python/language/test_tilelang_language_nvf4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_nvf4_mma_block_scale.py
@@ -425,7 +425,6 @@ def test_nvf4_mma_block_scale_lane_scale_mapping_matches_cute():
     "kwargs",
     [
         {"kind": "mxf4nvf4", "scale_vec_size": 2, "stype": "ue4m3"},
-        {"kind": "mxf4nvf4", "scale_vec_size": 4, "stype": "ue8m0"},
         {"kind": "mxf4", "scale_vec_size": 4, "stype": "ue4m3"},
     ],
 )
@@ -468,6 +467,64 @@ def test_sm120_mma_and_ldscale_reject_chunk_kmajor_scale_layout():
         emitter.mma(None, None, None, 0, SFA_buf=object(), SFB_buf=object(), sf_layout="blockscaled_chunk_kmajor")
     with pytest.raises(ValueError, match="mma_blockscaled_fulltile"):
         emitter.ldscale(None, None, None, None, None, sf_layout="blockscaled_chunk_kmajor")
+
+
+def _make_ue8m0_emitter(scale_vec_size, chunk):
+    return TensorCoreIntrinEmitterSM120(
+        is_blockscaled=True,
+        a_dtype=T.float4_e2m1fn,
+        b_dtype=T.float4_e2m1fn,
+        accum_dtype=T.float32,
+        a_transposed=False,
+        b_transposed=True,
+        block_row_warps=2,
+        block_col_warps=2,
+        warp_row_tiles=64,
+        warp_col_tiles=64,
+        chunk=chunk,
+        kind="mxf4nvf4",
+        scale_vec_size=scale_vec_size,
+        stype="ue8m0",
+    )
+
+
+def test_mxf4_2x_ue8m0_emitter_contract():
+    emitter = _make_ue8m0_emitter(2, 256)
+    assert (emitter.kind, emitter.scale_vec_size, emitter.stype) == ("mxf4nvf4", 2, "ue8m0")
+    assert emitter.sf_vec_size == 32
+
+    # One uint32 word covers K=128: word column is the k64-atom pair index,
+    # the byte id selects the 2-byte half by atom parity.
+    word_ks = [emitter._scale_word_k(0, ki, 32) for ki in range(4)]
+    byte_ids = [emitter._scale_byte_id(0, ki) for ki in range(4)]
+    analyzer = tvm.arith.Analyzer()
+    assert [int(analyzer.simplify(w)) for w in word_ks] == [0, 0, 1, 1]
+    assert [int(analyzer.simplify(tvm.tirx.const(0, "int32") + b)) for b in byte_ids] == [0, 2, 0, 2]
+
+    # 2X packs K=128 per word; narrower block_K cannot be staged.
+    for bad_chunk in (64, 192):
+        with pytest.raises(ValueError, match="multiple of"):
+            _make_ue8m0_emitter(2, bad_chunk)
+
+
+def test_mxf4nvf4_4x_ue8m0_emitter_contract():
+    emitter = _make_ue8m0_emitter(4, 256)
+    assert (emitter.kind, emitter.scale_vec_size, emitter.stype) == ("mxf4nvf4", 4, "ue8m0")
+    assert emitter.sf_vec_size == 16
+    # 4X keeps the whole-word consumption: byte id is the literal 0.
+    assert emitter._scale_byte_id(0, 3) == 0
+
+
+def test_sm120_fulltile_contract_tracks_2x_words_per_stage():
+    contract = SM120BlockScaleTile.from_emitter(
+        _make_ue8m0_emitter(2, 256),
+        sf_layout="blockscaled_chunk_kmajor",
+    )
+    assert (contract.kblocks, contract.sf_vec_size) == (4, 32)
+    assert contract.words_per_stage == 2
+    # Word columns range over words_per_stage, not kblocks.
+    with pytest.raises(ValueError, match="word column"):
+        contract._scale_word_offset(0, 2, 128)
 
 
 @pytest.mark.parametrize(

--- a/testing/python/language/test_tilelang_language_nvf4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_nvf4_mma_block_scale.py
@@ -1093,7 +1093,9 @@ def _cuda_toolkit_below(major: int, minor: int) -> bool:
 
         return _nvcc.get_cuda_version() < (major, minor)
     except Exception:
-        return False
+        # Fail closed: skip the version-gated test when the toolkit version
+        # cannot be determined.
+        return True
 
 
 @tilelang.testing.requires_cuda

--- a/testing/python/language/test_tilelang_language_nvf4_mma_block_scale.py
+++ b/testing/python/language/test_tilelang_language_nvf4_mma_block_scale.py
@@ -11,7 +11,10 @@ from tilelang import tvm
 from tilelang.cuda.intrinsics.layout.mma_layout import mma_load_a_32x32_to_shared_16x64_layout
 from tilelang.cuda.intrinsics.macro.mma_sm120_macro_generator import SM120BlockScaleTile
 from tilelang.cuda.language.intrinsics import TensorCoreIntrinEmitterSM120, get_swizzle_layout
-from examples.dequantize_gemm.quantize.nvfp4 import blockscaled_chunk_kmajor_word_offset
+from examples.dequantize_gemm.quantize.nvfp4 import (
+    blockscaled_chunk_kmajor_word_offset,
+    swizzle_blockscaled_chunk_kmajor_scale_words,
+)
 from tilelang.transform import simplify_prim_func
 
 
@@ -327,6 +330,125 @@ def _reference_blockscaled_gemm(A, B, SFA, SFB, M: int, N: int, K: int):
     sfa = _decode_ue4m3_scale_bytes(SFA).repeat_interleave(16, dim=1)
     sfb = _decode_ue4m3_scale_bytes(SFB).repeat_interleave(16, dim=1)
     return (a_f32 * sfa) @ (b_f32 * sfb).T
+
+
+def _make_varying_ue8m0_scale_words(rows: int, K: int, granularity: int):
+    # Adjacent granularity groups get different power-of-two scales so a
+    # byte-pair (parity) mix-up in the 2X path changes the result.
+    import torch
+
+    scale_choices = torch.tensor([0x7E, 0x7F, 0x80], device="cuda", dtype=torch.uint8)
+    row = torch.arange(rows, device="cuda", dtype=torch.int64)[:, None]
+    col = torch.arange(K // granularity, device="cuda", dtype=torch.int64)[None, :]
+    scale_bytes = scale_choices[(row + 2 * col) % scale_choices.numel()]
+    return _pack_scale_words(scale_bytes), scale_bytes
+
+
+def _decode_ue8m0_scale_bytes(scale_bytes):
+    import torch
+
+    return torch.pow(2.0, scale_bytes.to(torch.float32) - 127.0)
+
+
+def _reference_ue8m0_blockscaled_gemm(A, B, sfa_bytes, sfb_bytes, M: int, N: int, K: int, granularity: int):
+    a_f32 = _decode_rowmajor_fp4(A, M, K)
+    b_f32 = _decode_rowmajor_fp4(B, N, K)
+    sfa = _decode_ue8m0_scale_bytes(sfa_bytes).repeat_interleave(granularity, dim=1)
+    sfb = _decode_ue8m0_scale_bytes(sfb_bytes).repeat_interleave(granularity, dim=1)
+    return (a_f32 * sfa) @ (b_f32 * sfb).T
+
+
+@simplify_prim_func
+def _make_mxf4_matmul_codegen_kernel(
+    M,
+    N,
+    K,
+    num_stages=2,
+    *,
+    sf_granularity_k=32,
+    scale_dtype="ue8m0",
+    sf_layout=None,
+    block_row_warps=2,
+    block_col_warps=2,
+    warp_row_tiles=32,
+    warp_col_tiles=32,
+):
+    assert K % 64 == 0
+    in_dtype = T.float4_e2m1fn
+    out_dtype = T.float32
+    accum_dtype = T.float32
+
+    word_span = sf_granularity_k * 4
+
+    chunk = K
+    shared_scope = "shared.dyn"
+
+    block_M = block_row_warps * warp_row_tiles
+    block_N = block_col_warps * warp_col_tiles
+    block_K = chunk
+
+    A_shape = (M, K)
+    B_shape = (N, K)
+    SFA_shape = (M, K // word_span)
+    SFB_shape = (N, K // word_span)
+    A_shared_shape = (block_M, block_K)
+    B_shared_shape = (block_N, block_K)
+    SFA_shared_shape = (block_M, block_K // word_span)
+    SFB_shared_shape = (block_N, block_K // word_span)
+
+    warp_size = 32
+    threads = warp_size * (block_row_warps * block_col_warps)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(A_shape, in_dtype),
+        B: T.Tensor(B_shape, in_dtype),
+        SFA: T.Tensor(SFA_shape, T.uint32),
+        SFB: T.Tensor(SFB_shape, T.uint32),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (
+            bx,
+            by,
+        ):
+            A_shared = T.alloc_shared(A_shared_shape, in_dtype, scope=shared_scope)
+            B_shared = T.alloc_shared(B_shared_shape, in_dtype, scope=shared_scope)
+            SFA_shared = T.alloc_shared(SFA_shared_shape, T.uint32, scope=shared_scope)
+            SFB_shared = T.alloc_shared(SFB_shared_shape, T.uint32, scope=shared_scope)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            T.use_swizzle(panel_size=10)
+
+            for ko in T.Pipelined((K // block_K), num_stages=num_stages):
+                for i, k in T.Parallel(block_M, block_K):
+                    A_shared[i, k] = A[by * block_M + i, ko * block_K + k]
+
+                for j, k in T.Parallel(block_N, block_K):
+                    B_shared[j, k] = B[bx * block_N + j, ko * block_K + k]
+
+                for i, k in T.Parallel(block_M, block_K // word_span):
+                    SFA_shared[i, k] = SFA[by * block_M + i, ko * (block_K // word_span) + k]
+
+                for j, k in T.Parallel(block_N, block_K // word_span):
+                    SFB_shared[j, k] = SFB[bx * block_N + j, ko * (block_K // word_span) + k]
+
+                T.mma_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    SFA_shared,
+                    SFB_shared,
+                    transpose_B=True,
+                    clear_accum=True,
+                    k_start=ko * block_K,
+                    sf_a_granularity_k=sf_granularity_k,
+                    sf_b_granularity_k=sf_granularity_k,
+                    sf_layout=sf_layout,
+                    scale_dtype=scale_dtype,
+                )
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
 
 
 def test_nvf4_mma_block_scale_fragment_layouts_match_cute():
@@ -900,6 +1022,92 @@ def test_nvf4_mma_block_scale_varying_scale_correctness():
 
     C = kernel(A, B, SFA, SFB)
     ref = _reference_blockscaled_gemm(A, B, sfa_bytes, sfb_bytes, M, N, K)
+    torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
+
+
+def test_mma_gemm_blockscaled_rejects_mismatched_scale_mode():
+    with pytest.raises(ValueError, match="Unsupported SM120 block-scale mode"):
+        _make_mxf4_matmul_codegen_kernel(128, 128, 256, sf_granularity_k=32, scale_dtype="ue4m3")
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize("K", [128, 256])
+def test_mxf4_mma_block_scale_codegen(K):
+    kernel = tilelang.compile(
+        _make_mxf4_matmul_codegen_kernel(128, 128, K),
+        target="cuda",
+        out_idx=[4],
+    )
+    src = kernel.get_kernel_source()
+    assert "tl::sm120_mma_sync_blockscaled<" in src
+    assert "SM120MmaScaleType::kUE8M0" in src
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+@pytest.mark.parametrize(
+    "K,sf_layout",
+    [
+        (128, None),
+        (256, None),
+        (128, "blockscaled_chunk_kmajor"),
+        (256, "blockscaled_chunk_kmajor"),
+    ],
+)
+def test_mxf4_mma_block_scale_varying_scale_correctness(K, sf_layout):
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 128
+    # kmajor staging requires whole 128-row packer atoms per tile.
+    tiles = 64 if sf_layout else 32
+    kernel = tilelang.compile(
+        _make_mxf4_matmul_codegen_kernel(
+            M,
+            N,
+            K,
+            sf_layout=sf_layout,
+            warp_row_tiles=tiles,
+            warp_col_tiles=tiles,
+        ),
+        target="cuda",
+        out_idx=[4],
+    )
+
+    A, B = _make_packed_fp4_inputs(M, N, K, "random")
+    SFA, sfa_bytes = _make_varying_ue8m0_scale_words(M, K, 32)
+    SFB, sfb_bytes = _make_varying_ue8m0_scale_words(N, K, 32)
+    if sf_layout:
+        SFA = swizzle_blockscaled_chunk_kmajor_scale_words(SFA, block_words=K // 128)
+        SFB = swizzle_blockscaled_chunk_kmajor_scale_words(SFB, block_words=K // 128)
+
+    C = kernel(A, B, SFA, SFB)
+    ref = _reference_ue8m0_blockscaled_gemm(A, B, sfa_bytes, sfb_bytes, M, N, K, 32)
+    torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_mxf4nvf4_4x_ue8m0_varying_scale_correctness():
+    # granularity 16 + ue8m0: the CUDA 13.1 scale_vec::4X.ue8m0 instruction.
+    import torch
+
+    torch.manual_seed(0)
+    M = N = 128
+    K = 256
+    kernel = tilelang.compile(
+        _make_mxf4_matmul_codegen_kernel(M, N, K, sf_granularity_k=16),
+        target="cuda",
+        out_idx=[4],
+    )
+
+    A, B = _make_packed_fp4_inputs(M, N, K, "random")
+    SFA, sfa_bytes = _make_varying_ue8m0_scale_words(M, K, 16)
+    SFB, sfb_bytes = _make_varying_ue8m0_scale_words(N, K, 16)
+
+    C = kernel(A, B, SFA, SFB)
+    ref = _reference_ue8m0_blockscaled_gemm(A, B, sfa_bytes, sfb_bytes, M, N, K, 16)
     torch.testing.assert_close(C, ref, rtol=0.0, atol=0.0)
 
 

--- a/testing/python/quantize/test_tilelang_quantize_mxfp4_scale_layout.py
+++ b/testing/python/quantize/test_tilelang_quantize_mxfp4_scale_layout.py
@@ -1,0 +1,110 @@
+"""CPU contract tests for the MXFP4 (E2M1 + UE8M0) scale layout utilities."""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+tilelang_testing = pytest.importorskip("tilelang.testing")
+
+from examples.dequantize_gemm.quantize import (
+    decode_ue8m0_scale_bytes,
+    encode_ue8m0_scale_bytes,
+    pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes,
+    quantize_bf16_to_mxfp4_blockscaled,
+)
+from examples.dequantize_gemm.quantize.nvfp4 import decode_packed_fp4_e2m1
+
+
+def _expected_blockscaled_chunk_kmajor_byte_location(row: int, k32_idx: int, k128_cols: int) -> tuple[int, int, int]:
+    # Same physical order as the NVFP4 packer: 128-row K-major atoms with a
+    # fixed 4-group split; only the per-byte K coverage differs (32 vs 16).
+    k128_word = k32_idx // 4
+    byte_lane = k32_idx % 4
+    row_block = row // 128
+    row_in_block = row % 128
+    flat_word = row_block * 128 * k128_cols + k128_word * 128 + (row_in_block % 32) * 4 + (row_in_block // 32)
+    return flat_word // k128_cols, flat_word % k128_cols, byte_lane
+
+
+def _packed_byte(packed, row: int, word: int, byte_lane: int) -> int:
+    return (int(packed[row, word].item()) >> (8 * byte_lane)) & 0xFF
+
+
+def test_encode_ue8m0_scale_bytes_known_values():
+    values = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 448.0], dtype=torch.float32)
+    encoded = encode_ue8m0_scale_bytes(values, rounding="ceil")
+    # ceil to the next power of two: 1.5 -> 2.0, 448 -> 512.
+    assert torch.equal(encoded, torch.tensor([0x00, 0x7E, 0x7F, 0x80, 0x80, 0x88], dtype=torch.uint8))
+    decoded = decode_ue8m0_scale_bytes(encoded)
+    torch.testing.assert_close(decoded, torch.tensor([2.0**-127, 0.5, 1.0, 2.0, 2.0, 512.0]))
+    assert torch.isnan(decode_ue8m0_scale_bytes(torch.tensor([0xFF], dtype=torch.uint8))).all()
+
+
+def test_encode_ue8m0_scale_bytes_is_a_ceiling():
+    values = torch.pow(2.0, torch.linspace(-20, 20, 173, dtype=torch.float32)) * 1.0000001
+    decoded = decode_ue8m0_scale_bytes(encode_ue8m0_scale_bytes(values, rounding="ceil"))
+    assert bool((decoded >= values).all())
+    assert bool((decoded <= values * 2.0).all())
+
+
+@pytest.mark.parametrize("block_words", [1, 2])
+def test_pack_blockscaled_chunk_kmajor_ue8m0_matches_oracle(block_words):
+    rows = 256
+    k = 128 * block_words * 3
+    k32_cols = k // 32
+    generator = torch.Generator(device="cpu").manual_seed(37 + block_words)
+    scale_bytes = torch.randint(0, 255, (rows, k32_cols), generator=generator, dtype=torch.uint8)
+
+    packed = pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes(scale_bytes, block_words=block_words)
+
+    assert packed.shape == (rows, k32_cols // 4)
+    assert packed.dtype == torch.uint32
+    k128_cols = k32_cols // 4
+    for row in (0, 1, 31, 32, 127, 128, 200, 255):
+        for k32_idx in range(k32_cols):
+            physical_row, physical_word, byte_lane = _expected_blockscaled_chunk_kmajor_byte_location(row, k32_idx, k128_cols)
+            assert _packed_byte(packed, physical_row, physical_word, byte_lane) == int(scale_bytes[row, k32_idx])
+
+
+def test_pack_blockscaled_chunk_kmajor_ue8m0_rejects_bad_shapes():
+    with pytest.raises(ValueError, match="columns multiple of 8"):
+        pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes(torch.zeros((128, 4), dtype=torch.uint8), block_words=2)
+    with pytest.raises(ValueError, match=r"block_words in \(1, 2, 4\)"):
+        pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes(torch.zeros((128, 12), dtype=torch.uint8), block_words=3)
+    with pytest.raises(TypeError, match="torch.uint8"):
+        pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes(torch.zeros((128, 8), dtype=torch.int32))
+
+
+def test_quantize_bf16_to_mxfp4_blockscaled_contract():
+    rows, cols = 128, 256
+    x = torch.randn((rows, cols), dtype=torch.bfloat16)
+
+    packed_fp4, packed_scales, scale_bytes = quantize_bf16_to_mxfp4_blockscaled(x, return_scale_bytes=True)
+
+    assert packed_fp4.dtype == torch.int8 and packed_fp4.shape == (rows, cols // 2)
+    assert packed_scales.dtype == torch.uint32 and packed_scales.shape == (rows, cols // 128)
+    assert scale_bytes.dtype == torch.uint8 and scale_bytes.shape == (rows, cols // 32)
+    assert torch.equal(
+        packed_scales,
+        pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes(scale_bytes, block_words=2),
+    )
+
+
+def test_quantize_bf16_to_mxfp4_blockscaled_has_bounded_error():
+    rows, cols = 128, 512
+    generator = torch.Generator(device="cpu").manual_seed(11)
+    x = (torch.randn((rows, cols), generator=generator, dtype=torch.float32) * 3.0).to(torch.bfloat16)
+
+    packed_fp4, _, scale_bytes = quantize_bf16_to_mxfp4_blockscaled(x, return_scale_bytes=True)
+
+    scales = decode_ue8m0_scale_bytes(scale_bytes).repeat_interleave(32, dim=1)
+    reconstructed = decode_packed_fp4_e2m1(packed_fp4, cols) * scales
+    x_f32 = x.to(torch.float32)
+    # The ceil-power-of-two scale keeps |x| / scale within the FP4 range; the
+    # worst-case FP4 rounding gap is one unit at the top of the range.
+    assert bool(((x_f32 - reconstructed).abs() <= scales * 1.0 + 1e-6).all())
+    zero_blocks = x_f32.reshape(rows, cols // 32, 32).abs().amax(dim=2) == 0
+    assert bool((scale_bytes[zero_blocks] == 0).all()) if zero_blocks.any() else True
+
+
+if __name__ == "__main__":
+    tilelang_testing.main()

--- a/testing/python/quantize/test_tilelang_quantize_mxfp4_scale_layout.py
+++ b/testing/python/quantize/test_tilelang_quantize_mxfp4_scale_layout.py
@@ -98,6 +98,22 @@ def test_quantize_bf16_to_mxfp4_blockscaled_contract():
     )
 
 
+def test_quantize_mxfp4_nan_input_zeroes_its_block():
+    x = torch.randn(128, 256, dtype=torch.bfloat16)
+    x[0, 5] = float("nan")
+    packed, _, sbytes = quantize_bf16_to_mxfp4_blockscaled(x, return_scale_bytes=True)
+    assert int(sbytes[0, 0]) == 0
+    block = decode_packed_fp4_e2m1(packed, 256)[0, :32]
+    assert bool((block == 0).all())
+
+
+def test_quantize_mxfp4_inf_saturates_block_scale():
+    x = torch.randn(128, 256, dtype=torch.bfloat16)
+    x[0, 5] = float("inf")
+    _, _, sbytes = quantize_bf16_to_mxfp4_blockscaled(x, return_scale_bytes=True)
+    assert int(sbytes[0, 0]) == 0xFE
+
+
 def test_quantize_bf16_to_mxfp4_blockscaled_has_bounded_error():
     rows, cols = 128, 512
     generator = torch.Generator(device="cpu").manual_seed(11)

--- a/testing/python/quantize/test_tilelang_quantize_mxfp4_scale_layout.py
+++ b/testing/python/quantize/test_tilelang_quantize_mxfp4_scale_layout.py
@@ -46,6 +46,15 @@ def test_encode_ue8m0_scale_bytes_is_a_ceiling():
     assert bool((decoded <= values * 2.0).all())
 
 
+def test_encode_ue8m0_scale_bytes_saturates_at_format_max():
+    # Finite values above 2**127 (and +inf) saturate to 0xFE = 2**127; 0xFF
+    # stays reserved for NaN.
+    values = torch.tensor([2.0**127, torch.finfo(torch.float32).max, float("inf")], dtype=torch.float32)
+    encoded = encode_ue8m0_scale_bytes(values, rounding="ceil")
+    assert torch.equal(encoded, torch.full((3,), 0xFE, dtype=torch.uint8))
+    assert bool((decode_ue8m0_scale_bytes(encoded) == 2.0**127).all())
+
+
 @pytest.mark.parametrize("block_words", [1, 2])
 def test_pack_blockscaled_chunk_kmajor_ue8m0_matches_oracle(block_words):
     rows = 256

--- a/testing/python/quantize/test_tilelang_quantize_mxfp6_scale_layout.py
+++ b/testing/python/quantize/test_tilelang_quantize_mxfp6_scale_layout.py
@@ -1,0 +1,111 @@
+"""CPU contract tests for the MXFP6 (E2M3/E3M2 + UE8M0) quantizer."""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+tilelang_testing = pytest.importorskip("tilelang.testing")
+
+from examples.dequantize_gemm.quantize import (
+    decode_fp6_values,
+    decode_ue8m0_scale_bytes,
+    encode_fp6_values,
+    pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes,
+    pack_fp6_codes,
+    quantize_bf16_to_mxfp6_blockscaled,
+    unpack_fp6_bytes,
+)
+
+
+@pytest.mark.parametrize("dtype", ["e2m3", "e3m2"])
+def test_fp6_code_roundtrip_exhaustive(dtype):
+    # Every one of the 64 codes must decode -> encode back to itself
+    # (modulo the two zero codes: -0.0 re-encodes as +0.0).
+    codes = torch.arange(64, dtype=torch.uint8)
+    values = decode_fp6_values(codes, dtype)
+    re = encode_fp6_values(values, dtype)
+    neg_zero = 32  # sign bit set, magnitude 0
+    mask = codes != neg_zero
+    assert torch.equal(re[mask], codes[mask])
+    assert int(re[neg_zero]) in (0, 32)
+
+
+def test_fp6_pack_unpack_roundtrip():
+    torch.manual_seed(0)
+    codes = torch.randint(0, 64, (8, 64), dtype=torch.uint8)
+    packed = pack_fp6_codes(codes)
+    assert packed.shape == (8, 48)  # 0.75 bytes per element
+    assert torch.equal(unpack_fp6_bytes(packed, 64), codes)
+
+
+def test_fp6_pack_bit_order_matches_su6_stream():
+    # Element i occupies bits [6i, 6i+6) LSB-first - the exact stream the
+    # b6x16_p32 ldmatrix consumes (hardware-pinned in the sub-byte tests).
+    codes = torch.zeros((1, 4), dtype=torch.uint8)
+    codes[0, 0] = 0x3F
+    packed = pack_fp6_codes(codes)
+    assert packed[0, 0] == 0x3F and packed[0, 1] == 0 and packed[0, 2] == 0
+    codes = torch.zeros((1, 4), dtype=torch.uint8)
+    codes[0, 1] = 0x3F  # bits [6, 12)
+    packed = pack_fp6_codes(codes)
+    assert packed[0, 0] == 0xC0 and packed[0, 1] == 0x0F and packed[0, 2] == 0
+
+
+@pytest.mark.parametrize("dtype", ["e2m3", "e3m2"])
+def test_quantize_bf16_to_mxfp6_blockscaled_contract(dtype):
+    rows, cols = 128, 256
+    x = torch.randn((rows, cols), dtype=torch.bfloat16)
+    blob, packed_scales, scale_bytes = quantize_bf16_to_mxfp6_blockscaled(x, dtype=dtype, return_scale_bytes=True)
+    assert blob.dtype == torch.uint8 and blob.shape == (rows, cols * 3 // 4)
+    assert packed_scales.dtype == torch.uint32 and packed_scales.shape == (rows, cols // 128)
+    assert scale_bytes.shape == (rows, cols // 32)
+    assert torch.equal(packed_scales, pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes(scale_bytes, block_words=2))
+
+
+def test_quantize_mxfp6_compression_invariant():
+    rows, cols = 128, 256
+    x = torch.randn((rows, cols), dtype=torch.bfloat16)
+    blob, _ = quantize_bf16_to_mxfp6_blockscaled(x)
+    assert blob.element_size() * blob.numel() == rows * cols * 3 // 4
+
+
+@pytest.mark.parametrize("dtype,rel_bits,sub_quantum", [("e2m3", 3, 2.0**-4), ("e3m2", 2, 2.0**-5)])
+def test_quantize_bf16_to_mxfp6_blockscaled_has_bounded_error(dtype, rel_bits, sub_quantum):
+    rows, cols = 128, 512
+    generator = torch.Generator(device="cpu").manual_seed(11)
+    x = (torch.randn((rows, cols), generator=generator, dtype=torch.float32) * 3.0).to(torch.bfloat16)
+    blob, _, scale_bytes = quantize_bf16_to_mxfp6_blockscaled(x, dtype=dtype, return_scale_bytes=True)
+    codes = unpack_fp6_bytes(blob, cols)
+    scales = decode_ue8m0_scale_bytes(scale_bytes).repeat_interleave(32, dim=1)
+    reconstructed = decode_fp6_values(codes, dtype) * scales
+    x_f32 = x.to(torch.float32)
+    # RN: error <= 0.5 ulp -> |x| * 2^-(man_bits+1) for normals plus half the
+    # subnormal quantum (times the block scale) for tiny elements.
+    bound = x_f32.abs() * 2.0**-(rel_bits) + scales * sub_quantum + 1e-6
+    assert bool(((x_f32 - reconstructed).abs() <= bound).all())
+
+
+def test_quantize_mxfp6_nan_input_zeroes_its_block():
+    x = torch.randn(128, 256, dtype=torch.bfloat16)
+    x[0, 5] = float("nan")
+    blob, _, sbytes = quantize_bf16_to_mxfp6_blockscaled(x, return_scale_bytes=True)
+    assert int(sbytes[0, 0]) == 0
+    assert bool((unpack_fp6_bytes(blob, 256)[0, :32] == 0).all())
+
+
+def test_quantize_mxfp6_inf_saturates_block_scale():
+    x = torch.randn(128, 256, dtype=torch.bfloat16)
+    x[0, 5] = float("inf")
+    _, _, sbytes = quantize_bf16_to_mxfp6_blockscaled(x, return_scale_bytes=True)
+    assert int(sbytes[0, 0]) == 0xFE
+
+
+def test_quantize_mxfp6_all_zero_block():
+    x = torch.randn(128, 256, dtype=torch.bfloat16)
+    x[0, :32] = 0.0
+    blob, _, sbytes = quantize_bf16_to_mxfp6_blockscaled(x, return_scale_bytes=True)
+    assert int(sbytes[0, 0]) == 0
+    assert bool((unpack_fp6_bytes(blob, 256)[0, :32] == 0).all())
+
+
+if __name__ == "__main__":
+    tilelang_testing.main()

--- a/testing/python/quantize/test_tilelang_quantize_mxfp8_scale_layout.py
+++ b/testing/python/quantize/test_tilelang_quantize_mxfp8_scale_layout.py
@@ -89,11 +89,17 @@ def test_quantize_mxfp8_nan_input_zeroes_its_block():
     assert bool((fp8_data[0, :32].to(torch.float32) == 0).all())
 
 
-def test_quantize_mxfp8_inf_saturates_block_scale():
+@pytest.mark.parametrize("dtype,fmt_max", [("e4m3", 448.0), ("e5m2", 57344.0)])
+def test_quantize_mxfp8_inf_saturates_block_scale(dtype, fmt_max):
     x = torch.randn(128, 256, dtype=torch.bfloat16)
     x[0, 5] = float("inf")
-    _, _, sbytes = quantize_bf16_to_mxfp8_blockscaled(x, return_scale_bytes=True)
+    data, _, sbytes = quantize_bf16_to_mxfp8_blockscaled(x, dtype=dtype, return_scale_bytes=True)
     assert int(sbytes[0, 0]) == 0xFE
+    # The Inf element itself must be finite and equal to the format maximum
+    # (e4m3fn has no Inf: an unclamped cast would produce NaN; e5m2 would
+    # keep Inf).
+    v = data[0, 5].to(torch.float32)
+    assert bool(torch.isfinite(v)) and float(v) == fmt_max
 
 
 if __name__ == "__main__":

--- a/testing/python/quantize/test_tilelang_quantize_mxfp8_scale_layout.py
+++ b/testing/python/quantize/test_tilelang_quantize_mxfp8_scale_layout.py
@@ -1,0 +1,74 @@
+"""CPU contract tests for the MXFP8 (FP8 + UE8M0) quantizer."""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+tilelang_testing = pytest.importorskip("tilelang.testing")
+
+from examples.dequantize_gemm.quantize import (
+    decode_ue8m0_scale_bytes,
+    pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes,
+    quantize_bf16_to_mxfp8_blockscaled,
+)
+
+
+@pytest.mark.parametrize("dtype,torch_dtype", [("e4m3", torch.float8_e4m3fn), ("e5m2", torch.float8_e5m2)])
+def test_quantize_bf16_to_mxfp8_blockscaled_contract(dtype, torch_dtype):
+    rows, cols = 128, 256
+    x = torch.randn((rows, cols), dtype=torch.bfloat16)
+
+    fp8_data, packed_scales, scale_bytes = quantize_bf16_to_mxfp8_blockscaled(x, dtype=dtype, return_scale_bytes=True)
+
+    assert fp8_data.dtype == torch_dtype and fp8_data.shape == (rows, cols)
+    assert packed_scales.dtype == torch.uint32 and packed_scales.shape == (rows, cols // 128)
+    assert scale_bytes.dtype == torch.uint8 and scale_bytes.shape == (rows, cols // 32)
+    # Scale storage is byte-identical to the MXFP4 packer.
+    assert torch.equal(packed_scales, pack_blockscaled_chunk_kmajor_ue8m0_scale_bytes(scale_bytes, block_words=2))
+
+
+def test_quantize_mxfp8_compression_invariant():
+    # The purpose constraint: quantized global storage must actually shrink.
+    # FP8 data is exactly numel bytes (1 byte per element); any future route
+    # that widens the container fails this by construction.
+    rows, cols = 128, 256
+    x = torch.randn((rows, cols), dtype=torch.bfloat16)
+    fp8_data, _ = quantize_bf16_to_mxfp8_blockscaled(x)
+    assert fp8_data.element_size() == 1
+    assert fp8_data.numel() * fp8_data.element_size() == rows * cols
+
+
+def test_quantize_bf16_to_mxfp8_blockscaled_has_bounded_error():
+    rows, cols = 128, 512
+    generator = torch.Generator(device="cpu").manual_seed(11)
+    x = (torch.randn((rows, cols), generator=generator, dtype=torch.float32) * 3.0).to(torch.bfloat16)
+
+    fp8_data, _, scale_bytes = quantize_bf16_to_mxfp8_blockscaled(x, return_scale_bytes=True)
+
+    scales = decode_ue8m0_scale_bytes(scale_bytes).repeat_interleave(32, dim=1)
+    reconstructed = fp8_data.to(torch.float32) * scales
+    x_f32 = x.to(torch.float32)
+    # Round-to-nearest e4m3 cast: error <= 0.5 ulp. For normal scaled values
+    # that is |x| * 2^-4 (3 mantissa bits); elements much smaller than their
+    # block amax land in the e4m3 subnormal range (quantum 2^-9), giving the
+    # absolute scale * 2^-10 term.
+    bound = x_f32.abs() * 2.0**-3 + scales * 2.0**-10 + 1e-6
+    assert bool(((x_f32 - reconstructed).abs() <= bound).all())
+
+
+def test_quantize_mxfp8_nan_input_zeroes_its_block():
+    x = torch.randn(128, 256, dtype=torch.bfloat16)
+    x[0, 5] = float("nan")
+    fp8_data, _, sbytes = quantize_bf16_to_mxfp8_blockscaled(x, return_scale_bytes=True)
+    assert int(sbytes[0, 0]) == 0
+    assert bool((fp8_data[0, :32].to(torch.float32) == 0).all())
+
+
+def test_quantize_mxfp8_inf_saturates_block_scale():
+    x = torch.randn(128, 256, dtype=torch.bfloat16)
+    x[0, 5] = float("inf")
+    _, _, sbytes = quantize_bf16_to_mxfp8_blockscaled(x, return_scale_bytes=True)
+    assert int(sbytes[0, 0]) == 0xFE
+
+
+if __name__ == "__main__":
+    tilelang_testing.main()

--- a/testing/python/quantize/test_tilelang_quantize_mxfp8_scale_layout.py
+++ b/testing/python/quantize/test_tilelang_quantize_mxfp8_scale_layout.py
@@ -55,6 +55,32 @@ def test_quantize_bf16_to_mxfp8_blockscaled_has_bounded_error():
     assert bool(((x_f32 - reconstructed).abs() <= bound).all())
 
 
+def test_quantize_bf16_to_mxfp8_e5m2_has_bounded_error():
+    rows, cols = 128, 512
+    generator = torch.Generator(device="cpu").manual_seed(12)
+    x = (torch.randn((rows, cols), generator=generator, dtype=torch.float32) * 3.0).to(torch.bfloat16)
+
+    fp8_data, _, scale_bytes = quantize_bf16_to_mxfp8_blockscaled(x, dtype="e5m2", return_scale_bytes=True)
+
+    scales = decode_ue8m0_scale_bytes(scale_bytes).repeat_interleave(32, dim=1)
+    reconstructed = fp8_data.to(torch.float32) * scales
+    x_f32 = x.to(torch.float32)
+    # e5m2 has 2 mantissa bits (0.5 ulp = |x| * 2^-3) and a 2^-16 subnormal
+    # quantum, giving the absolute scale * 2^-17 term.
+    bound = x_f32.abs() * 2.0**-2 + scales * 2.0**-17 + 1e-6
+    assert bool(((x_f32 - reconstructed).abs() <= bound).all())
+
+
+def test_quantize_mxfp8_all_zero_block():
+    # UE8M0 cannot encode a zero scale; an all-zero block must be written as
+    # zero data with scale byte 0x00 (= 2^-127), reconstructing to exact 0.
+    x = torch.randn(128, 256, dtype=torch.bfloat16)
+    x[0, :32] = 0.0
+    fp8_data, _, sbytes = quantize_bf16_to_mxfp8_blockscaled(x, return_scale_bytes=True)
+    assert int(sbytes[0, 0]) == 0
+    assert bool((fp8_data[0, :32].to(torch.float32) == 0).all())
+
+
 def test_quantize_mxfp8_nan_input_zeroes_its_block():
     x = torch.randn(128, 256, dtype=torch.bfloat16)
     x[0, 5] = float("nan")

--- a/testing/python/quantize/test_tilelang_quantize_nvfp4_scale_layout.py
+++ b/testing/python/quantize/test_tilelang_quantize_nvfp4_scale_layout.py
@@ -589,6 +589,23 @@ def test_pack_blockscaled_chunk_kmajor_scale_bytes_random_binary_512x32_matches_
     assert torch.equal(_unpack_with_oracle(packed, rows, k16_cols), scale_bytes)
 
 
+@pytest.mark.parametrize("block_words", [1, 2])
+def test_pack_blockscaled_chunk_kmajor_scale_bytes_narrow_block_words_matches_oracle(block_words):
+    # block_K = 64 / 128 tiles: same 128-row K-major word stack, narrower
+    # per-tile width. Three K tiles so multi-tile column order is exercised.
+    rows = 256
+    k = 64 * block_words * 3
+    k16_cols = k // 16
+    generator = torch.Generator(device="cpu").manual_seed(23 + block_words)
+    scale_bytes = torch.randint(0, 256, (rows, k16_cols), generator=generator, dtype=torch.uint8)
+
+    packed = pack_blockscaled_chunk_kmajor_scale_bytes(scale_bytes, block_words=block_words)
+
+    assert packed.shape == (rows, k16_cols // 4)
+    assert packed.dtype == torch.uint32
+    assert torch.equal(_unpack_with_oracle(packed, rows, k16_cols), scale_bytes)
+
+
 def test_pack_blockscaled_chunk_kmajor_scale_bytes_matches_cutedsl_blocked_sf_layout():
     """Byte-level cross-compatibility with the CuTeDSL/CUTLASS canonical SF layout.
 
@@ -873,6 +890,9 @@ def test_blockscaled_chunk_kmajor_scale_packer_rejects_invalid_shapes():
 
     with pytest.raises(ValueError, match="K/16 columns multiple of 16"):
         pack_blockscaled_chunk_kmajor_scale_bytes(torch.zeros((128, 12), dtype=torch.uint8))
+
+    with pytest.raises(ValueError, match=r"block_words in \(1, 2, 4\)"):
+        pack_blockscaled_chunk_kmajor_scale_bytes(torch.zeros((128, 12), dtype=torch.uint8), block_words=3)
 
     with pytest.raises(TypeError, match="torch.uint8"):
         pack_blockscaled_chunk_kmajor_scale_bytes(torch.zeros((128, 16), dtype=torch.int32))

--- a/tilelang/cuda/intrinsics/macro/mma_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_macro_generator.py
@@ -158,6 +158,10 @@ class TensorCoreIntrinEmitter:
     def _get_dtype_abbrv(self, dtype: str) -> str:
         if "float4_e2m1_unpacked" in dtype:
             return "e2m1"
+        if "float6_e2m3fn_unpacked" in dtype:
+            return "e2m3"
+        if "float6_e3m2fn_unpacked" in dtype:
+            return "e3m2"
         if dtype not in self.dtype_abbrv:
             raise ValueError(f"Unsupported dtype: {dtype}")
         return self.dtype_abbrv[dtype]

--- a/tilelang/cuda/intrinsics/macro/mma_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_macro_generator.py
@@ -71,6 +71,10 @@ class TensorCoreIntrinEmitter:
         "float6_e3m2fn": "e3m2",
         "float4_e2m1fn": "e2m1",
         "custom[float4_e2m1_unpacked]8": "e2m1",
+        "float6_e2m3fn_unpacked": "e2m3",
+        "custom[float6_e2m3fn_unpacked]8": "e2m3",
+        "float6_e3m2fn_unpacked": "e3m2",
+        "custom[float6_e3m2fn_unpacked]8": "e3m2",
         "custom[tfloat32]": "tf32",
     }
 

--- a/tilelang/cuda/intrinsics/macro/mma_sm120_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_sm120_macro_generator.py
@@ -125,9 +125,10 @@ class SM120BlockScaleTile:
                 f"SM120 full-tile warp N shape mismatch: warp_col_tiles={self.warp_col_tiles}, "
                 f"warp_cols={self.warp_cols}, micro_size_n={self.micro_size_n}"
             )
-        if self.tile_m % 32 != 0 or self.tile_n % 32 != 0:
+        if self.tile_m % 128 != 0 or self.tile_n % 128 != 0:
             raise ValueError(
-                f"SM120 compact shared scale tiles require block M/N multiples of 32, got tile_m={self.tile_m}, tile_n={self.tile_n}"
+                "SM120 kmajor scale sources stack 128-row BlockScaledBasicChunk atoms, so "
+                f"block M/N must be multiples of 128, got tile_m={self.tile_m}, tile_n={self.tile_n}"
             )
         if self.kblocks <= 0 or self.micro_size_k <= 0 or self.tile_k != self.kblocks * self.micro_size_k:
             raise ValueError(
@@ -152,18 +153,29 @@ class SM120BlockScaleTile:
                 f"{self.warp_issues}, {self.warpgroup_issues}"
             )
 
+    @property
+    def words_per_stage(self) -> int:
+        """uint32 words per staged (tile_rows, tile_k) scale slice row span.
+
+        One word packs four scale bytes; for the 4X/ue4m3 config each byte
+        covers 16 K elements, so a tile_k stage holds ``tile_k // 64`` words.
+        """
+
+        return self.tile_k // 64
+
     def _scale_word_offset(self, row: int, kblock: int, tile_rows: int) -> int:
         """Return the uint32 scale-word offset for the source/smem scale layout."""
 
-        if tile_rows <= 0 or tile_rows % 32 != 0:
-            raise ValueError(f"scale tile rows must be a positive multiple of 32, got {tile_rows}")
+        if tile_rows <= 0 or tile_rows % 128 != 0:
+            raise ValueError(f"scale tile rows must be a positive multiple of 128, got {tile_rows}")
         if row < 0 or row >= tile_rows:
             raise ValueError(f"scale row must be in [0, {tile_rows}), got {row}")
         if kblock < 0 or kblock >= self.kblocks:
             raise ValueError(f"kblock must be in [0, {self.kblocks}), got {kblock}")
-        # K-major storage groups rows as [row % 32][row // 32] within each K atom.
-        row_groups = tile_rows // 32
-        return kblock * tile_rows + (row & 31) * row_groups + (row >> 5)
+        # The packer stacks 128-row K-major atoms vertically; inside one atom
+        # rows are stored as [word][row % 32][row // 32], regardless of the
+        # staged tile height.
+        return (row // 128) * (self.words_per_stage * 128) + kblock * 128 + (row % 32) * 4 + (row % 128) // 32
 
     def compact_selector_scale_rows(self, lane: int, warp_m: int, warp_n: int) -> tuple[tuple[int, int], tuple[int, int]]:
         """Return SFA/SFB semantic rows loaded by the current compact TV package."""
@@ -512,10 +524,16 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
         return (_k_start + self.micro_size_k * ki) // packed_word_k
 
     @staticmethod
-    def _tile_kmajor_scale_word(idx: PrimExpr, word_k: PrimExpr, tile_rows: int):
-        """Return a tile-local compact K-major scale-word offset."""
+    def _tile_kmajor_scale_word(idx: PrimExpr, word_k: PrimExpr, words_per_stage: int):
+        """Return a tile-local compact K-major scale-word offset.
 
-        return word_k * tile_rows + (idx % 32) * (tile_rows // 32) + idx // 32
+        The scale source stacks 128-row BlockScaledBasicChunk atoms
+        vertically: the in-atom order is the packer's fixed 4-group split of
+        128 rows regardless of the staged tile height, and rows beyond the
+        first atom live ``words_per_stage * 128`` words further.
+        """
+
+        return (idx // 128) * (words_per_stage * 128) + word_k * 128 + (idx % 32) * 4 + (idx % 128) // 32
 
     def mma(
         self,
@@ -736,6 +754,9 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
         if sf_layout != "blockscaled_chunk_kmajor":
             raise ValueError("sm120 full-tile MMA currently requires sf_layout='blockscaled_chunk_kmajor'")
         k_blocks = int(self.chunk // self.micro_size_k)
+        # Words per staged (tile_rows, block_K) scale slice: one uint32 packs
+        # four scale bytes covering sf_vec_size K elements each.
+        words_per_stage = int(self.chunk // (self.sf_vec_size * 4))
         tile = SM120BlockScaleTile.from_emitter(
             self,
             sf_layout=sf_layout,
@@ -744,8 +765,6 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
 
         warp_rows = self.warp_rows
         warp_cols = self.warp_cols
-        tile_m = tile.tile_m
-        tile_n = tile.tile_n
         sfa_words = tile.sfa_words
         sfb_words = tile.sfb_words
         local_size_a = self.local_size_a
@@ -780,14 +799,14 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
             scale_m0 = warp_m * self.warp_row_tiles + (qlane // 2) * 16 + sfa_row
             scale_n0 = warp_n * self.warp_col_tiles + qlane * 8 + sfb_col
             for g in T.unroll(sfa_words):
-                scale_a_word = self._tile_kmajor_scale_word(scale_m0 + g * 32, k_block, tile_m)
+                scale_a_word = self._tile_kmajor_scale_word(scale_m0 + g * 32, k_block, words_per_stage)
                 SFA_local_buf[g] = SFA_data[
-                    tuple(SFA_other) + (SFA_base_m + scale_a_word // k_blocks, SFA_base_k + scale_a_word % k_blocks)
+                    tuple(SFA_other) + (SFA_base_m + scale_a_word // words_per_stage, SFA_base_k + scale_a_word % words_per_stage)
                 ]
             for g in T.unroll(sfb_words):
-                scale_b_word = self._tile_kmajor_scale_word(scale_n0 + g * 32, k_block, tile_n)
+                scale_b_word = self._tile_kmajor_scale_word(scale_n0 + g * 32, k_block, words_per_stage)
                 SFB_local_buf[g] = SFB_data[
-                    tuple(SFB_other) + (SFB_base_n + scale_b_word // k_blocks, SFB_base_k + scale_b_word % k_blocks)
+                    tuple(SFB_other) + (SFB_base_n + scale_b_word // words_per_stage, SFB_base_k + scale_b_word % words_per_stage)
                 ]
 
         @T.macro

--- a/tilelang/cuda/intrinsics/macro/mma_sm120_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_sm120_macro_generator.py
@@ -57,6 +57,8 @@ class SM120BlockScaleTile:
     sfb_words: int
     warp_issues: int
     warpgroup_issues: int
+    # K elements covered by one scale byte (16 for 4X modes, 32 for 2X).
+    sf_vec_size: int = 16
 
     @classmethod
     def from_emitter(
@@ -89,6 +91,7 @@ class SM120BlockScaleTile:
             warpgroup_issues=(
                 int(emitter.warp_rows) * int(emitter.warp_cols) * 2 * int(emitter.block_row_warps) * int(emitter.block_col_warps)
             ),
+            sf_vec_size=int(emitter.sf_vec_size),
         )
         tile.validate()
         return tile
@@ -136,6 +139,11 @@ class SM120BlockScaleTile:
             )
         if self.sf_layout != "blockscaled_chunk_kmajor":
             raise ValueError("SM120 full-tile package contract requires sf_layout='blockscaled_chunk_kmajor'")
+        if self.sf_vec_size <= 0 or self.tile_k % (self.sf_vec_size * 4) != 0:
+            raise ValueError(
+                f"SM120 kmajor scale words pack {self.sf_vec_size * 4} K elements; "
+                f"tile_k must be a multiple of that, got tile_k={self.tile_k}"
+            )
         expected_sfa_words = (self.warp_rows + 1) // 2
         expected_sfb_words = (self.warp_cols + 1) // 2
         if (self.sfa_words, self.sfb_words) != (expected_sfa_words, expected_sfb_words):
@@ -157,11 +165,11 @@ class SM120BlockScaleTile:
     def words_per_stage(self) -> int:
         """uint32 words per staged (tile_rows, tile_k) scale slice row span.
 
-        One word packs four scale bytes; for the 4X/ue4m3 config each byte
-        covers 16 K elements, so a tile_k stage holds ``tile_k // 64`` words.
+        One word packs four scale bytes of ``sf_vec_size`` K elements each,
+        so a tile_k stage holds ``tile_k // (sf_vec_size * 4)`` words.
         """
 
-        return self.tile_k // 64
+        return self.tile_k // (self.sf_vec_size * 4)
 
     def _scale_word_offset(self, row: int, kblock: int, tile_rows: int) -> int:
         """Return the uint32 scale-word offset for the source/smem scale layout."""
@@ -170,8 +178,8 @@ class SM120BlockScaleTile:
             raise ValueError(f"scale tile rows must be a positive multiple of 128, got {tile_rows}")
         if row < 0 or row >= tile_rows:
             raise ValueError(f"scale row must be in [0, {tile_rows}), got {row}")
-        if kblock < 0 or kblock >= self.kblocks:
-            raise ValueError(f"kblock must be in [0, {self.kblocks}), got {kblock}")
+        if kblock < 0 or kblock >= self.words_per_stage:
+            raise ValueError(f"kblock must be a word column in [0, {self.words_per_stage}), got {kblock}")
         # The packer stacks 128-row K-major atoms vertically; inside one atom
         # rows are stored as [word][row % 32][row // 32], regardless of the
         # staged tile height.
@@ -286,6 +294,31 @@ _SUPPORTED_BLOCK_SCALE_MMA_CONFIGS = {
         a_dtype_abbrv="e2m1",
         b_dtype_abbrv="e2m1",
     ),
+    # MXFP4: 32-element scale granularity, power-of-two (ue8m0) scales. One
+    # uint32 scale word covers K=128; each k64 MMA atom consumes a 2-byte
+    # half selected by scale_*_byte_id.
+    ("mxf4nvf4", 2, "ue8m0"): BlockScaleMmaConfig(
+        kind="mxf4nvf4",
+        mma_prefix="m16n8k64",
+        atom_k=64,
+        scale_vec_size=2,
+        sf_vec_size=32,
+        scale_type="ue8m0",
+        a_dtype_abbrv="e2m1",
+        b_dtype_abbrv="e2m1",
+    ),
+    # NVF4 granularity with ue8m0 scales; the instruction needs CUDA 13.1+
+    # (see mma_block_scale.h), word/byte accounting matches the ue4m3 form.
+    ("mxf4nvf4", 4, "ue8m0"): BlockScaleMmaConfig(
+        kind="mxf4nvf4",
+        mma_prefix="m16n8k64",
+        atom_k=64,
+        scale_vec_size=4,
+        sf_vec_size=16,
+        scale_type="ue8m0",
+        a_dtype_abbrv="e2m1",
+        b_dtype_abbrv="e2m1",
+    ),
 }
 
 
@@ -346,6 +379,12 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
             self.scale_vec_size = self.block_scale_config.scale_vec_size
             self.stype = self.block_scale_config.scale_type
             self.sf_vec_size = self.block_scale_config.sf_vec_size
+            if int(chunk) % (self.sf_vec_size * 4) != 0:
+                raise ValueError(
+                    f"{self.kind} scale_vec::{self.scale_vec_size}X packs "
+                    f"{self.sf_vec_size * 4} K elements per uint32 scale word; "
+                    f"block_K must be a multiple of that, got block_K={chunk}"
+                )
         super().__init__(
             a_dtype=a_dtype,
             b_dtype=b_dtype,
@@ -523,6 +562,20 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
         _k_start = tvm.tirx.const(k_start, "int32") if isinstance(k_start, int) else k_start
         return (_k_start + self.micro_size_k * ki) // packed_word_k
 
+    def _scale_byte_id(self, k_start: PrimExpr, ki: PrimExpr):
+        """Byte offset of the consumed scale bytes inside their uint32 word.
+
+        scale_vec::4X consumes the whole word, so the byte id is always the
+        literal 0 (keeping 4X codegen byte-identical). scale_vec::2X consumes
+        a 2-byte half selected by the k64 atom parity inside the K=128 word.
+        """
+
+        if self.scale_vec_size == 4:
+            return 0
+        word_span = self.sf_vec_size * 4
+        _k_start = tvm.tirx.const(k_start, "int32") if isinstance(k_start, int) else k_start
+        return ((_k_start + self.micro_size_k * ki) % word_span) // self.sf_vec_size
+
     @staticmethod
     def _tile_kmajor_scale_word(idx: PrimExpr, word_k: PrimExpr, words_per_stage: int):
         """Return a tile-local compact K-major scale-word offset.
@@ -582,6 +635,7 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
         sf_b_granularity_k = sf_vec_size if sf_b_granularity_k is None else sf_b_granularity_k
         scale_a_word_k = self._scale_word_k(k_start, k_inner, sf_a_granularity_k)
         scale_b_word_k = self._scale_word_k(k_start, k_inner, sf_b_granularity_k)
+        scale_byte_id = self._scale_byte_id(k_start, k_inner)
         thread_binding = self.get_thread_binding()
         SFA_data, SFA_other, SFA_base_m, SFA_base_k = self._scale_region_parts(SFA_buf)
         SFB_data, SFB_other, SFB_base_n, SFB_base_k = self._scale_region_parts(SFB_buf)
@@ -621,6 +675,10 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
                     i * warp_cols * local_size_out + j * local_size_out,
                     scale_a_ptr,
                     scale_b_ptr,
+                    scale_byte_id,
+                    0,
+                    scale_byte_id,
+                    0,
                 )
                 if replicate_b:
                     scale_b_rep_ptr = T.access_ptr(
@@ -645,6 +703,10 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
                         i * warp_cols * local_size_out + j * local_size_out + lift(local_size_out) // 2,
                         scale_a_ptr,
                         scale_b_rep_ptr,
+                        scale_byte_id,
+                        0,
+                        scale_byte_id,
+                        0,
                     )
 
         return _warp_mma_block_scale(A_local_buf, B_local_buf, C_local_buf, SFA_data, SFB_data, thread_binding)
@@ -757,6 +819,8 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
         # Words per staged (tile_rows, block_K) scale slice: one uint32 packs
         # four scale bytes covering sf_vec_size K elements each.
         words_per_stage = int(self.chunk // (self.sf_vec_size * 4))
+        # k64 MMA atoms served by one scale word (4X: 1, 2X: 2 via byte halves).
+        atoms_per_word = int((self.sf_vec_size * 4) // self.micro_size_k)
         tile = SM120BlockScaleTile.from_emitter(
             self,
             sf_layout=sf_layout,
@@ -798,19 +862,21 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
             sfb_col = self._sfb_col_in_atom(tx)
             scale_m0 = warp_m * self.warp_row_tiles + (qlane // 2) * 16 + sfa_row
             scale_n0 = warp_n * self.warp_col_tiles + qlane * 8 + sfb_col
+            k_word = k_block if atoms_per_word == 1 else k_block // atoms_per_word
             for g in T.unroll(sfa_words):
-                scale_a_word = self._tile_kmajor_scale_word(scale_m0 + g * 32, k_block, words_per_stage)
+                scale_a_word = self._tile_kmajor_scale_word(scale_m0 + g * 32, k_word, words_per_stage)
                 SFA_local_buf[g] = SFA_data[
                     tuple(SFA_other) + (SFA_base_m + scale_a_word // words_per_stage, SFA_base_k + scale_a_word % words_per_stage)
                 ]
             for g in T.unroll(sfb_words):
-                scale_b_word = self._tile_kmajor_scale_word(scale_n0 + g * 32, k_block, words_per_stage)
+                scale_b_word = self._tile_kmajor_scale_word(scale_n0 + g * 32, k_word, words_per_stage)
                 SFB_local_buf[g] = SFB_data[
                     tuple(SFB_other) + (SFB_base_n + scale_b_word // words_per_stage, SFB_base_k + scale_b_word % words_per_stage)
                 ]
 
         @T.macro
-        def _mma_kblock(A_local_buf, B_local_buf, SFA_local_buf, SFB_local_buf, C_local_buf):
+        def _mma_kblock(A_local_buf, B_local_buf, SFA_local_buf, SFB_local_buf, C_local_buf, k_block):
+            scale_byte = 0 if atoms_per_word == 1 else (k_block % atoms_per_word) * 2
             for i in T.unroll(warp_rows):
                 scale_a_ptr = T.access_ptr(SFA_local_buf[i // 2], "r")
                 for j in T.unroll(warp_cols):
@@ -834,9 +900,9 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
                             i * warp_cols * local_size_out + j * local_size_out + n8_half * (local_size_out // 2),
                             scale_a_ptr,
                             scale_b_ptr,
-                            0,
+                            scale_byte,
                             i % 2,
-                            0,
+                            scale_byte,
                             (j % 2) * 2 + n8_half,
                         )
 
@@ -852,7 +918,7 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
                 SFB_local_0 = T.alloc_local((sfb_words,), "uint32")
 
                 _load_kblock(A_local_0, B_local_0, SFA_local_0, SFB_local_0, 0)
-                _mma_kblock(A_local_0, B_local_0, SFA_local_0, SFB_local_0, C_local_buf)
+                _mma_kblock(A_local_0, B_local_0, SFA_local_0, SFB_local_0, C_local_buf, 0)
 
         else:
 
@@ -872,11 +938,11 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
                 # Refill a package with k+2 only after its current K block has issued.
                 for k_block in T.unroll(k_blocks):
                     if k_block % 2 == 0:
-                        _mma_kblock(A_local_0, B_local_0, SFA_local_0, SFB_local_0, C_local_buf)
+                        _mma_kblock(A_local_0, B_local_0, SFA_local_0, SFB_local_0, C_local_buf, k_block)
                         if k_block + 2 < k_blocks:
                             _load_kblock(A_local_0, B_local_0, SFA_local_0, SFB_local_0, k_block + 2)
                     else:
-                        _mma_kblock(A_local_1, B_local_1, SFA_local_1, SFB_local_1, C_local_buf)
+                        _mma_kblock(A_local_1, B_local_1, SFA_local_1, SFB_local_1, C_local_buf, k_block)
                         if k_block + 2 < k_blocks:
                             _load_kblock(A_local_1, B_local_1, SFA_local_1, SFB_local_1, k_block + 2)
 
@@ -892,6 +958,8 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
         SFB_rep_fragment_buf,
         inst_m_idx: PrimExpr | int,
         inst_n_idx: PrimExpr | int,
+        *,
+        scale_byte_id: PrimExpr | int = 0,
     ):
         """Issue one SM120 block-scaled MMA atom from a full B fragment tile."""
         return self.mma_full_b_atom_with_prefetched_scales(
@@ -903,6 +971,7 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
             SFB_rep_fragment_buf,
             inst_m_idx,
             inst_n_idx,
+            scale_byte_id=scale_byte_id,
         )
 
     def mma_full_b_atom_with_prefetched_scales(
@@ -915,6 +984,8 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
         SFB_rep_local_buf,
         inst_m_idx: PrimExpr | int,
         inst_n_idx: PrimExpr | int,
+        *,
+        scale_byte_id: PrimExpr | int = 0,
     ):
         local_size_a = self.local_size_a
         local_size_b = self.local_size_b
@@ -958,6 +1029,10 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
                 inst_m_idx * warp_cols * local_size_out + inst_n_idx * local_size_out,
                 scale_a_ptr,
                 scale_b_ptr,
+                scale_byte_id,
+                0,
+                scale_byte_id,
+                0,
             )
             if replicate_b:
                 scale_b_rep_ptr = T.access_ptr(SFB_rep_local_buf[inst_n_idx], "r")
@@ -979,6 +1054,10 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
                     inst_m_idx * warp_cols * local_size_out + inst_n_idx * local_size_out + lift(local_size_out) // 2,
                     scale_a_ptr,
                     scale_b_rep_ptr,
+                    scale_byte_id,
+                    0,
+                    scale_byte_id,
+                    0,
                 )
 
         return _warp_mma_block_scale_full_b_atom_prefetched(

--- a/tilelang/cuda/intrinsics/macro/mma_sm120_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_sm120_macro_generator.py
@@ -512,12 +512,6 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
         return (_k_start + self.micro_size_k * ki) // packed_word_k
 
     @staticmethod
-    def _kmajor_scale_word(idx: PrimExpr, word_k: PrimExpr):
-        """Return the flattened uint32 offset for one packed scale word."""
-
-        return TensorCoreIntrinEmitterSM120._tile_kmajor_scale_word(idx, word_k, 128)
-
-    @staticmethod
     def _tile_kmajor_scale_word(idx: PrimExpr, word_k: PrimExpr, tile_rows: int):
         """Return a tile-local compact K-major scale-word offset."""
 
@@ -545,6 +539,10 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
             return super().mma(A_local_buf, B_local_buf, C_local_buf, k_inner)
         if SFA_buf is None or SFB_buf is None:
             raise ValueError("Block-scaled MMA requires SFA and SFB buffers")
+        if sf_layout != "rowmajor":
+            raise ValueError(
+                "mma() supports sf_layout='rowmajor' only; blockscaled_chunk_kmajor scales are handled by mma_blockscaled_fulltile"
+            )
         warp_rows = self.warp_rows
         warp_cols = self.warp_cols
         local_size_a = self.local_size_a
@@ -570,8 +568,6 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
         SFA_data, SFA_other, SFA_base_m, SFA_base_k = self._scale_region_parts(SFA_buf)
         SFB_data, SFB_other, SFB_base_n, SFB_base_k = self._scale_region_parts(SFB_buf)
         replicate_b = self.n_dim == 16
-        if sf_layout not in ("rowmajor", "blockscaled_chunk_kmajor"):
-            raise ValueError(f"Unsupported SM120 scale layout: {sf_layout}")
 
         @T.macro
         def _warp_mma_block_scale(A_local_buf, B_local_buf, C_local_buf, SFA_data, SFB_data, thread_binding):
@@ -581,26 +577,14 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
             for i, j in T.grid(warp_rows, warp_cols):
                 scale_m = warp_m * warp_row_tiles + i * micro_size_x + sfa_row
                 scale_n = warp_n * warp_col_tiles + j * micro_size_y + sfb_col
-                if sf_layout == "blockscaled_chunk_kmajor":
-                    scale_a_word = self._kmajor_scale_word(scale_m, scale_a_word_k)
-                    scale_b_word = self._kmajor_scale_word(scale_n, scale_b_word_k)
-                    scale_a_ptr = T.access_ptr(
-                        SFA_data[tuple(SFA_other) + (SFA_base_m + scale_a_word // 4, SFA_base_k + scale_a_word % 4)],
-                        "r",
-                    )
-                    scale_b_ptr = T.access_ptr(
-                        SFB_data[tuple(SFB_other) + (SFB_base_n + scale_b_word // 4, SFB_base_k + scale_b_word % 4)],
-                        "r",
-                    )
-                else:
-                    scale_a_ptr = T.access_ptr(
-                        SFA_data[tuple(SFA_other) + (SFA_base_m + scale_m, SFA_base_k + scale_a_word_k)],
-                        "r",
-                    )
-                    scale_b_ptr = T.access_ptr(
-                        SFB_data[tuple(SFB_other) + (SFB_base_n + scale_n, SFB_base_k + scale_b_word_k)],
-                        "r",
-                    )
+                scale_a_ptr = T.access_ptr(
+                    SFA_data[tuple(SFA_other) + (SFA_base_m + scale_m, SFA_base_k + scale_a_word_k)],
+                    "r",
+                )
+                scale_b_ptr = T.access_ptr(
+                    SFB_data[tuple(SFB_other) + (SFB_base_n + scale_n, SFB_base_k + scale_b_word_k)],
+                    "r",
+                )
                 T.ptx_mma_block_scale(
                     accum_dtype,
                     mma_prefix,
@@ -621,18 +605,10 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
                     scale_b_ptr,
                 )
                 if replicate_b:
-                    if sf_layout == "blockscaled_chunk_kmajor":
-                        scale_b_rep_n = scale_n + 8
-                        scale_b_rep_word = self._kmajor_scale_word(scale_b_rep_n, scale_b_word_k)
-                        scale_b_rep_ptr = T.access_ptr(
-                            SFB_data[tuple(SFB_other) + (SFB_base_n + scale_b_rep_word // 4, SFB_base_k + scale_b_rep_word % 4)],
-                            "r",
-                        )
-                    else:
-                        scale_b_rep_ptr = T.access_ptr(
-                            SFB_data[tuple(SFB_other) + (SFB_base_n + scale_n + 8, SFB_base_k + scale_b_word_k)],
-                            "r",
-                        )
+                    scale_b_rep_ptr = T.access_ptr(
+                        SFB_data[tuple(SFB_other) + (SFB_base_n + scale_n + 8, SFB_base_k + scale_b_word_k)],
+                        "r",
+                    )
                     T.ptx_mma_block_scale(
                         accum_dtype,
                         mma_prefix,
@@ -668,6 +644,10 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
         sf_b_granularity_k: int | None = None,
         sf_layout: str = "rowmajor",
     ):
+        if sf_layout != "rowmajor":
+            raise ValueError(
+                "ldscale() supports sf_layout='rowmajor' only; blockscaled_chunk_kmajor scales are handled by mma_blockscaled_fulltile"
+            )
         warp_rows = self.warp_rows
         warp_cols = self.warp_cols
         warp_row_tiles = self.warp_row_tiles
@@ -683,8 +663,6 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
         SFA_data, SFA_other, SFA_base_m, SFA_base_k = self._scale_region_parts(SFA_buf)
         SFB_data, SFB_other, SFB_base_n, SFB_base_k = self._scale_region_parts(SFB_buf)
         replicate_b = self.n_dim == 16
-        if sf_layout not in ("rowmajor", "blockscaled_chunk_kmajor"):
-            raise ValueError(f"Unsupported SM120 scale layout: {sf_layout}")
 
         @T.macro
         def _warp_ldscale_block_scale(SFA_local_buf, SFB_local_buf, SFB_rep_local_buf, SFA_data, SFB_data, thread_binding):
@@ -693,27 +671,12 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
             sfb_col = self._sfb_col_in_atom(tx)
             for i in T.unroll(warp_rows):
                 scale_m = warp_m * warp_row_tiles + i * micro_size_x + sfa_row
-                if sf_layout == "blockscaled_chunk_kmajor":
-                    scale_a_word = self._kmajor_scale_word(scale_m, scale_a_word_k)
-                    SFA_local_buf[i] = SFA_data[tuple(SFA_other) + (SFA_base_m + scale_a_word // 4, SFA_base_k + scale_a_word % 4)]
-                else:
-                    SFA_local_buf[i] = SFA_data[tuple(SFA_other) + (SFA_base_m + scale_m, SFA_base_k + scale_a_word_k)]
+                SFA_local_buf[i] = SFA_data[tuple(SFA_other) + (SFA_base_m + scale_m, SFA_base_k + scale_a_word_k)]
             for j in T.unroll(warp_cols):
                 scale_n = warp_n * warp_col_tiles + j * micro_size_y + sfb_col
-                if sf_layout == "blockscaled_chunk_kmajor":
-                    scale_b_word = self._kmajor_scale_word(scale_n, scale_b_word_k)
-                    SFB_local_buf[j] = SFB_data[tuple(SFB_other) + (SFB_base_n + scale_b_word // 4, SFB_base_k + scale_b_word % 4)]
-                else:
-                    SFB_local_buf[j] = SFB_data[tuple(SFB_other) + (SFB_base_n + scale_n, SFB_base_k + scale_b_word_k)]
+                SFB_local_buf[j] = SFB_data[tuple(SFB_other) + (SFB_base_n + scale_n, SFB_base_k + scale_b_word_k)]
                 if replicate_b:
-                    if sf_layout == "blockscaled_chunk_kmajor":
-                        scale_b_rep_n = scale_n + 8
-                        scale_b_rep_word = self._kmajor_scale_word(scale_b_rep_n, scale_b_word_k)
-                        SFB_rep_local_buf[j] = SFB_data[
-                            tuple(SFB_other) + (SFB_base_n + scale_b_rep_word // 4, SFB_base_k + scale_b_rep_word % 4)
-                        ]
-                    else:
-                        SFB_rep_local_buf[j] = SFB_data[tuple(SFB_other) + (SFB_base_n + scale_n + 8, SFB_base_k + scale_b_word_k)]
+                    SFB_rep_local_buf[j] = SFB_data[tuple(SFB_other) + (SFB_base_n + scale_n + 8, SFB_base_k + scale_b_word_k)]
 
         return _warp_ldscale_block_scale(
             SFA_local_buf,

--- a/tilelang/cuda/intrinsics/macro/mma_sm120_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_sm120_macro_generator.py
@@ -12,6 +12,7 @@ from ..layout.mma_layout import (
     ldmatrix_32x32_to_shared_16x64_layout_a,
     ldmatrix_32x32_to_shared_16x64_layout_b,
 )
+from ..layout.utils import get_ldmatrix_offset
 from .mma_macro_generator import TensorCoreIntrinEmitter as MMAIntrinEmitter
 
 lift = convert
@@ -322,9 +323,11 @@ _SUPPORTED_BLOCK_SCALE_MMA_CONFIGS = {
         a_dtype_abbrv="e2m1",
         b_dtype_abbrv="e2m1",
     ),
-    # MXFP8: pure-fp8 {e4m3,e5m2}^2 at m16n8k32, one ue8m0 byte per 32 K
-    # elements (scale_vec::1X is the only legal vector size for this kind).
-    # A uint32 scale word still covers K=128, now as four one-byte atoms.
+    # kind::mxf8f6f4 at m16n8k32: any pairing from the f8f6f4 family, one
+    # ue8m0 byte per 32 K elements (scale_vec::1X is the only legal vector
+    # size for this kind). A uint32 scale word still covers K=128, now as
+    # four one-byte atoms. fp4/fp6 operands use unpacked 8-bit smem/register
+    # containers loaded by the sub-byte ldmatrix variants.
     ("mxf8f6f4", 1, "ue8m0"): BlockScaleMmaConfig(
         kind="mxf8f6f4",
         mma_prefix="m16n8k32",
@@ -334,9 +337,29 @@ _SUPPORTED_BLOCK_SCALE_MMA_CONFIGS = {
         scale_type="ue8m0",
         a_dtype_abbrv=None,
         b_dtype_abbrv=None,
-        operand_family=("e4m3", "e5m2"),
+        operand_family=("e2m1", "e2m3", "e3m2", "e4m3", "e5m2"),
     ),
 }
+
+
+# smem->register load category per mxf8f6f4 operand dtype: fp8 uses the
+# classic b16 ldmatrix; fp4/fp6 use the sub-byte variants (m8n16.b8x16),
+# which share the b16 lane addressing (byte-identical fragment layout).
+# The value is (ldmatrix variant | None, post-load register shift bits).
+_MXF8F6F4_OPERAND_LOAD = {
+    "float4_e2m1_unpacked": ("su4", 2),
+    "float6_e2m3fn_unpacked": ("su6", 0),
+    "float6_e3m2fn_unpacked": ("su6", 0),
+}
+
+
+def _canonical_dtype_name(name: str) -> str:
+    """Strip TVM's ``custom[...]`` wrapper from registered dtype names."""
+    return name[len("custom[") : -1] if name.startswith("custom[") and name.endswith("]") else name
+
+
+def _mxf8f6f4_operand_load(dtype) -> tuple[str, int] | None:
+    return _MXF8F6F4_OPERAND_LOAD.get(_canonical_dtype_name(str(dtype)))
 
 
 def _get_block_scale_mma_config(kind: str, scale_vec_size: int, scale_type: str) -> BlockScaleMmaConfig:
@@ -451,9 +474,70 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
         else:
             super()._initialize_mma_prefix(k_dim)
 
+    def _ldmatrix_subbyte(self, side, local_buf, shared_buf, ki, rk, variant, shift_bits):
+        """su4/su6 fragment load for fp4/fp6 mxf8f6f4 operands.
+
+        The smem buffer models the 16U4/16U6_ALIGN16B padded-packed layout
+        (16 elements per 16-byte group), whose byte footprint equals the
+        8-bit path - so the classic 8-bit lane addressing is reused verbatim
+        and only the ldmatrix opcode (and the e2m1 <<2 container shift)
+        differ.
+        """
+        is_a = side == "A"
+        tiles = self.warp_row_tiles if is_a else self.warp_col_tiles
+        frags = self.warp_rows if is_a else self.warp_cols
+        micro_mn = self.micro_size_x if is_a else self.micro_size_y
+        chunk = self.chunk
+        micro_size_k = self.micro_size_k
+        local_size = self.local_size_a if is_a else self.local_size_b
+        transposed = self.a_transposed if is_a else self.b_transposed
+        if is_a and transposed:
+            raise ValueError("sub-byte ldmatrix variants have no trans form; A must be row-major (K-last)")
+        if not is_a and not transposed:
+            raise ValueError("sub-byte ldmatrix variants have no trans form; B must be transposed (K-last)")
+        num = 4 if is_a or self.n_dim == 16 else 2
+        shift_words = (local_size if num == 4 else local_size // 2) // 4
+
+        thread_binding = self.get_thread_binding()
+        region = self._legalize_to_buffer_region(shared_buf)
+        buf = region.buffer
+        base0 = region.region[-2].min
+        base1 = region.region[-1].min
+        other = [r.min for r in region.region[:-2]]
+        stride = buf.shape[-1]
+
+        @T.macro
+        def _warp_ldmatrix_subbyte(local_buf, shared_buf, ki, thread_binding, rk=0):
+            tx, warp_n, warp_m = self.extract_thread_binding(thread_binding)
+            for i in T.unroll(frags):
+                wi = (warp_m if is_a else warp_n) * tiles + i * micro_mn
+                wk = rk * chunk + ki * micro_size_k
+                # Byte-footprint identity with the 8-bit path lets us reuse
+                # its lane offsets (white-box pinned).
+                row_off, col_off = get_ldmatrix_offset(side, tx, 0, stride, "int8", transposed)
+                T.ptx_ldmatrix(
+                    T.bool(False),
+                    num,
+                    T.access_ptr(buf[tuple(other) + (base0 + wi + row_off, base1 + wk + col_off)], "r", extent=2 * num),
+                    T.access_ptr(local_buf[i * local_size], "w", extent=2 * num),
+                    variant=variant,
+                )
+                if shift_bits != 0:
+                    T.call_extern(
+                        "handle",
+                        "tl::fp4_e2m1_container_shift",
+                        T.access_ptr(local_buf[i * local_size], "rw", extent=2 * num),
+                        shift_words,
+                    )
+
+        return _warp_ldmatrix_subbyte(local_buf, region, ki, thread_binding, rk)
+
     def ldmatrix_a(self, A_local_buf: Buffer, A_shared_buf: Buffer | BufferRegion, ki: PrimExpr, rk: PrimExpr | None = 0):
         if not self.is_blockscaled:
             return super().ldmatrix_a(A_local_buf, A_shared_buf, ki, rk)
+        load = _mxf8f6f4_operand_load(self.a_dtype)
+        if load is not None:
+            return self._ldmatrix_subbyte("A", A_local_buf, A_shared_buf, ki, rk, load[0], load[1])
         if tvm.DataType(str(self.a_dtype)).bits == 8:
             # mxf8f6f4 operands use the standard 8-bit m16n8k32 fragment; the
             # base emitter's ldmatrix path produces it as-is.
@@ -508,6 +592,9 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
     def ldmatrix_b(self, B_local_buf: Buffer, B_shared_buf: Buffer | BufferRegion, ki: PrimExpr, rk: PrimExpr | None = 0):
         if not self.is_blockscaled:
             return super().ldmatrix_b(B_local_buf, B_shared_buf, ki, rk)
+        load = _mxf8f6f4_operand_load(self.b_dtype)
+        if load is not None:
+            return self._ldmatrix_subbyte("B", B_local_buf, B_shared_buf, ki, rk, load[0], load[1])
         if tvm.DataType(str(self.b_dtype)).bits == 8:
             # See ldmatrix_a: 8-bit fragments come from the base emitter.
             return super().ldmatrix_b(B_local_buf, B_shared_buf, ki, rk)

--- a/tilelang/cuda/intrinsics/macro/mma_sm120_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_sm120_macro_generator.py
@@ -184,10 +184,9 @@ class SM120BlockScaleTile:
             raise ValueError(f"scale row must be in [0, {tile_rows}), got {row}")
         if kblock < 0 or kblock >= self.words_per_stage:
             raise ValueError(f"kblock must be a word column in [0, {self.words_per_stage}), got {kblock}")
-        # The packer stacks 128-row K-major atoms vertically; inside one atom
-        # rows are stored as [word][row % 32][row // 32], regardless of the
-        # staged tile height.
-        return (row // 128) * (self.words_per_stage * 128) + kblock * 128 + (row % 32) * 4 + (row % 128) // 32
+        # Single source of truth for the packed K-major word order lives in
+        # TensorCoreIntrinEmitterSM120._tile_kmajor_scale_word.
+        return TensorCoreIntrinEmitterSM120._tile_kmajor_scale_word(row, kblock, self.words_per_stage)
 
     def compact_selector_scale_rows(self, lane: int, warp_m: int, warp_n: int) -> tuple[tuple[int, int], tuple[int, int]]:
         """Return SFA/SFB semantic rows loaded by the current compact TV package."""
@@ -496,7 +495,9 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
         if not is_a and not transposed:
             raise ValueError("sub-byte ldmatrix variants have no trans form; B must be transposed (K-last)")
         num = 4 if is_a or self.n_dim == 16 else 2
-        shift_words = (local_size if num == 4 else local_size // 2) // 4
+        # The ldmatrix writes num uint32 registers; every written word holds
+        # containers and must be shifted (x2 writes 2 words, x4 writes 4).
+        shift_words = num
 
         thread_binding = self.get_thread_binding()
         region = self._legalize_to_buffer_region(shared_buf)

--- a/tilelang/cuda/intrinsics/macro/mma_sm120_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_sm120_macro_generator.py
@@ -27,8 +27,11 @@ class BlockScaleMmaConfig:
     scale_vec_size: int
     sf_vec_size: int
     scale_type: str
-    a_dtype_abbrv: str
-    b_dtype_abbrv: str
+    # Fixed operand abbreviation, or None for a per-instance choice from
+    # ``operand_family`` (mxf8f6f4 accepts any {e4m3,e5m2} pairing).
+    a_dtype_abbrv: str | None
+    b_dtype_abbrv: str | None
+    operand_family: tuple[str, ...] = ()
     # Accessing T.float32 here would create a circular import during language initialization.
     accum_dtype: str = "float32"
     active_sfa_threads: int = 16
@@ -319,6 +322,20 @@ _SUPPORTED_BLOCK_SCALE_MMA_CONFIGS = {
         a_dtype_abbrv="e2m1",
         b_dtype_abbrv="e2m1",
     ),
+    # MXFP8: pure-fp8 {e4m3,e5m2}^2 at m16n8k32, one ue8m0 byte per 32 K
+    # elements (scale_vec::1X is the only legal vector size for this kind).
+    # A uint32 scale word still covers K=128, now as four one-byte atoms.
+    ("mxf8f6f4", 1, "ue8m0"): BlockScaleMmaConfig(
+        kind="mxf8f6f4",
+        mma_prefix="m16n8k32",
+        atom_k=32,
+        scale_vec_size=1,
+        sf_vec_size=32,
+        scale_type="ue8m0",
+        a_dtype_abbrv=None,
+        b_dtype_abbrv=None,
+        operand_family=("e4m3", "e5m2"),
+    ),
 }
 
 
@@ -364,14 +381,24 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
             self.block_scale_config = _get_block_scale_mma_config(kind, scale_vec_size, stype)
             a_dtype_abbrv = self._get_dtype_abbrv(str(a_dtype))
             b_dtype_abbrv = self._get_dtype_abbrv(str(b_dtype))
+            expected_a = (
+                (self.block_scale_config.a_dtype_abbrv,)
+                if self.block_scale_config.a_dtype_abbrv
+                else self.block_scale_config.operand_family
+            )
+            expected_b = (
+                (self.block_scale_config.b_dtype_abbrv,)
+                if self.block_scale_config.b_dtype_abbrv
+                else self.block_scale_config.operand_family
+            )
             if (
-                a_dtype_abbrv != self.block_scale_config.a_dtype_abbrv
-                or b_dtype_abbrv != self.block_scale_config.b_dtype_abbrv
+                a_dtype_abbrv not in expected_a
+                or b_dtype_abbrv not in expected_b
                 or str(accum_dtype) != self.block_scale_config.accum_dtype
             ):
                 raise ValueError(
-                    f"{self.block_scale_config.kind} expects a_dtype={self.block_scale_config.a_dtype_abbrv}, "
-                    f"b_dtype={self.block_scale_config.b_dtype_abbrv}, "
+                    f"{self.block_scale_config.kind} expects a_dtype in {expected_a}, "
+                    f"b_dtype in {expected_b}, "
                     f"accum_dtype={self.block_scale_config.accum_dtype}; "
                     f"got a_dtype={a_dtype}, b_dtype={b_dtype}, accum_dtype={accum_dtype}"
                 )
@@ -410,8 +437,10 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
 
     def _initialize_abbrev(self, a_dtype, b_dtype, accum_dtype):
         if self.is_blockscaled:
-            self.a_dtype_abbrv = self.block_scale_config.a_dtype_abbrv
-            self.b_dtype_abbrv = self.block_scale_config.b_dtype_abbrv
+            # Family configs (a_dtype_abbrv=None) take the abbreviation from
+            # the actual operand dtype instead of the config.
+            self.a_dtype_abbrv = self.block_scale_config.a_dtype_abbrv or self._get_dtype_abbrv(str(a_dtype))
+            self.b_dtype_abbrv = self.block_scale_config.b_dtype_abbrv or self._get_dtype_abbrv(str(b_dtype))
             self.accum_dtype_abbrv = self._get_dtype_abbrv(accum_dtype)
         else:
             super()._initialize_abbrev(a_dtype, b_dtype, accum_dtype)
@@ -424,6 +453,10 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
 
     def ldmatrix_a(self, A_local_buf: Buffer, A_shared_buf: Buffer | BufferRegion, ki: PrimExpr, rk: PrimExpr | None = 0):
         if not self.is_blockscaled:
+            return super().ldmatrix_a(A_local_buf, A_shared_buf, ki, rk)
+        if tvm.DataType(str(self.a_dtype)).bits == 8:
+            # mxf8f6f4 operands use the standard 8-bit m16n8k32 fragment; the
+            # base emitter's ldmatrix path produces it as-is.
             return super().ldmatrix_a(A_local_buf, A_shared_buf, ki, rk)
         warp_row_tiles = self.warp_row_tiles
         warp_rows = self.warp_rows
@@ -474,6 +507,9 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
 
     def ldmatrix_b(self, B_local_buf: Buffer, B_shared_buf: Buffer | BufferRegion, ki: PrimExpr, rk: PrimExpr | None = 0):
         if not self.is_blockscaled:
+            return super().ldmatrix_b(B_local_buf, B_shared_buf, ki, rk)
+        if tvm.DataType(str(self.b_dtype)).bits == 8:
+            # See ldmatrix_a: 8-bit fragments come from the base emitter.
             return super().ldmatrix_b(B_local_buf, B_shared_buf, ki, rk)
         warp_col_tiles = self.warp_col_tiles
         warp_cols = self.warp_cols
@@ -876,7 +912,9 @@ class TensorCoreIntrinEmitterSM120(MMAIntrinEmitter):
 
         @T.macro
         def _mma_kblock(A_local_buf, B_local_buf, SFA_local_buf, SFB_local_buf, C_local_buf, k_block):
-            scale_byte = 0 if atoms_per_word == 1 else (k_block % atoms_per_word) * 2
+            # Byte stride inside the uint32 scale word: 4X consumes the whole
+            # word (byte 0), 2X a 2-byte half, 1X a single byte.
+            scale_byte = 0 if atoms_per_word == 1 else (k_block % atoms_per_word) * (4 // atoms_per_word)
             for i in T.unroll(warp_rows):
                 scale_a_ptr = T.access_ptr(SFA_local_buf[i // 2], "r")
                 for j in T.unroll(warp_cols):

--- a/tilelang/cuda/language/tir.py
+++ b/tilelang/cuda/language/tir.py
@@ -552,7 +552,7 @@ def mma_fill(dtype, local_size, local_ptr, offset):
 
 
 @_dtype_forward
-def ptx_ldmatrix(trans, num, src_access_ptr, dst_access_ptr):
+def ptx_ldmatrix(trans, num, src_access_ptr, dst_access_ptr, variant=None):
     """TileLang intrinsic for ptx load matrix from shared memory
 
     Uses `tl.ptx_ldmatrix` which expects access pointers created via
@@ -574,18 +574,26 @@ def ptx_ldmatrix(trans, num, src_access_ptr, dst_access_ptr):
     dst_access_ptr : PrimExpr
         A `tl.access_ptr` pointing to the destination (local/register) buffer.
 
+    variant : Optional[str]
+        Sub-byte source form: ``"su4"`` (``m8n16.b8x16.b4x16_p64``) or
+        ``"su6"`` (``m8n16.b8x16.b6x16_p32``), unpacking 4-/6-bit elements
+        into 8-bit register containers. These forms have no ``trans``
+        flavor. ``None`` keeps the classic ``m8n8.b16`` form.
+
     Returns
     -------
     call : PrimExpr
         The call expression (handle-typed).
     """
+    args = [trans, num, src_access_ptr, dst_access_ptr]
+    if variant is not None:
+        if variant not in ("su4", "su6"):
+            raise ValueError(f"ptx_ldmatrix variant must be 'su4' or 'su6', got {variant!r}")
+        args.append(tvm.tirx.StringImm(variant))
     return tvm.tirx.call_intrin(
         "handle",
         tvm.tirx.op.Op.get("tl.ptx_ldmatrix"),
-        trans,
-        num,
-        src_access_ptr,
-        dst_access_ptr,
+        *args,
     )
 
 

--- a/tilelang/cuda/op/gemm/gemm_mma_sm120.py
+++ b/tilelang/cuda/op/gemm/gemm_mma_sm120.py
@@ -40,6 +40,25 @@ class GemmMMASm120BlockScaled(GemmMMA):
         if not self.is_gemm_ss():
             raise ValueError("T.mma_gemm_blockscaled supports shared-memory A/B operands only")
 
+    def _scale_mode(self) -> tuple[int, str]:
+        annotations = getattr(self.gemm_node, "annotations", {})
+        sf_a_granularity_k = annotations.get("sf_a_granularity_k")
+        sf_b_granularity_k = annotations.get("sf_b_granularity_k")
+        if sf_a_granularity_k is None or sf_b_granularity_k is None:
+            raise ValueError("Block-scaled MMA GEMM requires sf_a_granularity_k and sf_b_granularity_k")
+        if int(sf_a_granularity_k) != int(sf_b_granularity_k):
+            raise ValueError(
+                "Block-scaled MMA GEMM requires matching A/B scale granularities, got "
+                f"{int(sf_a_granularity_k)} and {int(sf_b_granularity_k)}"
+            )
+        sf_dtype = annotations.get("sf_dtype")
+        if sf_dtype is None:
+            sf_dtype = "ue4m3"
+        else:
+            # The language layer stores a StringImm (see mma_gemm_blockscaled).
+            sf_dtype = str(getattr(sf_dtype, "value", sf_dtype))
+        return int(sf_a_granularity_k), sf_dtype
+
     def _make_mma_emitter(self, target: Target, thread_nums: int, thread_var: tirx.Var | None = None):
         m_warp, n_warp = self.policy.compute_warp_partition(
             self.M,
@@ -48,6 +67,7 @@ class GemmMMASm120BlockScaled(GemmMMA):
             target,
             GEMM_INST_MMA_BLOCK_SCALED,
         )
+        granularity, sf_dtype = self._scale_mode()
         return self.intrin_emitter_cls(
             a_dtype=self.a_dtype,
             b_dtype=self.b_dtype,
@@ -61,6 +81,10 @@ class GemmMMASm120BlockScaled(GemmMMA):
             chunk=self.chunk,
             thread_var=thread_var,
             is_blockscaled=True,
+            kind="mxf4nvf4",
+            # One k64 MMA atom consumes 64 // granularity scale bytes.
+            scale_vec_size=64 // granularity,
+            stype=sf_dtype,
         )
 
     def infer_layout(self, target: Target, thread_nums: int):
@@ -128,6 +152,11 @@ class GemmMMASm120BlockScaled(GemmMMA):
             return _Simplify(_gemm_ss_blockscaled_kmajor, inline_let=True)
 
         if int(block_K // micro_size_k) == 4:
+            # ki parity decides the consumed byte pair inside a scale word for
+            # scale_vec::2X; 4X keeps the literal 0. Blocks reusing fragment
+            # set 0 issue even ki, set 1 issues odd ki.
+            scale_byte_even = mma_emitter._scale_byte_id(self.sf_k_start, 0)
+            scale_byte_odd = mma_emitter._scale_byte_id(self.sf_k_start, 1)
 
             @T.prim_func
             def _gemm_ss_blockscaled_static_kblock() -> None:
@@ -183,6 +212,7 @@ class GemmMMASm120BlockScaled(GemmMMA):
                             SFB_rep_local_0,
                             i,
                             j,
+                            scale_byte_id=scale_byte_even,
                         )
 
                 mma_emitter.ldmatrix_a(A_local_0, A_region, 2)
@@ -210,6 +240,7 @@ class GemmMMASm120BlockScaled(GemmMMA):
                             SFB_rep_local_1,
                             i,
                             j,
+                            scale_byte_id=scale_byte_odd,
                         )
 
                 mma_emitter.ldmatrix_a(A_local_1, A_region, 3)
@@ -237,6 +268,7 @@ class GemmMMASm120BlockScaled(GemmMMA):
                             SFB_rep_local_0,
                             i,
                             j,
+                            scale_byte_id=scale_byte_even,
                         )
                 for i in T.unroll(warp_rows):
                     for j in T.unroll(warp_cols):
@@ -249,6 +281,7 @@ class GemmMMASm120BlockScaled(GemmMMA):
                             SFB_rep_local_1,
                             i,
                             j,
+                            scale_byte_id=scale_byte_odd,
                         )
 
             return _Simplify(_gemm_ss_blockscaled_static_kblock, inline_let=True)

--- a/tilelang/cuda/op/gemm/gemm_mma_sm120.py
+++ b/tilelang/cuda/op/gemm/gemm_mma_sm120.py
@@ -7,7 +7,7 @@ from tilelang.cuda.intrinsics.macro.mma_sm120_macro_generator import (
 from tilelang.cuda.target import target_is_cuda, target_is_sm120
 from tilelang.transform.simplify import _Simplify
 from tilelang.utils.language import is_full_region
-from tvm import tirx
+from tvm import DataType, tirx
 from tvm.ir import Range
 from tvm.target import Target
 
@@ -30,6 +30,12 @@ class GemmMMASm120BlockScaled(GemmMMA):
     """SM120 warp-level block-scaled MMA lowering."""
 
     intrin_emitter_cls = TensorCoreIntrinEmitterBlockScaled
+
+    @property
+    def allow_f8f6f4_mixed_dtypes(self) -> bool:
+        # kind::mxf8f6f4 accepts any {e4m3, e5m2} A/B pairing; the emitter
+        # config rejects pairings outside the family.
+        return True
 
     @staticmethod
     def _validate_target(target: Target) -> None:
@@ -68,6 +74,21 @@ class GemmMMASm120BlockScaled(GemmMMA):
             GEMM_INST_MMA_BLOCK_SCALED,
         )
         granularity, sf_dtype = self._scale_mode()
+        # The MMA kind follows the operand dtype family: 4-bit e2m1 operands
+        # lower to kind::mxf4nvf4 (k64 atoms), 8-bit fp8 operands to
+        # kind::mxf8f6f4 (k32 atoms). One MMA atom consumes
+        # atom_k // granularity scale bytes; the emitter validates the
+        # resulting (kind, scale_vec_size, sf_dtype) combination.
+        a_bits = DataType(str(self.a_dtype)).bits
+        b_bits = DataType(str(self.b_dtype)).bits
+        if a_bits != b_bits:
+            raise ValueError(
+                f"T.mma_gemm_blockscaled requires A and B from the same operand width family, "
+                f"got a_dtype={self.a_dtype}, b_dtype={self.b_dtype}"
+            )
+        kind, atom_k = ("mxf8f6f4", 32) if a_bits == 8 else ("mxf4nvf4", 64)
+        if granularity > atom_k:
+            raise ValueError(f"sf_granularity_k={granularity} exceeds the {kind} MMA atom K extent {atom_k}")
         return self.intrin_emitter_cls(
             a_dtype=self.a_dtype,
             b_dtype=self.b_dtype,
@@ -81,9 +102,8 @@ class GemmMMASm120BlockScaled(GemmMMA):
             chunk=self.chunk,
             thread_var=thread_var,
             is_blockscaled=True,
-            kind="mxf4nvf4",
-            # One k64 MMA atom consumes 64 // granularity scale bytes.
-            scale_vec_size=64 // granularity,
+            kind=kind,
+            scale_vec_size=atom_k // granularity,
             stype=sf_dtype,
         )
 
@@ -151,10 +171,12 @@ class GemmMMASm120BlockScaled(GemmMMA):
 
             return _Simplify(_gemm_ss_blockscaled_kmajor, inline_let=True)
 
-        if int(block_K // micro_size_k) == 4:
+        if int(block_K // micro_size_k) == 4 and mma_emitter.scale_vec_size != 1:
             # ki parity decides the consumed byte pair inside a scale word for
             # scale_vec::2X; 4X keeps the literal 0. Blocks reusing fragment
-            # set 0 issue even ki, set 1 issues odd ki.
+            # set 0 issue even ki, set 1 issues odd ki. scale_vec::1X byte ids
+            # have period 4, which breaks the even/odd assumption, so
+            # mxf8f6f4 always takes the generic serial path below.
             scale_byte_even = mma_emitter._scale_byte_id(self.sf_k_start, 0)
             scale_byte_odd = mma_emitter._scale_byte_id(self.sf_k_start, 1)
 

--- a/tilelang/cuda/op/gemm/gemm_mma_sm120.py
+++ b/tilelang/cuda/op/gemm/gemm_mma_sm120.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from tilelang import language as T
 from tilelang.cuda.intrinsics.macro.mma_sm120_macro_generator import (
+    _canonical_dtype_name,
+    _mxf8f6f4_operand_load,
     TensorCoreIntrinEmitterSM120 as TensorCoreIntrinEmitterBlockScaled,
 )
 from tilelang.cuda.target import target_is_cuda, target_is_sm120
@@ -74,19 +76,31 @@ class GemmMMASm120BlockScaled(GemmMMA):
             GEMM_INST_MMA_BLOCK_SCALED,
         )
         granularity, sf_dtype = self._scale_mode()
-        # The MMA kind follows the operand dtype family: 4-bit e2m1 operands
-        # lower to kind::mxf4nvf4 (k64 atoms), 8-bit fp8 operands to
-        # kind::mxf8f6f4 (k32 atoms). One MMA atom consumes
-        # atom_k // granularity scale bytes; the emitter validates the
-        # resulting (kind, scale_vec_size, sf_dtype) combination.
-        a_bits = DataType(str(self.a_dtype)).bits
-        b_bits = DataType(str(self.b_dtype)).bits
-        if a_bits != b_bits:
+        # The MMA kind follows the operand dtypes: a packed-fp4 pair lowers
+        # to kind::mxf4nvf4 (k64 atoms, packed fragments); any other pairing
+        # from the f8f6f4 family - fp8, and fp4/fp6 in their unpacked
+        # 8-bit-container smem forms - lowers to kind::mxf8f6f4 (k32 atoms).
+        # One MMA atom consumes atom_k // granularity scale bytes; the
+        # emitter validates the resulting (kind, scale_vec, sf_dtype) combo.
+        a_name = _canonical_dtype_name(str(self.a_dtype))
+        b_name = _canonical_dtype_name(str(self.b_dtype))
+
+        def _mxf8f6f4_operand_ok(name: str) -> bool:
+            if _mxf8f6f4_operand_load(name) is not None:
+                return True
+            return name.startswith("float8") and DataType(name).bits == 8
+
+        if a_name == b_name == "float4_e2m1fn":
+            kind, atom_k = "mxf4nvf4", 64
+        elif _mxf8f6f4_operand_ok(a_name) and _mxf8f6f4_operand_ok(b_name):
+            kind, atom_k = "mxf8f6f4", 32
+        else:
             raise ValueError(
-                f"T.mma_gemm_blockscaled requires A and B from the same operand width family, "
+                "T.mma_gemm_blockscaled operands must be a packed float4_e2m1fn pair "
+                "(kind::mxf4nvf4) or any f8f6f4-family pairing with fp4/fp6 in their "
+                "unpacked smem forms (kind::mxf8f6f4); "
                 f"got a_dtype={self.a_dtype}, b_dtype={self.b_dtype}"
             )
-        kind, atom_k = ("mxf8f6f4", 32) if a_bits == 8 else ("mxf4nvf4", 64)
         if granularity > atom_k:
             raise ValueError(f"sf_granularity_k={granularity} exceeds the {kind} MMA atom K extent {atom_k}")
         return self.intrin_emitter_cls(

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -171,6 +171,14 @@ def __dtype_call__(self: dtype, *args, is_size_var: bool = False) -> tirx.Var:
         val = "Float4E2M1Unpacked"
         if self.lanes > 1:
             val += f"x{self.lanes}"
+    elif self.is_float6_e2m3fn_unpacked():
+        val = "Float6E2M3FNUnpacked"
+        if self.lanes > 1:
+            val += f"x{self.lanes}"
+    elif self.is_float6_e3m2fn_unpacked():
+        val = "Float6E3M2FNUnpacked"
+        if self.lanes > 1:
+            val += f"x{self.lanes}"
     else:
         raise TypeError(f"Invalid type {self}")
     if "_" in val:
@@ -261,6 +269,9 @@ _FLOAT4_E2M1FN_BITS = 4
 _FLOAT4_E2M1FN_TYPE_CODE = 17
 _FLOAT4_E2M1_UNPACKED_BITS = 8
 _FLOAT4_E2M1_UNPACKED_TYPE_CODE = 131
+_FLOAT6_UNPACKED_BITS = 8
+_FLOAT6_E2M3FN_UNPACKED_TYPE_CODE = 132
+_FLOAT6_E3M2FN_UNPACKED_TYPE_CODE = 133
 
 
 def __dtype_is_float4_e2m1fn__(self: dtype) -> bool:
@@ -290,6 +301,21 @@ def __dtype_is_float4__(self: dtype) -> bool:
     return __dtype_is_float4_e2m1fn__(self) or __dtype_is_float4_e2m1_unpacked__(self)
 
 
+def __dtype_is_float6_e2m3fn_unpacked__(self: dtype) -> bool:
+    """8-bit FP6 E2M3 unpacked shared-memory storage (16U6_ALIGN16B)."""
+    return self.bits == _FLOAT6_UNPACKED_BITS and int(self.type_code) == _FLOAT6_E2M3FN_UNPACKED_TYPE_CODE
+
+
+def __dtype_is_float6_e3m2fn_unpacked__(self: dtype) -> bool:
+    """8-bit FP6 E3M2 unpacked shared-memory storage (16U6_ALIGN16B)."""
+    return self.bits == _FLOAT6_UNPACKED_BITS and int(self.type_code) == _FLOAT6_E3M2FN_UNPACKED_TYPE_CODE
+
+
+def __dtype_is_float6_unpacked__(self: dtype) -> bool:
+    """Whether this is any 8-bit unpacked FP6 storage variant."""
+    return __dtype_is_float6_e2m3fn_unpacked__(self) or __dtype_is_float6_e3m2fn_unpacked__(self)
+
+
 def is_float4_e2m1fn(value: AnyDType) -> bool:
     """Whether *value* is the packed 4-bit FP4 E2M1 variant."""
     return get_tvm_dtype(value).is_float4_e2m1fn()
@@ -305,12 +331,20 @@ def is_float4(value: AnyDType) -> bool:
     return get_tvm_dtype(value).is_float4()
 
 
+def is_float6_unpacked(value: AnyDType) -> bool:
+    """Whether *value* is an 8-bit unpacked FP6 shared-memory variant."""
+    return get_tvm_dtype(value).is_float6_unpacked()
+
+
 def is_f8f6f4_family(value: AnyDType) -> bool:
     """Whether *value* is a tcgen05 ``kind::f8f6f4`` / ``mxf8f6f4`` operand dtype."""
     dt = get_tvm_dtype(value)
-    if dt.is_float4():
+    if dt.is_float4() or dt.is_float6_unpacked():
         return True
     name = str(dt)
+    # Note: custom-registered dtypes stringify as ``custom[...]`` and never
+    # match the ``float8``/``float6`` prefixes - unpacked variants must be
+    # handled by predicate above, not by name.
     return (dt.bits == 8 and name.startswith("float8")) or (dt.bits == 6 and name.startswith("float6"))
 
 
@@ -342,6 +376,9 @@ dtype.bytes = property(__dtype_bytes__)
 dtype.is_float4_e2m1fn = __dtype_is_float4_e2m1fn__
 dtype.is_float4_e2m1_unpacked = __dtype_is_float4_e2m1_unpacked__
 dtype.is_float4 = __dtype_is_float4__
+dtype.is_float6_e2m3fn_unpacked = __dtype_is_float6_e2m3fn_unpacked__
+dtype.is_float6_e3m2fn_unpacked = __dtype_is_float6_e3m2fn_unpacked__
+dtype.is_float6_unpacked = __dtype_is_float6_unpacked__
 
 
 def get_tvm_dtype(value: AnyDType) -> dtype:
@@ -522,6 +559,8 @@ if TYPE_CHECKING:
     class float4_e2m1fnx32(dtype): ...
     class float4_e2m1fnx64(dtype): ...
     class float4_e2m1_unpacked(dtype): ...
+    class float6_e2m3fn_unpacked(dtype): ...
+    class float6_e3m2fn_unpacked(dtype): ...
     class bfloat16(dtype): ...
     class bfloat16x2(dtype): ...
     class tfloat32(dtype): ...
@@ -700,6 +739,9 @@ else:
     float4_e2m1fnx64 = dtype("float4_e2m1fnx64")
     # SMEM/TMA-only layout type; do not expose vectorized register/cast variants.
     float4_e2m1_unpacked = dtype("custom[float4_e2m1_unpacked]8")
+    # 8-bit unpacked FP6 smem storage (CUTLASS float_e2m3/e3m2_unpacksmem_t).
+    float6_e2m3fn_unpacked = dtype("custom[float6_e2m3fn_unpacked]8")
+    float6_e3m2fn_unpacked = dtype("custom[float6_e3m2fn_unpacked]8")
     bfloat16 = dtype("bfloat16")
     bfloat16x2 = dtype("bfloat16x2")
     tfloat32 = dtype("custom[tfloat32]")
@@ -875,6 +917,8 @@ _all_dtypes = [
     "float4_e2m1fnx32",
     "float4_e2m1fnx64",
     "float4_e2m1_unpacked",
+    "float6_e2m3fn_unpacked",
+    "float6_e3m2fn_unpacked",
     "bfloat16",
     "bfloat16x2",
     "tfloat32",

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -229,6 +229,12 @@ def __dtype_as_torch__(self: dtype) -> torch.dtype:
     elif dtype_str == "float4_e2m1fn":
         logger.info("torch doesn't support float4_e2m1fn, using float4_e2m1fnx2 as storage dtype.")
         return torch.float4_e2m1fn_x2 if hasattr(torch, "float4_e2m1fn_x2") else torch.int8
+    elif dtype_str in ("float6_e2m3fn", "float6_e3m2fn"):
+        # torch has no fp6 dtype; packed fp6 tensors travel as uint8 blobs of
+        # numel*3/4 bytes (LSB-first 6-bit stream), checked by the sub-byte
+        # binder's total-bits constraint.
+        logger.info("torch doesn't support %s, using uint8 blob storage.", dtype_str)
+        return torch.uint8
     elif dtype_str == "custom[tfloat32]":
         return torch.float32
     elif dtype_str == "int4":

--- a/tilelang/language/gemm_op.py
+++ b/tilelang/language/gemm_op.py
@@ -498,13 +498,18 @@ def mma_gemm_blockscaled(
     - ``(16, "ue8m0")``: NVF4 granularity with power-of-two scales,
       ``scale_vec::4X`` (needs CUDA 13.1+ toolchains)
 
-    ``kind::mxf8f6f4`` (FP8 operands, ``m16n8k32``):
+    ``kind::mxf8f6f4`` (f8f6f4 operands, ``m16n8k32``):
 
-    - ``(32, "ue8m0")``: MXFP8, ``scale_vec::1X`` (the only legal scale
-      vector size for this kind); any {e4m3, e5m2} A/B pairing is accepted.
-      Mixed e4m3 x e5m2 targets fp8 training backward passes, though this
-      synchronous TN path currently covers inference-style forward GEMMs
-      only.
+    - ``(32, "ue8m0")``: ``scale_vec::1X`` (the only legal scale vector
+      size for this kind); any A/B pairing of {``float8_e4m3``,
+      ``float8_e5m2``, ``float4_e2m1fn_unpacked``,
+      ``float6_e2m3fn_unpacked``, ``float6_e3m2fn_unpacked``} is accepted.
+      The sub-byte operands use the unpacked shared-memory forms (one
+      8-bit container per element); a packed ``float4_e2m1fn`` A/B *pair*
+      selects ``kind::mxf4nvf4`` above instead. Mixed pairings target
+      weight-quantized inference (e.g. W4A8/W6A8) and fp8 training
+      backward passes, though this synchronous TN path currently covers
+      inference-style forward GEMMs only.
 
     ``scale_dtype=None`` infers ``"ue4m3"`` for granularity 16 and
     ``"ue8m0"`` for granularity 32.

--- a/tilelang/language/gemm_op.py
+++ b/tilelang/language/gemm_op.py
@@ -453,6 +453,9 @@ def tcgen05_gemm_blockscaled(
     )
 
 
+_SM120_BLOCK_SCALE_MODES = {(16, "ue4m3"), (32, "ue8m0"), (16, "ue8m0")}
+
+
 def mma_gemm_blockscaled(
     A: BufferLikeType,
     B: BufferLikeType,
@@ -468,6 +471,7 @@ def mma_gemm_blockscaled(
     sf_a_granularity_k: int,
     sf_b_granularity_k: int,
     sf_layout: str | None = None,
+    scale_dtype: str | None = None,
 ) -> tirx.PrimExpr:
     """Explicit SM120 warp-level block-scaled MMA GEMM.
 
@@ -477,14 +481,41 @@ def mma_gemm_blockscaled(
     scale addressing. Unlike TCGEN05, this path is synchronous warp-level
     ``mma.sync`` and does not use tensor memory or mbarriers.
 
-    The current supported instruction is SM120 NVF4:
-    ``m16n8k64.kind::mxf4nvf4.block_scale.scale_vec::4X`` with E2M1 operands,
-    FP32 accumulation, and UE4M3 scale factors.
+    Supported instructions, all ``m16n8k64.kind::mxf4nvf4.block_scale`` with
+    E2M1 operands and FP32 accumulation, selected by
+    ``(sf_granularity_k, scale_dtype)``:
+
+    - ``(16, "ue4m3")``: NVF4, ``scale_vec::4X`` (the historical default)
+    - ``(32, "ue8m0")``: MXFP4, ``scale_vec::2X``
+    - ``(16, "ue8m0")``: NVF4 granularity with power-of-two scales,
+      ``scale_vec::4X`` (needs CUDA 13.1+ toolchains)
+
+    ``scale_dtype=None`` infers ``"ue4m3"`` for granularity 16 and
+    ``"ue8m0"`` for granularity 32.
     """
 
+    if int(sf_a_granularity_k) != int(sf_b_granularity_k):
+        raise ValueError(
+            "T.mma_gemm_blockscaled requires matching A/B scale granularities, got "
+            f"sf_a_granularity_k={sf_a_granularity_k}, sf_b_granularity_k={sf_b_granularity_k}"
+        )
+    granularity = int(sf_a_granularity_k)
+    if scale_dtype is None:
+        scale_dtype = {16: "ue4m3", 32: "ue8m0"}.get(granularity)
+    if (granularity, scale_dtype) not in _SM120_BLOCK_SCALE_MODES:
+        supported = ", ".join(str(mode) for mode in sorted(_SM120_BLOCK_SCALE_MODES))
+        raise ValueError(
+            "Unsupported SM120 block-scale mode "
+            f"(sf_granularity_k={granularity}, scale_dtype={scale_dtype}); "
+            f"supported (granularity, scale_dtype): {supported}"
+        )
+
     ann = {
-        "sf_a_granularity_k": int(sf_a_granularity_k),
-        "sf_b_granularity_k": int(sf_b_granularity_k),
+        "sf_a_granularity_k": granularity,
+        "sf_b_granularity_k": granularity,
+        # StringImm rather than a bare str: short strings take tvm-ffi's
+        # small-string form, which the annotations Map<str, Object> rejects.
+        "sf_dtype": tirx.StringImm(scale_dtype),
     }
     if sf_layout is not None:
         ann["sf_layout"] = sf_layout

--- a/tilelang/language/gemm_op.py
+++ b/tilelang/language/gemm_op.py
@@ -476,10 +476,16 @@ def mma_gemm_blockscaled(
     """Explicit SM120 warp-level block-scaled MMA GEMM.
 
     This API follows the same scale-factor model as
-    ``T.tcgen05_gemm_blockscaled``: users pass the scale tensors, logical
-    ``k_start``, and K granularity, while the lowering derives the low-level
-    scale addressing. Unlike TCGEN05, this path is synchronous warp-level
-    ``mma.sync`` and does not use tensor memory or mbarriers.
+    ``T.tcgen05_gemm_blockscaled``: users pass the scale tensors and K
+    granularity, while the lowering derives the low-level scale addressing.
+    Unlike TCGEN05, this path is synchronous warp-level ``mma.sync`` and does
+    not use tensor memory or mbarriers.
+
+    ``k_start`` semantics depend on ``sf_layout``: for ``"rowmajor"`` it is
+    the K-word offset *relative to the SFA/SFB buffers passed in* — pass 0
+    when staging a per-k-iteration slice into shared memory; for
+    ``"blockscaled_chunk_kmajor"`` the fulltile path addresses the staged
+    scale tile directly and ``k_start`` is ignored.
 
     Supported instructions, all ``m16n8k64.kind::mxf4nvf4.block_scale`` with
     E2M1 operands and FP32 accumulation, selected by

--- a/tilelang/language/gemm_op.py
+++ b/tilelang/language/gemm_op.py
@@ -487,14 +487,24 @@ def mma_gemm_blockscaled(
     ``"blockscaled_chunk_kmajor"`` the fulltile path addresses the staged
     scale tile directly and ``k_start`` is ignored.
 
-    Supported instructions, all ``m16n8k64.kind::mxf4nvf4.block_scale`` with
-    E2M1 operands and FP32 accumulation, selected by
+    The MMA kind follows the operand dtype family (FP32 accumulation in all
+    cases); the mode inside a kind is selected by
     ``(sf_granularity_k, scale_dtype)``:
+
+    ``kind::mxf4nvf4`` (E2M1 operands, ``m16n8k64``):
 
     - ``(16, "ue4m3")``: NVF4, ``scale_vec::4X`` (the historical default)
     - ``(32, "ue8m0")``: MXFP4, ``scale_vec::2X``
     - ``(16, "ue8m0")``: NVF4 granularity with power-of-two scales,
       ``scale_vec::4X`` (needs CUDA 13.1+ toolchains)
+
+    ``kind::mxf8f6f4`` (FP8 operands, ``m16n8k32``):
+
+    - ``(32, "ue8m0")``: MXFP8, ``scale_vec::1X`` (the only legal scale
+      vector size for this kind); any {e4m3, e5m2} A/B pairing is accepted.
+      Mixed e4m3 x e5m2 targets fp8 training backward passes, though this
+      synchronous TN path currently covers inference-style forward GEMMs
+      only.
 
     ``scale_dtype=None`` infers ``"ue4m3"`` for granularity 16 and
     ``"ue8m0"`` for granularity 32.


### PR DESCRIPTION
Built on top of #3081 (`sm120_mxfp4`); shares its first commits and will be rebased once it merges.

## Summary

Lands SM120 `kind::mxf8f6f4` (`m16n8k32`, `scale_vec::1X`, UE8M0 scales per 32 K-elements) covering **all 25 operand pairings** of `{e2m1, e2m3, e3m2, e4m3, e5m2}`:

- **fp8**: full chain; a unit-scale fast path is bitwise-equal to plain fp8 `T.gemm` over the full code domain.
- **fp4**: global stays packed (2 elem/byte) → 16U4_ALIGN16B TMA (or SIMT reference producer) → new `ldmatrix …b4x16_p64` wrappers + e2m1 container shift.
- **fp6**: new `float6_{e2m3,e3m2}fn_unpacked` dtypes (tvm-fork companion commit, mirroring the fp4 precedent from #2271); global is a packed uint8 blob (0.75 B/elem) → **new 16U6_ALIGN16B TMA producer** → `b6x16_p32` ldmatrix.
- **Two official examples** with pytest-enforced acceptance: `sm120_w4a8_…` (mxfp4 weights × mxfp8 activations) and `sm120_w6a8_…` (mxfp8 × mxfp6 e3m2, mirroring CUTLASS example 79c), plus `mxfp8`/`mxfp6` quantizers.

Loaders are routed **per operand, not per pairing** — the su4/su6 paths unlock every mixed combination at once.

## Design note: register containers on SM120

`float4_e2m1_unpacked` was an SMEM/TMA-only tag (codegen FATAL on register use) — valid on SM100, where `tcgen05.mma` reads operands via SMEM descriptors and sub-byte data never reaches registers. SM120's `mma.sync` consumes **register fragments by ABI**, so the smem form must be lifted into 8-bit containers (fp4: ldmatrix zero-extends to bits[3:0], then `<<2` → bits[5:2]; fp6: bits[5:0]). `PrintType` now emits `uchar` for the unpacked tags; the numeric-type printer keeps its FATAL (tags stay non-arithmetic).

## Fixes found along the way

- **ffi binder sub-byte rebinding**: integer `8 / bits` pack factor truncates to 1 for 6-bit; both shape and stride sites now use bit-exact `runtime * 8 / bits` (identical for fp4, guarded by the existing total-bits assert).
- **Rowmajor kblock4 fast path** assumed scale_vec::2X byte parity; with 1X, bytes 2/3 of each scale word were silently never consumed. Now gated to `scale_vec >= 2X`.
- **TMA guards**: the descriptorless 1D bulk path now rejects packed→unpacked pairs (was a silent raw byte copy); the driver's 128-element innermost-dim rule is enforced at compile time.

## Correctness & performance

Three data bands per config — controlled (`atol=0`), full code domain (NaN masks + bitwise finite), and quantized (real quantizer output through both engines, **bitwise**). Full-entropy order pins hold across kmajor/rowmajor and TMA/SIMT producers; extreme UE8M0 semantics (overflow→Inf, **subnormal scale products preserved, no FTZ**, 0xFF=NaN) measured and cross-checked bitwise vs CUTLASS. **21 CUTLASS 4.7.0 bitwise comparisons and a 299-test cold-cache regression are green.** (Known: fp4×fp4 under mxf8f6f4 has no CUTLASS bitwise oracle — CUTLASS lowers fp4 pairs to k64 mxf4nvf4; python reference covers it.)

RTX PRO 6000, same-data interleaved medians vs **tuned** CUTLASS baseline (feasible tile face is 128³ only; both schedules measured):

| Config | TileLang | Best CUTLASS | Ratio |
|---|---|---|---|
| mxf8 4096³ / 8192³ | 570.8 / 706.6 | 612.4 / 697.3 | 0.93× / **1.01×** |
| W4A8 4096³ / 8192³ | 579.9 / 725.5 | 638.8 / 745.2 | 0.91× / 0.97× |
| W6A8 4096³ / 8192³ | 567.7 / 715.3 | — | TMA producer: 326→568 (+74%) |

The 0.91–0.97 gap matches the known simple-form vs CUTLASS gap from the mxf4 family; a warp-specialized form is the convergence path and out of scope here.

## How to test

```bash
export CUDA_HOME=<cuda-13.x env> CUTLASS_ROOT=<cutlass-4.7.0>
rm -rf ~/.tilelang/cache
pytest testing/python/language/test_tilelang_language_{nvf4,mxf8f6f4}_mma_block_scale.py \
       testing/python/language/test_tilelang_language_{ldmatrix_sub_byte,mxf8f6f4_subbyte_operands}.py \
       testing/python/language/test_tilelang_language_{fp6_unpacked,float4_e2m1_unpacked}_dtype.py \
       testing/python/quantize/ -q
python -m maint.gemm.gemm_sm120.correctness_evaluation_{mxf8,w4a8,w6a8}_vs_cutlass  # run each
python examples/gemm_sm120/sm120_w4a8_mxf8f6f4_gemm.py --m 2048 --n 2048 --k 2048 --verify --from-bf16
```

## Reviewer attention

1. The unpacked-tag register relaxation: keep a TCGEN05-scoped check in place of the old global FATAL?
2. Binder rebinding is a shared ABI path; fp4 provably unchanged, but symbolic-shape + sub-byte kernels were only statically analyzed.
3. Unpacked fp4 × fp4 legally lowers to mxf8f6f4 (~half the packed pair's mxf4nvf4 throughput) without a warning — flag or docs only?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Add SM120 `kind::mxf8f6f4` block-scaled MMA for 25 FP4, FP6, and FP8 operand pairings.
- Add unpacked FP4/FP6 handling, sub-byte `ldmatrix`, and 16U4/16U6 TMA support.
- Add MXFP4, MXFP6, and MXFP8 quantizers with UE8M0 scale packing.
- Add W4A8 and W6A8 GEMM examples.
- Extend CUDA lowering, dtype handling, FFI binding, and mixed-dtype validation.
- Add correctness tests and CUTLASS comparisons for layouts, quantization, special values, scale extremes, and producer equivalence.
- Update the `3rdparty/tvm` pointer.

## Validation

- Report 21 CUTLASS bitwise comparisons.
- Report a 285-test cold-cache regression.
- Add negative tests for invalid dimensions, layouts, and operand pairings.
- Pass pre-commit hooks.

## C++ style / lint notes

- The PR changes C++ and CUDA files.
- It does not change `docs/developer_guide/cpp_style.md` or documented style rules.
- CI includes the **C++ API Style Audit (warning only)** step.
- TLCPP003 and TLCPP004 findings are advisory. They should not block merge unless they introduce a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->