### PR TITLE
[Layout][Reducer] Preserve vectorized reducer update plans

### DIFF
--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -25,6 +25,7 @@
 #include "loop_vectorize.h"
 #include "../config.h"
 #include "../op/builtin.h"
+#include "../op/reducer.h"
 #include "../op/utils.h"
 #include "arith/int_operator.h"
 #include "arith/ir_visitor_with_analyzer.h"
@@ -658,6 +659,21 @@ private:
                node->op == tl::access_ptr()) {
       // address_of and tl.access_ptr have buffer load value so we should
       // analysis the buffer load node to update vector_size_.
+      return arith::IRMutatorWithAnalyzer::VisitExpr_(node);
+    } else if (node->op.same_as(tl::reducer_update())) {
+      // The accumulate itself never loop-vectorizes: by the time execution
+      // vectorization runs (post ReducerPlanAndMaterialize) this call has
+      // been rewritten into an ordinary read-modify-write store, which the
+      // reduction-axis scalarization guard below keeps correct. During
+      // layout inference the call therefore only influences the LAYOUT
+      // SHAPE this nest plans. Shape it by the contribution loads (visit
+      // the args as ordinary expressions; the accumulator access is
+      // loop-invariant and adds no constraint) instead of the generic
+      // opaque-call rule, whose all-lanes-invariant test degrades every
+      // update nest to a scalar-shaped (elementwise mod-threads) plan and
+      // forces that shape onto the fragments feeding it — scalarizing
+      // their shared-memory copies (observed as a 1.1-1.3x latency
+      // regression on production kernels when such a plan wins).
       return arith::IRMutatorWithAnalyzer::VisitExpr_(node);
     }
 

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -367,5 +367,60 @@ def test_spill_pricing_no_false_positive_on_strided_fragment_layouts():
     torch.testing.assert_close(out, ref.reshape(1), rtol=1e-5, atol=1e-5)
 
 
+@tilelang.testing.requires_cuda
+def test_reducer_update_nest_plans_vectorized_shape():
+    """Distilled from TileKernels' mhc_post_bwd (a 1.11-1.14x production
+    regression): a bf16 shared->fragment copy feeding a reducer-update nest.
+
+    tl.reducer_update lives only between CanonicalizeLegacyReducer and
+    ReducerPlanAndMaterialize, so at layout-planning time the update nest's
+    body contains an opaque call. The generic opaque-call rule (all buffer
+    accesses lane-invariant) degrades the nest's planned vector width to 1,
+    i.e. a scalar-shaped mod-threads plan; when an attempt rooted at the
+    nest wins (a coin flip: such solutions tie with the vectorized ones on
+    every cost term), that shape is forced onto the fragments and the
+    feeding shared-memory copies scalarize (16-bit LDS instead of packed
+    32/64-bit). The planner must shape update nests by their contribution
+    loads instead: execution-side correctness (the reduction-axis store
+    hazard) is enforced at lowering, where the call has already been
+    materialized into a guarded ordinary store."""
+    threads = 128
+
+    @T.prim_func
+    def kernel(A: T.Tensor((4, 256), T.bfloat16), Out: T.Tensor((1,), T.float32)):
+        with T.Kernel(1, threads=threads):
+            a_sh = T.alloc_shared((4, 256), T.bfloat16)
+            a_fr = T.alloc_fragment((4, 256), T.float32)
+            acc = T.alloc_reducer((1,), T.float32, op="sum")
+            T.copy(A, a_sh)
+            T.copy(a_sh, a_fr)
+            T.reducer_init(acc)
+            for i, j in T.Parallel(4, 256):
+                T.reducer_update(acc[0], a_fr[i, j])
+            res = T.alloc_fragment((1,), T.float32)
+            T.finalize_reducer(acc, res)
+            if T.get_thread_binding() == 0:
+                Out[0] = res[0]
+
+    kern = tl.compile(
+        kernel,
+        out_idx=-1,
+        pass_configs={
+            tl.PassConfigKey.TL_DISABLE_VECTORIZE_256: True,
+            tl.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+            tl.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        },
+    )
+    src = kern.get_kernel_source()
+    # The shared->fragment copy must stay vectorized: packed bf16 pairs
+    # converted with __bfloat1622float2, never one scalar (float)(...) cast
+    # per element off a mod-threads distribution.
+    assert "__bfloat1622float2" in src, src
+
+    a = torch.randn(4, 256, dtype=torch.bfloat16, device="cuda")
+    out = kern(a)
+    torch.testing.assert_close(out, a.float().sum().reshape(1), rtol=1e-3, atol=1e-3)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Preserve vector-width information when layout inference analyzes `T.reducer_update` nests.
- Prevent reducer update attempts from selecting scalar-shaped fragment layouts that can degrade shared-to-fragment copies and regress kernel latency.

## Changes

- Handle `tl.reducer_update` before the generic opaque-call path in the loop vectorization analyzer.
- Analyze the update arguments as ordinary expressions so contribution loads determine the layout-planning vector shape.
- Keep execution correctness unchanged: reducer updates are materialized into guarded read-modify-write stores before execution-side vectorization.
- Add a CUDA regression covering a bfloat16 shared-to-fragment copy feeding a reducer and verify both packed source generation and the numerical result.

## Validation

- `cmake --build build -j 32`
- `python -m pytest testing/python/transform/test_tilelang_transform_layout_inference.py::test_reducer_update_nest_plans_vectorized_shape -x -vv`
- `python -m pytest testing/python/transform/test_tilelang_transform_layout_inference.py -x -vv`
- `./format.sh`
- `git diff --check`

## Risk

- The special case applies only while `tl.reducer_update` is still present for layout planning; reducer materialization and execution-side reduction guards remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserve vector-width information when layout inference analyzes `tl.reducer_update` nests.
- Visit reducer-update arguments as ordinary expressions instead of treating the call as opaque.
- Keep reducer updates materialized as guarded read-modify-write stores during execution vectorization.
- Add a CUDA regression test for packed bfloat16 shared-to-fragment copies and reducer correctness.
- Validate builds, layout-inference tests, formatting, and `git diff --check`.

## C++ style / lint notes

- The change touches C++ implementation code but does not modify rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step is relevant to C++ changes.
- No correctness or build issue is identified. Any TLCPP003/TLCPP004 findings remain advisory unless they indicate an API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->