### PR TITLE
[Docs] List HYGON in README ecosystem hardware adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ TileLang requires Python 3.10 or newer. The default `auto` target detects CUDA, 
 | Huawei Ascend | Ascend C / NPU IR | Ascend A2 and A3 | Ecosystem | Developed in [tilelang-ascend](https://github.com/tile-ai/tilelang-ascend) and the MLIR-based [tilelang-mlir-ascend](https://github.com/tile-ai/tilelang-mlir-ascend). |
 | MetaX MACA | MACA adapter | MetaX C500 | Ecosystem | Developed in [tilelang-metax](https://github.com/tile-ai/tilelang-metax); requires the MACA software stack. |
 | Moore Threads MUSA | `musa` | S5000, S4000, and M1000 | Ecosystem | Developed in [tilelang-musa](https://github.com/tile-ai/tilelang-musa) and released independently. |
+| HYGON | `hcu` | Linux; BW1000, BW1100, BW150 and K100_AI | Ecosystem | Developed in [tilelang-hygon](https://github.com/tile-ai/tilelang-hygon); requires the DTK software stack. |
 
 Prebuilt wheels are published for Linux x86-64/AArch64, Windows x86-64, and macOS arm64. Ecosystem adapters live in separate repositories, are not included in the main TileLang release wheels, and may follow different compatibility schedules. See the [target guide](https://tilelang.com/get_started/targets.html) for target syntax, architecture options, and backend-specific notes, or the corresponding adapter repository for installation and tested-device details.
 


### PR DESCRIPTION
- Add HYGON (`hcu`) to the README Hardware Support table as an Ecosystem adapter (same style as other vendor rows).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added HYGON ecosystem hardware support to the README.
- Documented the `hcu` target for Linux on BW1000, BW1100, BW150, and K100_AI devices.
- Referenced the `tilelang-hygon` repository and DTK software stack requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->