### PR TITLE
[Bugfix][CMake] Fix reconfigure aborting in FindPipCUDAToolkit before project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,12 @@
 
 cmake_minimum_required(VERSION 3.26)
 
-# Detect CUDA toolkit: tries host installation first, then falls back to
-# pip-installed packages (env WITH_PIP_CUDA_TOOLCHAIN or auto-detect).
-# Must be included before project() so CMAKE_CUDA_COMPILER is set.
+# Locate Ninja before project(): that is where the generator resolves
+# CMAKE_MAKE_PROGRAM. CUDA detection lives in the same module but must run after
+# project() instead -- see the second include below.
+set(TILELANG_ACTIVATE_NINJA_ONLY ON)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/FindPipCUDAToolkit.cmake)
+unset(TILELANG_ACTIVATE_NINJA_ONLY)
 
 # Capture this CMakeLists.txt's directory once so `function()` bodies below
 # can reference files shipped with the project. CMake 4.x resolves
@@ -16,6 +18,14 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/FindPipCUDAToolkit.cmake)
 set(TILELANG_CMAKELISTS_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 project(TILE_LANG C CXX)
+
+# Detect CUDA toolkit: tries host installation first, then falls back to
+# pip-installed packages (env WITH_PIP_CUDA_TOOLCHAIN or auto-detect). This has to
+# run after project() so that an enabled language is available -- FindCUDAToolkit's
+# imported-target setup calls find_package(Threads REQUIRED), which hard-errors
+# otherwise. CMAKE_CUDA_COMPILER is published as a cache entry, so subprojects
+# configured further down (add_subdirectory(${TVM_SOURCE}) below) still see it.
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/FindPipCUDAToolkit.cmake)
 
 # MSVC-specific build configuration. Must run after project() so MSVC is
 # defined, but before add_subdirectory(${TVM_SOURCE}) below so subprojects

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,13 @@
 
 cmake_minimum_required(VERSION 3.26)
 
-# Locate Ninja before project(): that is where the generator resolves
-# CMAKE_MAKE_PROGRAM. CUDA detection lives in the same module but must run after
-# project() instead -- see the second include below.
-set(TILELANG_ACTIVATE_NINJA_ONLY ON)
+# Activate the build toolchain before project(): the MSVC environment has to be in
+# place when the compilers are probed, and the generator resolves CMAKE_MAKE_PROGRAM
+# there. CUDA detection lives in the same module but must run after project() instead
+# -- see the second include below.
+set(TILELANG_PRE_PROJECT_ONLY ON)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/FindPipCUDAToolkit.cmake)
-unset(TILELANG_ACTIVATE_NINJA_ONLY)
+unset(TILELANG_PRE_PROJECT_ONLY)
 
 # Capture this CMakeLists.txt's directory once so `function()` bodies below
 # can reference files shipped with the project. CMake 4.x resolves

--- a/cmake/FindPipCUDAToolkit.cmake
+++ b/cmake/FindPipCUDAToolkit.cmake
@@ -303,9 +303,28 @@ function(_tilelang_activate_msvc_env)
     set(CMAKE_EXE_LINKER_FLAGS_INIT "${_tilelang_libpath_flags} ${CMAKE_EXE_LINKER_FLAGS_INIT}")
     set(CMAKE_SHARED_LINKER_FLAGS_INIT "${_tilelang_libpath_flags} ${CMAKE_SHARED_LINKER_FLAGS_INIT}")
     set(CMAKE_MODULE_LINKER_FLAGS_INIT "${_tilelang_libpath_flags} ${CMAKE_MODULE_LINKER_FLAGS_INIT}")
-    set(CMAKE_EXE_LINKER_FLAGS "${_tilelang_libpath_flags} ${CMAKE_EXE_LINKER_FLAGS}" CACHE STRING "Executable linker flags" FORCE)
-    set(CMAKE_SHARED_LINKER_FLAGS "${_tilelang_libpath_flags} ${CMAKE_SHARED_LINKER_FLAGS}" CACHE STRING "Shared linker flags" FORCE)
-    set(CMAKE_MODULE_LINKER_FLAGS "${_tilelang_libpath_flags} ${CMAKE_MODULE_LINKER_FLAGS}" CACHE STRING "Module linker flags" FORCE)
+
+    # The three variables below are cached with FORCE, unlike the *_INIT ones above,
+    # which are plain variables recomputed on every configure. A bare prepend would
+    # therefore stack another copy of the same flags each time this function runs: the
+    # early-out at the top of the function tests ENV{VSCMD_VER}, which a fresh cmake
+    # process does not inherit unless it was launched from a developer prompt, so a
+    # reconfigure re-runs the whole probe and prepends again. Only prepend when this
+    # module's prefix is not already present (literal substring, since the paths
+    # contain characters that would need regex escaping).
+    string(FIND "${CMAKE_EXE_LINKER_FLAGS}" "${_tilelang_libpath_flags}" _tilelang_libpath_pos)
+    if(_tilelang_libpath_pos EQUAL -1)
+      set(CMAKE_EXE_LINKER_FLAGS "${_tilelang_libpath_flags} ${CMAKE_EXE_LINKER_FLAGS}" CACHE STRING "Executable linker flags" FORCE)
+    endif()
+    string(FIND "${CMAKE_SHARED_LINKER_FLAGS}" "${_tilelang_libpath_flags}" _tilelang_libpath_pos)
+    if(_tilelang_libpath_pos EQUAL -1)
+      set(CMAKE_SHARED_LINKER_FLAGS "${_tilelang_libpath_flags} ${CMAKE_SHARED_LINKER_FLAGS}" CACHE STRING "Shared linker flags" FORCE)
+    endif()
+    string(FIND "${CMAKE_MODULE_LINKER_FLAGS}" "${_tilelang_libpath_flags}" _tilelang_libpath_pos)
+    if(_tilelang_libpath_pos EQUAL -1)
+      set(CMAKE_MODULE_LINKER_FLAGS "${_tilelang_libpath_flags} ${CMAKE_MODULE_LINKER_FLAGS}" CACHE STRING "Module linker flags" FORCE)
+    endif()
+    unset(_tilelang_libpath_pos)
   endif()
   if(EXISTS "${_tilelang_sdk_bin}/rc.exe")
     set(CMAKE_RC_COMPILER "${_tilelang_sdk_bin}/rc.exe")

--- a/cmake/FindPipCUDAToolkit.cmake
+++ b/cmake/FindPipCUDAToolkit.cmake
@@ -3,8 +3,11 @@
 # Locate CUDA toolkit — first trying the host system, then falling back
 # to pip-installed packages (nvidia-cuda-nvcc, nvidia-cuda-cccl).
 #
-# This module should be included BEFORE project() to set CMAKE_CUDA_COMPILER
-# when pip CUDA is used.
+# CMakeLists.txt includes this module twice. The first include, before project(),
+# passes TILELANG_ACTIVATE_NINJA_ONLY and only locates Ninja; the second, after
+# project(), runs the CUDA detection (which needs an enabled language). See the note
+# next to the TILELANG_ACTIVATE_NINJA_ONLY check below. CMAKE_CUDA_COMPILER is set as
+# a cache entry, so it is still visible to subprojects configured afterwards.
 #
 # Detection order:
 #   1. Try find_package(CUDAToolkit QUIET) — succeeds if a host CUDA
@@ -465,6 +468,21 @@ function(_tilelang_activate_ninja)
 endfunction()
 
 _tilelang_activate_ninja()
+
+# CMakeLists.txt includes this module twice: once before project() with
+# TILELANG_ACTIVATE_NINJA_ONLY set, so that CMAKE_MAKE_PROGRAM is in place when the
+# generator is resolved, and once after project() for the CUDA detection below.
+#
+# The split is required because find_package(CUDAToolkit) sets up its imported
+# targets, and that path calls find_package(Threads REQUIRED) whenever
+# CMAKE_C_COMPILER or CMAKE_CXX_COMPILER is set. FindThreads aborts with
+# "FindThreads only works if either C or CXX language is enabled" unless a language
+# is enabled, which is not the case before project(). On a fresh configure those two
+# variables are still empty, so the branch is skipped and nothing fails; on a
+# reconfigure they are restored from the cache, so the pre-project include aborted.
+if(TILELANG_ACTIVATE_NINJA_ONLY)
+  return()
+endif()
 
 # --- Try host CUDA first ---
 find_package(CUDAToolkit QUIET)

--- a/cmake/FindPipCUDAToolkit.cmake
+++ b/cmake/FindPipCUDAToolkit.cmake
@@ -4,10 +4,11 @@
 # to pip-installed packages (nvidia-cuda-nvcc, nvidia-cuda-cccl).
 #
 # CMakeLists.txt includes this module twice. The first include, before project(),
-# passes TILELANG_ACTIVATE_NINJA_ONLY and only locates Ninja; the second, after
-# project(), runs the CUDA detection (which needs an enabled language). See the note
-# next to the TILELANG_ACTIVATE_NINJA_ONLY check below. CMAKE_CUDA_COMPILER is set as
-# a cache entry, so it is still visible to subprojects configured afterwards.
+# passes TILELANG_PRE_PROJECT_ONLY and only activates the toolchain (MSVC environment,
+# Ninja lookup); the second, after project(), runs the CUDA detection, which needs an
+# enabled language. See the note next to the TILELANG_PRE_PROJECT_ONLY check below.
+# CMAKE_CUDA_COMPILER is set as a cache entry, so it is still visible to subprojects
+# configured afterwards.
 #
 # Detection order:
 #   1. Try find_package(CUDAToolkit QUIET) — succeeds if a host CUDA
@@ -426,8 +427,6 @@ function(_tilelang_activate_msvc_env)
   message(STATUS "FindPipCUDAToolkit: activated MSVC environment for Ninja via ${_tilelang_vsdevcmd_native}")
 endfunction()
 
-_tilelang_activate_msvc_env()
-
 function(_tilelang_activate_ninja)
   if(NOT CMAKE_GENERATOR MATCHES "Ninja")
     return()
@@ -467,20 +466,29 @@ function(_tilelang_activate_ninja)
   endif()
 endfunction()
 
-_tilelang_activate_ninja()
-
-# CMakeLists.txt includes this module twice: once before project() with
-# TILELANG_ACTIVATE_NINJA_ONLY set, so that CMAKE_MAKE_PROGRAM is in place when the
-# generator is resolved, and once after project() for the CUDA detection below.
+# CMakeLists.txt includes this module twice, because its two jobs want opposite sides
+# of project():
 #
-# The split is required because find_package(CUDAToolkit) sets up its imported
-# targets, and that path calls find_package(Threads REQUIRED) whenever
-# CMAKE_C_COMPILER or CMAKE_CXX_COMPILER is set. FindThreads aborts with
-# "FindThreads only works if either C or CXX language is enabled" unless a language
-# is enabled, which is not the case before project(). On a fresh configure those two
-# variables are still empty, so the branch is skipped and nothing fails; on a
-# reconfigure they are restored from the cache, so the pre-project include aborted.
-if(TILELANG_ACTIVATE_NINJA_ONLY)
+#   * Toolchain activation (MSVC environment, Ninja lookup) must run *before*
+#     project(), since that is where the generator resolves CMAKE_MAKE_PROGRAM and
+#     where the compilers are probed.
+#   * CUDA detection must run *after* project(). find_package(CUDAToolkit) sets up its
+#     imported targets, and that path calls find_package(Threads REQUIRED) whenever
+#     CMAKE_C_COMPILER or CMAKE_CXX_COMPILER is set. FindThreads aborts with
+#     "FindThreads only works if either C or CXX language is enabled" unless a
+#     language is enabled. On a fresh configure those two variables are still empty,
+#     so the branch is skipped and nothing fails; on a reconfigure they are restored
+#     from the cache, so a pre-project include aborts.
+#
+# The activation helpers stay inside the first phase on purpose:
+# _tilelang_activate_msvc_env() is not idempotent. Its early-out tests
+# ENV{VSCMD_VER}, which VsDevCmd.bat's output does not carry back, so a second call
+# in the same configure re-runs the whole probe and prepends another copy of the
+# /LIBPATH flags to the cached CMAKE_*_LINKER_FLAGS entries, which then grow on every
+# reconfigure.
+if(TILELANG_PRE_PROJECT_ONLY)
+  _tilelang_activate_msvc_env()
+  _tilelang_activate_ninja()
   return()
 endif()
 


### PR DESCRIPTION
## Problem

Re-running `cmake` in an existing build directory always fails:

```console
$ mkdir build && cd build
$ cmake .. -DUSE_CUDA=ON -G Ninja     # exit 0
$ cmake .. -DUSE_CUDA=ON -G Ninja     # exit 1
CMake Error at .../Modules/FindThreads.cmake:66 (message):
  FindThreads only works if either C or CXX language is enabled
Call Stack (most recent call first):
  .../Modules/FindCUDAToolkit.cmake:1219 (find_package)
  cmake/FindPipCUDAToolkit.cmake:470 (find_package)
  CMakeLists.txt:9 (include)
```

This also breaks `ninja` in an already-configured tree whenever a CMake input changed, because ninja re-runs `cmake` first — so editing `CMakeLists.txt` or flipping a cache option leaves the build unusable until `build/` is deleted. Reproduced with CMake 3.31.8 on Linux, but nothing here is version- or environment-specific.

## Cause

`FindCUDAToolkit` creates its imported targets under

```cmake
if(NOT TARGET CUDA::cudart_static_deps)
  add_library(CUDA::cudart_static_deps IMPORTED INTERFACE)
  if(UNIX AND (CMAKE_C_COMPILER OR CMAKE_CXX_COMPILER))
    find_package(Threads REQUIRED)
```

`FindPipCUDAToolkit` is included at `CMakeLists.txt:9`, before `project()`, so no language is enabled and `FindThreads` hard-errors if it is reached.

On a **fresh** configure `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` are still empty at that point, the guard is false, and `find_package(Threads)` is never called — which is why the first configure succeeds. On a **reconfigure** both variables come back from the cache (written by `project()` during the previous run), the guard is now true, and the pre-project include aborts.

## Fix

Only the Ninja lookup genuinely has to run before `project()` — that is where the generator resolves `CMAKE_MAKE_PROGRAM`. The CUDA detection does not. `CMakeLists.txt` now includes the module twice: once before `project()` with `TILELANG_ACTIVATE_NINJA_ONLY` set, and once after `project()` for the detection.

Moving detection after `project()` is behaviour-preserving:

- Nothing enables CUDA as a CMake language — both `project()` calls (this one and TVM's) list only `C CXX`, and there is no `enable_language(CUDA)` anywhere in the tree.
- `CMAKE_CUDA_COMPILER` is published as a `CACHE FILEPATH ... FORCE` entry, so subprojects configured further down — `add_subdirectory(${TVM_SOURCE})` at `CMakeLists.txt:479` — still see it regardless of ordering.
- The only consumer of `TILELANG_CUDA_TOOLKIT_AVAILABLE` is the `USE_CUDA` default at `CMakeLists.txt:437`, well after `project()`.
- `CUDAToolkit_FOUND` is read in exactly one place, the `if` on the line following the probe.

## Verification

- Three consecutive `cmake` configures in the same build dir: all exit 0 (second one failed before this change). CUDA is still detected the same way — `TILELANG_CUDA_TOOLKIT_SOURCE=host`, `TILELANG_CUDA_TOOLKIT_AVAILABLE=ON`, `Found CUDAToolkit ... 12.8.93`, `Enable CUDA support by default`.
- Incremental `ninja` in a build directory configured *before* the change: the re-run of `cmake` now succeeds and the libraries relink cleanly.
- Full build from scratch still succeeds; `import tilelang` works against the rebuilt libraries and kernel compilation output is unchanged.
- `pre-commit run --files CMakeLists.txt cmake/FindPipCUDAToolkit.cmake` passes.

No behavioural change is intended, only build robustness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes CMake reconfiguration failures when `USE_CUDA=ON`.

## Changes

- Run `FindPipCUDAToolkit` before `project()` only for Ninja lookup and toolchain activation.
- Run it again after `project()` for CUDA toolkit detection.
- Run MSVC environment setup and Ninja lookup only once per configuration.
- Prevent duplicate linker flags during reconfiguration.
- Publish `CMAKE_CUDA_COMPILER` to the cache for downstream subprojects.
- Preserve existing CUDA detection and `USE_CUDA` behavior.

## Verification

- Repeated configuration succeeds.
- Incremental and full Ninja builds succeed.
- Imports succeed.
- Pre-commit checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->