### PR TITLE
[ROCm] Support packed INT4x2/UINT4x2 codegen

### DIFF
--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -6,6 +6,7 @@
 
 #include "copy.h"
 #include "../transform/common/loop_fusion_utils.h"
+#include "../transform/common/storage_size.h"
 #include "../transform/loop_partition.h"
 #include "../transform/loop_vectorize.h"
 #include "backend/common/target_utils.h"
@@ -31,6 +32,33 @@ namespace tl {
 using namespace tirx;
 using namespace ffi;
 
+namespace {
+
+bool IsPacked4BitNonLocalBuffer(const Buffer &buffer) {
+  return (IsGlobalBuffer(buffer) || IsSharedBuffer(buffer)) &&
+         buffer->dtype.lanes() == 1 && IsPacked4BitStorage(buffer->dtype);
+}
+
+ParallelOp InferGeneratedParallelOp(const For &loop,
+                                    const LowerArgs &lower_args,
+                                    arith::Analyzer *analyzer) {
+  auto par_op = ParallelOp(loop);
+  std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict,
+                                    InferLevel::kFree};
+  for (auto level : levels) {
+    par_op->InferLayout({lower_args.target,
+                         lower_args.thread_bounds,
+                         lower_args.layout_map,
+                         analyzer,
+                         lower_args.buffer_remap,
+                         {}},
+                        level);
+  }
+  return par_op;
+}
+
+} // namespace
+
 Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &lower_args,
                      arith::Analyzer *analyzer) {
   bool is_cpu_target = lower_args.target->GetTargetDeviceType() == kDLCPU;
@@ -38,7 +66,6 @@ Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &lower_args,
   auto fused_loop = Downcast<For>(ParallelLoopFuser::Fuse(simt_loop));
 
   For vectorized_thread_loop;
-  auto par_op = ParallelOp(fused_loop);
 
   if (is_cpu_target || IsLocalBuffer(op.src) || IsLocalBuffer(op.dst)) {
     if (IsLocalBuffer(op.src) && !IsLocalBuffer(op.dst)) {
@@ -68,21 +95,16 @@ Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &lower_args,
                       << "` may cause conflicted write.";
       }
     }
+    if (TargetIsRocm(lower_args.target) && IsPacked4BitNonLocalBuffer(op.dst)) {
+      ValidatePacked4BitStoreOwnership(
+          fused_loop, lower_args.thread_index, lower_args.thread_bounds,
+          analyzer, lower_args.buffer_remap, lower_args.layout_map);
+    }
     vectorized_thread_loop = VectorizeLoop(fused_loop, lower_args.layout_map);
     return vectorized_thread_loop;
   }
 
-  std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict,
-                                    InferLevel::kFree};
-  for (auto level : levels) {
-    par_op->InferLayout({lower_args.target,
-                         lower_args.thread_bounds,
-                         lower_args.layout_map,
-                         analyzer,
-                         lower_args.buffer_remap,
-                         {}},
-                        level);
-  }
+  auto par_op = InferGeneratedParallelOp(fused_loop, lower_args, analyzer);
   auto loop_layout = par_op->GetLoopLayout();
   Optional<PrimExpr> predicate = par_op->GetPredicate(lower_args.thread_index);
   if (TargetIsRocm(lower_args.target)) {
@@ -252,23 +274,18 @@ Stmt LowerIm2ColSIMT(const Im2ColOpNode &op, const LowerArgs &lower_args,
   body = For(i, make_zero(i.dtype()), block_m, ForKind::kParallel, body);
 
   auto fused_loop = Downcast<For>(ParallelLoopFuser::Fuse(Downcast<For>(body)));
-  auto par_op = ParallelOp(fused_loop);
-  std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict,
-                                    InferLevel::kFree};
-  for (auto level : levels) {
-    par_op->InferLayout({lower_args.target,
-                         lower_args.thread_bounds,
-                         lower_args.layout_map,
-                         analyzer,
-                         lower_args.buffer_remap,
-                         {}},
-                        level);
-  }
+  auto par_op = InferGeneratedParallelOp(fused_loop, lower_args, analyzer);
   auto loop_layout = par_op->GetLoopLayout();
+  Optional<PrimExpr> predicate = par_op->GetPredicate(lower_args.thread_index);
+  if (TargetIsRocm(lower_args.target) && IsPacked4BitNonLocalBuffer(dst)) {
+    ValidatePacked4BitStoreOwnership(
+        par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
+        predicate, lower_args.buffer_remap, lower_args.layout_map);
+  }
   return LowerParallelLoop(
       par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
-      lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-      /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
+      lower_args.layout_map, predicate, /*parallel_loop=*/true,
+      par_op->LoopLayoutRequiresPaddingGuard());
 }
 
 bool RegisterDefaultIm2Col() {

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -8,6 +8,7 @@
 #include "../transform/common/loop_fusion_utils.h"
 #include "../transform/loop_partition.h"
 #include "../transform/loop_vectorize.h"
+#include "backend/common/target_utils.h"
 #include "span_utils.h"
 #include "support/check.h"
 #include "utils.h"
@@ -83,10 +84,16 @@ Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &lower_args,
                         level);
   }
   auto loop_layout = par_op->GetLoopLayout();
+  Optional<PrimExpr> predicate = par_op->GetPredicate(lower_args.thread_index);
+  if (TargetIsRocm(lower_args.target)) {
+    ValidatePacked4BitStoreOwnership(
+        par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
+        predicate, lower_args.buffer_remap, lower_args.layout_map);
+  }
   return LowerParallelLoop(
       par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
-      lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-      /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
+      lower_args.layout_map, predicate, /*parallel_loop=*/true,
+      par_op->LoopLayoutRequiresPaddingGuard());
 }
 
 namespace {

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -5,6 +5,7 @@
 
 #include "parallel.h"
 #include "support/check.h"
+#include <tvm/arith/int_set.h>
 #include <tvm/ffi/extra/structural_equal.h>
 #include <tvm/ir/cast.h>
 #include <tvm/runtime/logging.h>
@@ -16,6 +17,7 @@
 
 #include "../layout/layout.h"
 #include "../layout/utils.h"
+#include "../transform/common/storage_size.h"
 #include "../transform/loop_partition.h"
 #include "../transform/loop_vectorize.h"
 #include "arith/int_operator.h"
@@ -72,6 +74,251 @@ private:
   Map<Buffer, Layout> layout_map_;
 };
 
+struct PackedSubByteStoreAccess {
+  Buffer buffer;
+  Array<PrimExpr> indices;
+  Array<IterVar> iter_vars;
+  std::vector<size_t> parallel_positions;
+};
+
+class PackedSubByteStoreCollector : public StmtExprVisitor {
+public:
+  static std::vector<PackedSubByteStoreAccess> Collect(const Stmt &stmt) {
+    PackedSubByteStoreCollector collector;
+    collector(stmt);
+    return collector.stores_;
+  }
+
+private:
+  void VisitStmt_(const ForNode *op) final {
+    size_t position = iter_vars_.size();
+    IterVarType iter_type = op->kind == ForKind::kParallel
+                                ? IterVarType::kDataPar
+                                : IterVarType::kOrdered;
+    iter_vars_.push_back(IterVar(Range::FromMinExtent(op->min, op->extent),
+                                 op->loop_var, iter_type));
+    if (op->kind == ForKind::kParallel) {
+      parallel_positions_.push_back(position);
+    }
+    StmtExprVisitor::VisitStmt_(op);
+    if (op->kind == ForKind::kParallel) {
+      parallel_positions_.pop_back();
+    }
+    iter_vars_.pop_back();
+  }
+
+  void VisitStmt_(const BufferStoreNode *op) final {
+    bool is_packed_physical_store =
+        (IsGlobalBuffer(op->buffer) || IsSharedBuffer(op->buffer)) &&
+        op->buffer->dtype.lanes() == 1 &&
+        IsPacked4BitStorage(op->buffer->dtype);
+    if (is_packed_physical_store && !iter_vars_.empty()) {
+      stores_.push_back({op->buffer, op->indices,
+                         Array<IterVar>(iter_vars_.begin(), iter_vars_.end()),
+                         parallel_positions_});
+    }
+    StmtExprVisitor::VisitStmt_(op);
+  }
+
+  std::vector<IterVar> iter_vars_;
+  std::vector<size_t> parallel_positions_;
+  std::vector<PackedSubByteStoreAccess> stores_;
+};
+
+Optional<PrimExpr>
+GetPackedStoreElementOffset(const PackedSubByteStoreAccess &access) {
+  Array<PrimExpr> physical = access.buffer.OffsetOf(access.indices);
+  Buffer flattened = access.buffer.GetFlattenedBuffer();
+  if (physical.empty() || physical.size() != flattened->shape.size()) {
+    return Optional<PrimExpr>();
+  }
+
+  PrimExpr linear = physical[0];
+  for (size_t i = 1; i < physical.size(); ++i) {
+    linear = linear * flattened->shape[i] + physical[i];
+  }
+  return linear;
+}
+
+Optional<PrimExpr>
+GetPackedStoreByteOffset(const PackedSubByteStoreAccess &access) {
+  Optional<PrimExpr> maybe_elem_offset = GetPackedStoreElementOffset(access);
+  if (!maybe_elem_offset.defined()) {
+    return Optional<PrimExpr>();
+  }
+  PrimExpr elem_offset = maybe_elem_offset.value();
+  return floordiv(elem_offset, make_const(elem_offset.dtype(), 2));
+}
+
+struct ProvenPackedStoreOwner {
+  Var storage;
+  PrimExpr owner;
+  arith::IntSet byte_domain;
+};
+
+arith::IntSet GetPackedStoreByteDomain(const PackedSubByteStoreAccess &access,
+                                       const PrimExpr &byte_offset) {
+  Map<IterVar, arith::IntSet> iter_domains;
+  for (const IterVar &iter_var : access.iter_vars) {
+    iter_domains.Set(iter_var, arith::IntSet::FromRange(iter_var->dom));
+  }
+  return arith::EvalSet(byte_offset, iter_domains);
+}
+
+bool PackedStoreDomainsAreProvablyDisjoint(const arith::IntSet &lhs,
+                                           const arith::IntSet &rhs,
+                                           arith::Analyzer *analyzer) {
+  if (!lhs.HasLowerBound() || !lhs.HasUpperBound() || !rhs.HasLowerBound() ||
+      !rhs.HasUpperBound()) {
+    return false;
+  }
+  return analyzer->CanProve(lhs.max() < rhs.min()) ||
+         analyzer->CanProve(rhs.max() < lhs.min());
+}
+
+bool ProvePackedSubByteStoreOwnership(const Stmt &stmt,
+                                      const Fragment &candidate,
+                                      arith::Analyzer *analyzer,
+                                      bool canonical_replica_guard_guaranteed,
+                                      bool throw_on_error = false) {
+  auto stores = PackedSubByteStoreCollector::Collect(stmt);
+  Var byte_var("__tl_packed_byte");
+  std::vector<ProvenPackedStoreOwner> proven_store_owners;
+  for (const auto &access : stores) {
+    if (access.parallel_positions.size() != candidate->InputDim()) {
+      if (throw_on_error) {
+        throw LayoutConflictException(
+            "Cannot prove packed four-bit byte ownership: candidate thread "
+            "layout does not match the parallel loop domain.");
+      }
+      return false;
+    }
+
+    Optional<PrimExpr> maybe_byte_offset = GetPackedStoreByteOffset(access);
+    if (!maybe_byte_offset.defined()) {
+      if (throw_on_error) {
+        throw LayoutConflictException(
+            "Cannot prove packed four-bit byte ownership: buffer indices "
+            "cannot be flattened to one physical storage offset.");
+      }
+      return false;
+    }
+
+    try {
+      PrimExpr byte_offset = analyzer->Simplify(maybe_byte_offset.value());
+      arith::IntSet byte_domain = GetPackedStoreByteDomain(access, byte_offset);
+      PrimExpr occurrence = MakeFlattenedExpression(
+          DivideUnusedIterators({byte_offset}, access.iter_vars, analyzer));
+      Layout inverse =
+          Layout(access.iter_vars, {byte_offset, occurrence})->Inverse();
+
+      Var occurrence_var("__tl_packed_occurrence");
+      auto inverse_shape = inverse->InputShape();
+      ICHECK_EQ(inverse_shape.size(), 2U);
+      Array<PrimExpr> recovered = inverse->Forward({byte_var, occurrence_var});
+
+      Array<PrimExpr> parallel_indices;
+      for (size_t position : access.parallel_positions) {
+        parallel_indices.push_back(recovered[position]);
+      }
+
+      bool is_replicated =
+          !analyzer->CanProveEqual(candidate->ReplicateExtent(), Integer(1));
+      if (is_replicated && !canonical_replica_guard_guaranteed) {
+        if (throw_on_error) {
+          std::ostringstream oss;
+          oss << "Cannot safely lower a replicated packed four-bit physical "
+                 "store without a proven single-replica guard. Buffer="
+              << access.buffer->name;
+          throw LayoutConflictException(oss.str());
+        }
+        return false;
+      }
+      Optional<PrimExpr> replica =
+          is_replicated ? Optional<PrimExpr>(Integer(0)) : Optional<PrimExpr>();
+
+      PrimExpr owner = analyzer->Simplify(
+          candidate->ForwardThread(parallel_indices, replica));
+      const int64_t *occurrence_extent =
+          as_const_int(analyzer->Simplify(inverse_shape[1]));
+      if (occurrence_extent == nullptr || *occurrence_extent <= 0) {
+        if (throw_on_error) {
+          std::ostringstream oss;
+          oss << "Cannot prove packed four-bit byte ownership: the byte "
+                 "occurrence domain is not statically bounded. Buffer="
+              << access.buffer->name;
+          throw LayoutConflictException(oss.str());
+        }
+        return false;
+      }
+      arith::Analyzer occurrence_analyzer;
+      occurrence_analyzer.Bind(
+          byte_var, Range::FromMinExtent(Integer(0), inverse_shape[0]));
+      occurrence_analyzer.Bind(
+          occurrence_var,
+          Range::FromMinExtent(Integer(0), Integer(*occurrence_extent)));
+
+      Map<Var, PrimExpr> recovered_iter_vars;
+      for (size_t i = 0; i < access.iter_vars.size(); ++i) {
+        recovered_iter_vars.Set(access.iter_vars[i]->var, recovered[i]);
+      }
+      PrimExpr roundtrip_byte = occurrence_analyzer.Simplify(
+          Substitute(byte_offset, recovered_iter_vars));
+      PrimExpr roundtrip_occurrence = occurrence_analyzer.Simplify(
+          Substitute(occurrence, recovered_iter_vars));
+      if (!occurrence_analyzer.CanProveEqual(roundtrip_byte, byte_var) ||
+          !occurrence_analyzer.CanProveEqual(roundtrip_occurrence,
+                                             occurrence_var)) {
+        if (throw_on_error) {
+          std::ostringstream oss;
+          oss << "Cannot prove packed four-bit byte ownership: the recovered "
+                 "ownership inverse does not round-trip the physical byte "
+                 "mapping. Buffer="
+              << access.buffer->name;
+          throw LayoutConflictException(oss.str());
+        }
+        return false;
+      }
+
+      owner = occurrence_analyzer.Simplify(owner);
+      bool occurrence_changes_owner = UsesVar(owner, [&](const VarNode *var) {
+        return var == occurrence_var.get();
+      });
+      if (!occurrence_changes_owner) {
+        bool agrees_with_other_store_sites = true;
+        for (const auto &previous : proven_store_owners) {
+          if (previous.storage.same_as(access.buffer->data) &&
+              !PackedStoreDomainsAreProvablyDisjoint(previous.byte_domain,
+                                                     byte_domain, analyzer) &&
+              !analyzer->CanProveEqual(previous.owner, owner)) {
+            agrees_with_other_store_sites = false;
+            break;
+          }
+        }
+        if (agrees_with_other_store_sites) {
+          proven_store_owners.push_back(
+              {access.buffer->data, owner, byte_domain});
+          continue;
+        }
+      }
+    } catch (const NormalizeIterException &) {
+      // An unprovable inverse is unsafe for a non-atomic packed store.
+    }
+
+    if (throw_on_error) {
+      std::ostringstream oss;
+      oss << "Cannot safely lower a packed four-bit store: logical elements "
+             "that share a writable byte may be assigned to different GPU "
+             "threads. Use a byte-owned layout or rewrite the access pattern. "
+             "Buffer="
+          << access.buffer->name << ", candidate=" << candidate->DebugOutput();
+      throw LayoutConflictException(oss.str());
+    }
+    return false;
+  }
+  return true;
+}
+
 // Choose a vector width for non-fragment SIMT loops while keeping the full
 // thread extent active.  The loop partitioner covers work in chunks of
 // `thread_extent * vector_size`; when the logical loop size is ragged, the
@@ -121,6 +368,37 @@ int SelectMinPaddingVectorSize(int max_vector_size, PrimExpr loop_total_size,
 }
 
 } // anonymous namespace
+
+void ValidatePacked4BitStoreOwnership(const For &remapped_loop,
+                                      const Fragment &loop_layout,
+                                      PrimExpr thread_index,
+                                      arith::Analyzer *analyzer,
+                                      const Optional<PrimExpr> &predicate) {
+  bool canonical_replica_guard_guaranteed =
+      analyzer->CanProveEqual(loop_layout->ReplicateExtent(), Integer(1));
+  if (!canonical_replica_guard_guaranteed && predicate.defined()) {
+    try {
+      Layout inverse = loop_layout->Inverse();
+      Array<PrimExpr> outputs;
+      for (size_t i = 0; i < loop_layout->OutputDim(); ++i) {
+        outputs.push_back(Integer(0));
+      }
+      PrimExpr normalized_thread = thread_index;
+      if (loop_layout->ThreadRange().defined()) {
+        normalized_thread = normalized_thread - loop_layout->ThreadRange()->min;
+      }
+      outputs.push_back(normalized_thread);
+      PrimExpr replica = analyzer->Simplify(inverse->Forward(outputs).back());
+      canonical_replica_guard_guaranteed = analyzer->CanProve(Or(
+          Not(predicate.value()), EQ(replica, make_const(replica.dtype(), 0))));
+    } catch (const NormalizeIterException &) {
+      // Fail closed below when the final layout cannot be inverted.
+    }
+  }
+  ProvePackedSubByteStoreOwnership(remapped_loop, loop_layout, analyzer,
+                                   canonical_replica_guard_guaranteed,
+                                   /*throw_on_error=*/true);
+}
 
 /**
  * @brief Handle a parallel For node during traversal, collecting loop metadata.
@@ -553,6 +831,16 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &layout_args,
     // In non-free mode without a source buffer, if we don't have any layout
     // yet (e.g., no annotation), we have nothing to infer here.
     return {};
+  }
+
+  if (TargetIsRocm(layout_args.target)) {
+    For remapped_root = IfBufferRemapLoopGenerator::run(
+        root_, layout_args.buffer_remap, layout_args.layout_map);
+    ProvePackedSubByteStoreOwnership(remapped_root, loop_layout_,
+                                     layout_args.analyzer,
+                                     /*canonical_replica_guard_guaranteed=*/
+                                     store_fragment_buffers_.empty(),
+                                     /*throw_on_error=*/true);
   }
 
   // Non-fragment SIMT loops may deliberately over-cover a ragged iteration

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -368,11 +368,24 @@ int SelectMinPaddingVectorSize(int max_vector_size, PrimExpr loop_total_size,
 
 } // anonymous namespace
 
-void ValidatePacked4BitStoreOwnership(const For &remapped_loop,
+void ValidatePacked4BitStoreOwnership(const For &loop,
                                       const Fragment &loop_layout,
                                       PrimExpr thread_index,
                                       arith::Analyzer *analyzer,
                                       const Optional<PrimExpr> &predicate) {
+  ValidatePacked4BitStoreOwnership(loop, loop_layout, thread_index, analyzer,
+                                   predicate, {}, {});
+}
+
+void ValidatePacked4BitStoreOwnership(const For &loop,
+                                      const Fragment &loop_layout,
+                                      PrimExpr thread_index,
+                                      arith::Analyzer *analyzer,
+                                      const Optional<PrimExpr> &predicate,
+                                      const Map<Buffer, Buffer> &buffer_remap,
+                                      const Map<Buffer, Layout> &layout_map) {
+  For remapped_loop =
+      IfBufferRemapLoopGenerator::run(loop, buffer_remap, layout_map);
   bool canonical_replica_guard_guaranteed =
       analyzer->CanProveEqual(loop_layout->ReplicateExtent(), Integer(1));
   if (!canonical_replica_guard_guaranteed && predicate.defined()) {

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -82,8 +82,13 @@ struct PackedSubByteStoreAccess {
 
 class PackedSubByteStoreCollector : public StmtExprVisitor {
 public:
-  static std::vector<PackedSubByteStoreAccess> Collect(const Stmt &stmt) {
+  static std::vector<PackedSubByteStoreAccess>
+  Collect(const Stmt &stmt,
+          const Optional<IterVar> &execution_thread = Optional<IterVar>()) {
     PackedSubByteStoreCollector collector;
+    if (execution_thread.defined()) {
+      collector.iter_vars_.push_back(execution_thread.value());
+    }
     collector(stmt);
     return collector.stores_;
   }
@@ -175,16 +180,17 @@ bool PackedStoreDomainsAreProvablyDisjoint(const arith::IntSet &lhs,
          analyzer->CanProve(rhs.max() < lhs.min());
 }
 
-bool ProvePackedSubByteStoreOwnership(const Stmt &stmt,
-                                      const Fragment &candidate,
-                                      arith::Analyzer *analyzer,
-                                      bool canonical_replica_guard_guaranteed,
-                                      bool throw_on_error = false) {
-  auto stores = PackedSubByteStoreCollector::Collect(stmt);
+bool ProvePackedSubByteStoreOwnership(
+    const Stmt &stmt, const Fragment &candidate, arith::Analyzer *analyzer,
+    bool canonical_replica_guard_guaranteed, bool throw_on_error = false,
+    const Optional<IterVar> &execution_thread = Optional<IterVar>(),
+    const Optional<PrimExpr> &execution_owner = Optional<PrimExpr>()) {
+  auto stores = PackedSubByteStoreCollector::Collect(stmt, execution_thread);
   Var byte_var("__tl_packed_byte");
   std::vector<ProvenPackedStoreOwner> proven_store_owners;
   for (const auto &access : stores) {
-    if (access.parallel_positions.size() != candidate->InputDim()) {
+    if (!execution_owner.defined() &&
+        access.parallel_positions.size() != candidate->InputDim()) {
       if (throw_on_error) {
         throw LayoutConflictException(
             "Cannot prove packed four-bit byte ownership: candidate thread "
@@ -216,28 +222,32 @@ bool ProvePackedSubByteStoreOwnership(const Stmt &stmt,
       ICHECK_EQ(inverse_shape.size(), 2U);
       Array<PrimExpr> recovered = inverse->Forward({byte_var, occurrence_var});
 
-      Array<PrimExpr> parallel_indices;
-      for (size_t position : access.parallel_positions) {
-        parallel_indices.push_back(recovered[position]);
-      }
-
-      bool is_replicated =
-          !analyzer->CanProveEqual(candidate->ReplicateExtent(), Integer(1));
-      if (is_replicated && !canonical_replica_guard_guaranteed) {
-        if (throw_on_error) {
-          std::ostringstream oss;
-          oss << "Cannot safely lower a replicated packed four-bit physical "
-                 "store without a proven single-replica guard. Buffer="
-              << access.buffer->name;
-          throw LayoutConflictException(oss.str());
+      PrimExpr owner;
+      if (execution_owner.defined()) {
+        owner = execution_owner.value();
+      } else {
+        Array<PrimExpr> parallel_indices;
+        for (size_t position : access.parallel_positions) {
+          parallel_indices.push_back(recovered[position]);
         }
-        return false;
+        bool is_replicated =
+            !analyzer->CanProveEqual(candidate->ReplicateExtent(), Integer(1));
+        if (is_replicated && !canonical_replica_guard_guaranteed) {
+          if (throw_on_error) {
+            std::ostringstream oss;
+            oss << "Cannot safely lower a replicated packed four-bit physical "
+                   "store without a proven single-replica guard. Buffer="
+                << access.buffer->name;
+            throw LayoutConflictException(oss.str());
+          }
+          return false;
+        }
+        Optional<PrimExpr> replica = is_replicated
+                                         ? Optional<PrimExpr>(Integer(0))
+                                         : Optional<PrimExpr>();
+        owner = analyzer->Simplify(
+            candidate->ForwardThread(parallel_indices, replica));
       }
-      Optional<PrimExpr> replica =
-          is_replicated ? Optional<PrimExpr>(Integer(0)) : Optional<PrimExpr>();
-
-      PrimExpr owner = analyzer->Simplify(
-          candidate->ForwardThread(parallel_indices, replica));
       const int64_t *occurrence_extent =
           as_const_int(analyzer->Simplify(inverse_shape[1]));
       if (occurrence_extent == nullptr || *occurrence_extent <= 0) {
@@ -261,6 +271,8 @@ bool ProvePackedSubByteStoreOwnership(const Stmt &stmt,
       for (size_t i = 0; i < access.iter_vars.size(); ++i) {
         recovered_iter_vars.Set(access.iter_vars[i]->var, recovered[i]);
       }
+      owner =
+          occurrence_analyzer.Simplify(Substitute(owner, recovered_iter_vars));
       PrimExpr roundtrip_byte = occurrence_analyzer.Simplify(
           Substitute(byte_offset, recovered_iter_vars));
       PrimExpr roundtrip_occurrence = occurrence_analyzer.Simplify(
@@ -279,7 +291,6 @@ bool ProvePackedSubByteStoreOwnership(const Stmt &stmt,
         return false;
       }
 
-      owner = occurrence_analyzer.Simplify(owner);
       bool occurrence_changes_owner = UsesVar(owner, [&](const VarNode *var) {
         return var == occurrence_var.get();
       });
@@ -310,7 +321,10 @@ bool ProvePackedSubByteStoreOwnership(const Stmt &stmt,
              "that share a writable byte may be assigned to different GPU "
              "threads. Use a byte-owned layout or rewrite the access pattern. "
              "Buffer="
-          << access.buffer->name << ", candidate=" << candidate->DebugOutput();
+          << access.buffer->name;
+      if (candidate.defined()) {
+        oss << ", candidate=" << candidate->DebugOutput();
+      }
       throw LayoutConflictException(oss.str());
     }
     return false;
@@ -410,6 +424,28 @@ void ValidatePacked4BitStoreOwnership(const For &loop,
   ProvePackedSubByteStoreOwnership(remapped_loop, loop_layout, analyzer,
                                    canonical_replica_guard_guaranteed,
                                    /*throw_on_error=*/true);
+}
+
+void ValidatePacked4BitStoreOwnership(const For &loop, PrimExpr thread_index,
+                                      const Range &thread_bounds,
+                                      arith::Analyzer *analyzer,
+                                      const Map<Buffer, Buffer> &buffer_remap,
+                                      const Map<Buffer, Layout> &layout_map) {
+  For remapped_loop =
+      IfBufferRemapLoopGenerator::run(loop, buffer_remap, layout_map);
+  Optional<IterVar> execution_thread;
+  if (const auto *thread_var = thread_index.as<VarNode>()) {
+    execution_thread =
+        IterVar(thread_bounds, GetRef<Var>(thread_var), IterVarType::kDataPar);
+  } else if (!analyzer->CanProveEqual(thread_bounds->extent, Integer(1))) {
+    throw LayoutConflictException(
+        "Cannot prove packed four-bit byte ownership: the hardware thread "
+        "index is not a single variable.");
+  }
+  ProvePackedSubByteStoreOwnership(remapped_loop, Fragment(), analyzer,
+                                   /*canonical_replica_guard_guaranteed=*/true,
+                                   /*throw_on_error=*/true, execution_thread,
+                                   thread_index);
 }
 
 /**

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -21,7 +21,6 @@
 #include "../transform/loop_partition.h"
 #include "../transform/loop_vectorize.h"
 #include "arith/int_operator.h"
-#include "backend/common/target_utils.h"
 #include "builtin.h"
 #include "reducer.h"
 #include "span_utils.h"
@@ -831,16 +830,6 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &layout_args,
     // In non-free mode without a source buffer, if we don't have any layout
     // yet (e.g., no annotation), we have nothing to infer here.
     return {};
-  }
-
-  if (TargetIsRocm(layout_args.target)) {
-    For remapped_root = IfBufferRemapLoopGenerator::run(
-        root_, layout_args.buffer_remap, layout_args.layout_map);
-    ProvePackedSubByteStoreOwnership(remapped_root, loop_layout_,
-                                     layout_args.analyzer,
-                                     /*canonical_replica_guard_guaranteed=*/
-                                     store_fragment_buffers_.empty(),
-                                     /*throw_on_error=*/true);
   }
 
   // Non-fragment SIMT loops may deliberately over-cover a ragged iteration

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -55,6 +55,19 @@ void ValidatePacked4BitStoreOwnership(const For &loop,
                                       const Map<Buffer, Buffer> &buffer_remap,
                                       const Map<Buffer, Layout> &layout_map);
 
+/**
+ * Validate a generated loop that is executed independently by every thread,
+ * rather than partitioned by `LowerParallelLoop`.
+ *
+ * This is used by local-buffer copy lowering, where the destination indices
+ * may contain the hardware thread index directly.
+ */
+void ValidatePacked4BitStoreOwnership(const For &loop, PrimExpr thread_index,
+                                      const Range &thread_bounds,
+                                      arith::Analyzer *analyzer,
+                                      const Map<Buffer, Buffer> &buffer_remap,
+                                      const Map<Buffer, Layout> &layout_map);
+
 class ParallelOpNode;
 
 /*!

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -31,16 +31,29 @@ using namespace ffi;
 
 /**
  * Validate that every physical byte written by scalar packed four-bit stores
- * in `remapped_loop` is owned by one GPU thread under `loop_layout`.
+ * in `loop` is owned by one GPU thread under `loop_layout`.
  *
  * Throws LayoutConflictException when ownership cannot be proven. This must
  * run before LowerParallelLoop removes the logical loop layout.
  */
-void ValidatePacked4BitStoreOwnership(const For &remapped_loop,
+void ValidatePacked4BitStoreOwnership(const For &loop,
                                       const Fragment &loop_layout,
                                       PrimExpr thread_index,
                                       arith::Analyzer *analyzer,
                                       const Optional<PrimExpr> &predicate);
+
+/**
+ * Apply the physical buffer layouts, then validate packed four-bit ownership.
+ * This overload is used by tile operators whose generated SIMT loops have not
+ * yet passed through LowerTileOp's buffer visitors.
+ */
+void ValidatePacked4BitStoreOwnership(const For &loop,
+                                      const Fragment &loop_layout,
+                                      PrimExpr thread_index,
+                                      arith::Analyzer *analyzer,
+                                      const Optional<PrimExpr> &predicate,
+                                      const Map<Buffer, Buffer> &buffer_remap,
+                                      const Map<Buffer, Layout> &layout_map);
 
 class ParallelOpNode;
 

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -29,6 +29,19 @@ namespace tl {
 using namespace tirx;
 using namespace ffi;
 
+/**
+ * Validate that every physical byte written by scalar packed four-bit stores
+ * in `remapped_loop` is owned by one GPU thread under `loop_layout`.
+ *
+ * Throws LayoutConflictException when ownership cannot be proven. This must
+ * run before LowerParallelLoop removes the logical loop layout.
+ */
+void ValidatePacked4BitStoreOwnership(const For &remapped_loop,
+                                      const Fragment &loop_layout,
+                                      PrimExpr thread_index,
+                                      arith::Analyzer *analyzer,
+                                      const Optional<PrimExpr> &predicate);
+
 class ParallelOpNode;
 
 /*!

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -760,13 +760,14 @@ void CodeGenTileLangHIP::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
   LOG(FATAL) << "Cannot convert type " << t << " to CUDA type";
 }
 
-void CodeGenTileLangHIP::PrintVecConstructor(DataType t,
+void CodeGenTileLangHIP::PrintVecConstructor(DataType data_type,
                                              std::ostream &os) { // NOLINT(*)
-  if ((t.is_int() || t.is_uint()) && t.bits() == 4 && t.lanes() == 2) {
-    os << (t.is_uint() ? "tl_pack_uint4x2" : "tl_pack_int4x2");
+  if ((data_type.is_int() || data_type.is_uint()) && data_type.bits() == 4 &&
+      data_type.lanes() == 2) {
+    os << (data_type.is_uint() ? "tl_pack_uint4x2" : "tl_pack_int4x2");
     return;
   }
-  CodeGenC::PrintVecConstructor(t, os);
+  CodeGenC::PrintVecConstructor(data_type, os);
 }
 
 void CodeGenTileLangHIP::PrintVecBinaryOp(const std::string &op, DataType t,
@@ -1435,6 +1436,22 @@ void CodeGenTileLangHIP::PrintCallExtern(Type ret_type, String global_symbol,
   }
 }
 
+void CodeGenTileLangHIP::PrintPackedInt4Load(const BufferNode *buffer,
+                                             const std::string &index,
+                                             std::ostream &os) { // NOLINT(*)
+  DataType element_dtype = buffer->dtype;
+  ICHECK(element_dtype == DataType::Int(4) ||
+         element_dtype == DataType::UInt(4));
+  std::string vid = GetVarID(buffer->data.get());
+  if (element_dtype.is_uint()) {
+    os << "tl_uint4_packed_load((const unsigned char*)" << vid << ", " << index
+       << ")";
+  } else {
+    os << "tl_int4_packed_load((const signed char*)" << vid << ", " << index
+       << ")";
+  }
+}
+
 // Print a reference expression to a buffer.
 std::string CodeGenTileLangHIP::GetBufferRef(DataType t,
                                              const BufferNode *buffer,
@@ -1735,8 +1752,15 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
         << "T.__ldg currently supports flattened 1D buffer accesses.";
     const BufferNode *buffer = bl->buffer.get();
     PrimExpr base = bl->indices[0];
-    auto buffer_ref = this->GetBufferRef(op->dtype, buffer, base);
-    os << buffer_ref;
+    DataType element_dtype = buffer->dtype;
+    bool is_scalar_packed_int4 =
+        op->dtype.is_scalar() && (element_dtype == DataType::Int(4) ||
+                                  element_dtype == DataType::UInt(4));
+    if (is_scalar_packed_int4) {
+      PrintPackedInt4Load(buffer, PrintExpr(base), os);
+    } else {
+      os << this->GetBufferRef(op->dtype, buffer, base);
+    }
   } else if (op->op.same_as(builtin::tvm_fill_fragment())) {
     need_mma_h_ = true;
     ICHECK_EQ(op->args.size(), 6U);
@@ -2239,13 +2263,7 @@ void CodeGenTileLangHIP::VisitExpr_(const BufferLoadNode *op,
   std::string vid = GetVarID(buffer_var.get());
   auto print_packed_int4_load = [&](const std::string &idx_str,
                                     std::ostream &stream) {
-    if (element_dtype.is_uint()) {
-      stream << "tl_uint4_packed_load((const unsigned char*)" << vid << ", "
-             << idx_str << ")";
-    } else {
-      stream << "tl_int4_packed_load((const signed char*)" << vid << ", "
-             << idx_str << ")";
-    }
+    PrintPackedInt4Load(op->buffer.get(), idx_str, stream);
   };
 
   if (is_packed_int4_buffer && value_dtype.is_scalar()) {

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -18,6 +18,7 @@
 #include <utility>
 #include <vector>
 
+#include "arith/pattern_match.h"
 #include "backend/common/target_utils.h"
 #include "rocm/op/builtin.h"
 
@@ -30,6 +31,13 @@ namespace {
 
 bool IsValidCPAsyncTransferBytes(int64_t bytes) {
   return bytes == 4 || bytes == 8 || bytes == 16;
+}
+
+bool IsProvablyDivisible(const PrimExpr &expr, int64_t divisor) {
+  ICHECK_GT(divisor, 0);
+  arith::Analyzer analyzer;
+  arith::ModularSet modular_set = analyzer.modular_set(expr);
+  return modular_set->coeff % divisor == 0 && modular_set->base % divisor == 0;
 }
 
 std::optional<DataType> GetAccessPtrElementType(const PrimExpr &expr) {
@@ -622,7 +630,15 @@ void CodeGenTileLangHIP::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
     }
     case 4: {
       if (t.is_scalar()) {
-        os << "int";
+        if (!t.is_uint()) {
+          os << "signed char";
+        } else {
+          os << "char";
+        }
+        return;
+      } else if (t.lanes() == 2) {
+        // Two packed 4-bit lanes occupy exactly one byte.
+        os << "int8_t";
         return;
       } else if (t.lanes() == 4) {
         os << "int16_t";
@@ -742,6 +758,15 @@ void CodeGenTileLangHIP::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
     }
   }
   LOG(FATAL) << "Cannot convert type " << t << " to CUDA type";
+}
+
+void CodeGenTileLangHIP::PrintVecConstructor(DataType t,
+                                             std::ostream &os) { // NOLINT(*)
+  if ((t.is_int() || t.is_uint()) && t.bits() == 4 && t.lanes() == 2) {
+    os << (t.is_uint() ? "tl_pack_uint4x2" : "tl_pack_int4x2");
+    return;
+  }
+  CodeGenC::PrintVecConstructor(t, os);
 }
 
 void CodeGenTileLangHIP::PrintVecBinaryOp(const std::string &op, DataType t,
@@ -1477,15 +1502,15 @@ std::string CodeGenTileLangHIP::GetBufferRef(DataType t,
   }
 
   std::string index_str = PrintExpr(index);
-  if (t.bits() == 4 || (t.bits() == 1 && t.is_int())) {
-    // This is a special case, because CodegenCUDA::PrintType()
-    // returns "int" for bool and for 4-bit integers. In most cases,
-    // we divide by the number of lanes to determine the index.
-    // However, the backing type for scalar int4 and scalar bool is
-    // int32.  Therefore, we need to divide by the ratio of their
-    // sizes in that case.
+  if (t.bits() == 4 && !t.is_float4()) {
+    // Scalar int4/uint4 storage is byte-packed (2 logical elements per byte).
+    // Vector accesses reinterpret the packed bytes as the requested carrier.
+    int div_factor = t.lanes() == 1 ? 2 : t.lanes();
+    index_str =
+        PrintExpr(arith::Analyzer().Simplify(truncdiv(index, div_factor)));
+    os << "*(" << "(" << ptr_cast(t) << vid << ")" << " + " << index_str << ")";
+  } else if (t.bits() == 4 || (t.bits() == 1 && t.is_int())) {
     int div_factor = (t.lanes() == 1) ? (32 / t.bits()) : t.lanes();
-
     os << "*(" << "(" << ptr_cast(t) << vid << ")" << " + " << index_str
        << " / " << div_factor << ")";
   } else if (t == buffer_element_dtype) {
@@ -2120,8 +2145,11 @@ void CodeGenTileLangHIP::VisitStmt_(const AllocBufferNode *op) {
   // Skip the normal type+scope header; emit the packed type directly below.
   bool is_fp4_scalar_local =
       dtype.is_float4() && dtype.is_scalar() && scope == "local";
+  bool is_int4_scalar_local =
+      (dtype == DataType::Int(4) || dtype == DataType::UInt(4)) &&
+      dtype.is_scalar() && scope == "local";
 
-  if (!is_fp4_scalar_local) {
+  if (!is_fp4_scalar_local && !is_int4_scalar_local) {
     PrintStorageScope(scope, stream);
     PrintType(dtype, stream);
   }
@@ -2138,8 +2166,9 @@ void CodeGenTileLangHIP::VisitStmt_(const AllocBufferNode *op) {
     if (scope == "shared") {
       if (dtype.is_float4_e2m1fn() && dtype.is_scalar()) {
         constant_size = (constant_size + 1) / 2;
-      } else if (dtype == DataType::Int(4) || dtype == DataType::UInt(4) ||
-                 dtype == DataType::Int(1)) {
+      } else if (dtype == DataType::Int(4) || dtype == DataType::UInt(4)) {
+        constant_size = (constant_size + 1) / 2;
+      } else if (dtype == DataType::Int(1)) {
         size_t elements_per_storage_word = 32 / dtype.bits();
         constant_size = (constant_size + elements_per_storage_word - 1) /
                         elements_per_storage_word;
@@ -2155,6 +2184,10 @@ void CodeGenTileLangHIP::VisitStmt_(const AllocBufferNode *op) {
       stream << "fp4_e2_2_t " << vid_packed << '[' << (constant_size + 1) / 2
              << "];\n";
       fp4_packed_buffers_[op->buffer->data] = vid_packed;
+    } else if (is_int4_scalar_local) {
+      stream << "alignas(16) ";
+      PrintType(dtype, stream);
+      stream << ' ' << vid << '[' << (constant_size + 1) / 2 << "];\n";
     } else if (scope == "local.var") {
       // Single-element variable: emit an initializer so the value is defined.
       // Default to 0; respect the user-provided tl.local_var_init annotation.
@@ -2177,6 +2210,135 @@ void CodeGenTileLangHIP::VisitStmt_(const AllocBufferNode *op) {
   RegisterHandleType(op->buffer->data.get(), op->buffer->dtype);
 }
 
+void CodeGenTileLangHIP::VisitExpr_(const BufferLoadNode *op,
+                                    std::ostream &os) { // NOLINT(*)
+  ICHECK_EQ(op->indices.size(), 1)
+      << "Load from non-flat memory not supported.";
+  ICHECK(!op->predicate.defined())
+      << "Predicated buffer load is not supported.";
+
+  DataType value_dtype = op->dtype;
+  PrimExpr index = op->indices[0];
+  Var buffer_var = op->buffer->data;
+  DataType element_dtype = op->buffer->dtype;
+
+  const bool is_packed_int4_buffer = (element_dtype == DataType::Int(4) ||
+                                      element_dtype == DataType::UInt(4)) &&
+                                     element_dtype.is_scalar();
+  const bool is_packed_int4_vector = is_packed_int4_buffer &&
+                                     value_dtype.lanes() > 1 &&
+                                     value_dtype.element_of() == element_dtype;
+  const bool is_packed_int4x2 =
+      is_packed_int4_vector && value_dtype.lanes() == 2;
+
+  if (!is_packed_int4_buffer) {
+    CodeGenC::VisitExpr_(op, os);
+    return;
+  }
+
+  std::string vid = GetVarID(buffer_var.get());
+  auto print_packed_int4_load = [&](const std::string &idx_str,
+                                    std::ostream &stream) {
+    if (element_dtype.is_uint()) {
+      stream << "tl_uint4_packed_load((const unsigned char*)" << vid << ", "
+             << idx_str << ")";
+    } else {
+      stream << "tl_int4_packed_load((const signed char*)" << vid << ", "
+             << idx_str << ")";
+    }
+  };
+
+  if (is_packed_int4_buffer && value_dtype.is_scalar()) {
+    print_packed_int4_load(PrintExpr(index), os);
+    return;
+  }
+
+  int lanes = value_dtype.lanes();
+  if (value_dtype.lanes() == element_dtype.lanes()) {
+    std::string ref = GetBufferRef(value_dtype, op->buffer.get(), index);
+    HandleVolatileLoads(ref, op, os);
+    return;
+  }
+
+  bool can_vector_load = false;
+  arith::PVar<PrimExpr> base;
+  int ramp_lanes = value_dtype.lanes() / element_dtype.lanes();
+  if (arith::ramp(base, 1, ramp_lanes).Match(index)) {
+    can_vector_load = true;
+    if (is_packed_int4_vector) {
+      can_vector_load = IsProvablyDivisible(base.Eval(), value_dtype.lanes());
+    }
+  }
+
+  if (can_vector_load) {
+    std::string ref = GetVecLoad(value_dtype, op->buffer.get(), base.Eval());
+    HandleVolatileLoads(ref, op, os);
+    return;
+  }
+
+  if (is_packed_int4_vector && !is_packed_int4x2) {
+    // Unaligned and gathered packed loads are safe to scalarize because they
+    // do not introduce byte-level read-modify-write races.
+    std::string result = name_supply_->FreshName("_");
+    this->PrintIndent();
+    this->PrintType(value_dtype, stream);
+    stream << ' ' << result << ";\n";
+    int ssa_scope = BeginScope();
+    const RampNode *ramp = index.as<RampNode>();
+    std::string sindex;
+    if (ramp == nullptr) {
+      sindex = SSAGetID(PrintExpr(index), index.dtype());
+    }
+    for (int i = 0; i < lanes; ++i) {
+      std::ostringstream lane_index;
+      if (ramp != nullptr) {
+        PrimExpr lane =
+            arith::Analyzer().Simplify(ramp->base + ramp->stride * i);
+        lane_index << PrintExpr(lane);
+      } else {
+        PrintVecElemLoad(sindex, index.dtype(), i, lane_index);
+      }
+      std::ostringstream lane_value;
+      print_packed_int4_load(lane_index.str(), lane_value);
+      PrintVecElemStore(result, value_dtype, i, lane_value.str());
+    }
+    EndScope(ssa_scope);
+    os << result;
+    return;
+  }
+
+  std::ostringstream svalue_expr;
+  std::string sindex = SSAGetID(PrintExpr(index), index.dtype());
+  DataType elem_type = value_dtype.element_of();
+  for (int i = 0; i < lanes; ++i) {
+    std::ostringstream value_temp;
+    if (is_packed_int4x2) {
+      std::ostringstream lane_index;
+      PrintVecElemLoad(sindex, index.dtype(), i, lane_index);
+      print_packed_int4_load(lane_index.str(), value_temp);
+    } else {
+      if (!HandleTypeMatch(buffer_var.get(), elem_type)) {
+        value_temp << "((";
+        if (buffer_var.get()->dtype.is_handle()) {
+          auto it = alloc_storage_scope_.find(buffer_var.get());
+          if (it != alloc_storage_scope_.end()) {
+            PrintStorageScope(it->second, value_temp);
+          }
+        }
+        PrintType(elem_type, value_temp);
+        value_temp << "*)" << vid << ')';
+      } else {
+        value_temp << vid;
+      }
+      value_temp << '[';
+      PrintVecElemLoad(sindex, index.dtype(), i, value_temp);
+      value_temp << ']';
+    }
+    PrintVecElemLoadExpr(value_dtype, i, value_temp.str(), svalue_expr);
+  }
+  os << svalue_expr.str();
+}
+
 void CodeGenTileLangHIP::VisitStmt_(const BufferStoreNode *op) {
   ICHECK_EQ(op->indices.size(), 1) << "Store to non-flat memory not supported.";
   ICHECK(!op->predicate.defined())
@@ -2184,13 +2346,36 @@ void CodeGenTileLangHIP::VisitStmt_(const BufferStoreNode *op) {
 
   DataType value_dtype = op->value.dtype();
   DataType element_dtype = op->buffer->dtype;
+  PrimExpr index_expr = op->indices[0];
   Var buffer_var = op->buffer->data;
+
+  const bool is_packed_int4_buffer = (element_dtype == DataType::Int(4) ||
+                                      element_dtype == DataType::UInt(4)) &&
+                                     element_dtype.is_scalar();
+  const bool is_packed_int4_vector = is_packed_int4_buffer &&
+                                     value_dtype.lanes() > 1 &&
+                                     value_dtype.element_of() == element_dtype;
+
+  if (is_packed_int4_buffer && value_dtype.is_scalar()) {
+    std::string idx_str = PrintExpr(index_expr);
+    std::string value = this->PrintExpr(op->value);
+    std::string vid = GetVarID(buffer_var.get());
+    this->PrintIndent();
+    if (element_dtype.is_uint()) {
+      stream << "tl_uint4_packed_store((unsigned char*)" << vid << ", "
+             << idx_str << ", " << value << ");\n";
+    } else {
+      stream << "tl_int4_packed_store((signed char*)" << vid << ", " << idx_str
+             << ", " << value << ");\n";
+    }
+    return;
+  }
 
   // FP4 scalar store: use tl_fp4_packed_store to correctly handle nibble-level
   // writes without corrupting the neighbouring nibble.
   if (element_dtype.is_float4() && element_dtype.is_scalar() &&
       value_dtype.is_scalar()) {
-    std::string idx_str = PrintExpr(op->indices[0]);
+    std::string idx_str = PrintExpr(index_expr);
     std::string value = this->PrintExpr(op->value);
     this->PrintIndent();
     auto packed_it = fp4_packed_buffers_.find(buffer_var);
@@ -2205,16 +2390,79 @@ void CodeGenTileLangHIP::VisitStmt_(const BufferStoreNode *op) {
     return;
   }
 
-  // Default path for all other types.
-  CodeGenC::VisitStmt_(op);
+  if (!is_packed_int4_buffer) {
+    CodeGenC::VisitStmt_(op);
+    return;
+  }
+
+  if (value_dtype.lanes() == element_dtype.lanes()) {
+    std::string value = this->PrintExpr(op->value);
+    std::string ref =
+        this->GetBufferRef(value_dtype, op->buffer.get(), index_expr);
+    this->PrintIndent();
+    stream << ref << " = " << value << ";\n";
+    return;
+  }
+
+  arith::PVar<PrimExpr> base;
+  int ramp_lanes = value_dtype.lanes() / element_dtype.lanes();
+  bool is_unit_stride_ramp = arith::ramp(base, 1, ramp_lanes).Match(index_expr);
+  if (is_packed_int4_vector &&
+      (!is_unit_stride_ramp ||
+       !IsProvablyDivisible(base.Eval(), value_dtype.lanes()))) {
+    LOG(FATAL) << "Packed int4/uint4 vector stores require a unit-stride ramp "
+                  "with a logical base provably divisible by the vector lane "
+                  "count, but got "
+               << index_expr;
+  }
+  if (is_unit_stride_ramp) {
+    std::string value = this->PrintExpr(op->value);
+    this->PrintVecStore(op->buffer.get(), value_dtype, base.Eval(), value);
+    return;
+  }
+
+  int vec_scope = BeginScope();
+  std::string index = SSAGetID(PrintExpr(index_expr), index_expr.dtype());
+  std::string value = SSAGetID(PrintExpr(op->value), op->value.dtype());
+  std::string vid = GetVarID(buffer_var.get());
+  for (int i = 0; i < value_dtype.lanes(); ++i) {
+    this->PrintIndent();
+    DataType elem_type = value_dtype.element_of();
+    if (!HandleTypeMatch(buffer_var.get(), elem_type)) {
+      stream << "((";
+      if (buffer_var.get()->dtype.is_handle()) {
+        auto it = alloc_storage_scope_.find(buffer_var.get());
+        if (it != alloc_storage_scope_.end()) {
+          PrintStorageScope(it->second, stream);
+        }
+      }
+      PrintType(elem_type, stream);
+      stream << "*)" << vid << ')';
+    } else {
+      stream << vid;
+    }
+    stream << '[';
+    PrintVecElemLoad(index, index_expr.dtype(), i, stream);
+    stream << "] = ";
+    PrintVecElemLoad(value, op->value.dtype(), i, stream);
+    stream << ";\n";
+  }
+  EndScope(vec_scope);
 }
 
 void CodeGenTileLangHIP::VisitExpr_(const RampNode *op, std::ostream &os) {
   int lanes = static_cast<int>(Downcast<IntImm>(op->lanes)->value);
   ICHECK_LE(lanes, 4)
       << "ValueError: Ramp of more than 4 lanes is not allowed.";
-  os << "(make_";
-  PrintType(op->dtype, os);
+  bool is_packed_int4x2 = (op->dtype.is_int() || op->dtype.is_uint()) &&
+                          op->dtype.bits() == 4 && op->dtype.lanes() == 2;
+  os << "(";
+  if (is_packed_int4x2) {
+    PrintVecConstructor(op->dtype, os);
+  } else {
+    os << "make_";
+    PrintType(op->dtype, os);
+  }
   os << "(";
   for (int i = 0; i < lanes; i++) {
     os << "(" << PrintExpr(op->base) << ")" << "+(" << PrintExpr(op->stride)
@@ -2228,6 +2476,13 @@ void CodeGenTileLangHIP::VisitExpr_(const RampNode *op, std::ostream &os) {
 void CodeGenTileLangHIP::VisitExpr_(const BroadcastNode *op,
                                     std::ostream &os) { // NOLINT(*)
   int lanes = static_cast<int>(Downcast<IntImm>(op->lanes)->value);
+  if ((op->dtype.is_int() || op->dtype.is_uint()) && op->dtype.bits() == 4 &&
+      lanes == 2) {
+    std::string value = PrintExpr(op->value);
+    PrintVecConstructor(op->dtype, os);
+    os << '(' << value << ", " << value << ')';
+    return;
+  }
   if ((op->dtype.is_int() || op->dtype.is_uint()) && op->dtype.bits() == 8 &&
       lanes == 4) {
     // make_int8x4
@@ -2449,6 +2704,15 @@ void CodeGenTileLangHIP::PrintVecElemLoadExpr(DataType t, int i,
                                               const std::string &value,
                                               std::ostream &os) {
   ICHECK_GT(t.lanes(), 1);
+  if ((t.is_int() || t.is_uint()) && t.bits() == 4 && t.lanes() == 2) {
+    if (i == 0) {
+      PrintVecConstructor(t, os);
+      os << '(';
+    }
+    os << value;
+    os << (i == t.lanes() - 1 ? ")" : ",");
+    return;
+  }
   if (t.bits() == 8 && (t.is_int() || t.is_uint())) {
     if (!(t.lanes() == 2 || t.lanes() == 3)) {
       if (i != 0) {

--- a/src/rocm/codegen/codegen_hip.h
+++ b/src/rocm/codegen/codegen_hip.h
@@ -33,9 +33,10 @@ public:
                          std::ostream &os) final; // NOLINT(*)
   void PrintVecBinaryOp(const std::string &op, DataType t, PrimExpr lhs,
                         PrimExpr rhs,
-                        std::ostream &os) final;                // NOLINT(*)
-  void PrintType(DataType t, std::ostream &os) final;           // NOLINT(*)
-  void PrintVecConstructor(DataType t, std::ostream &os) final; // NOLINT(*)
+                        std::ostream &os) final;      // NOLINT(*)
+  void PrintType(DataType t, std::ostream &os) final; // NOLINT(*)
+  void PrintVecConstructor(DataType data_type,
+                           std::ostream &os) final; // NOLINT(*)
   void PrintVecElemLoad(const std::string &vec, DataType t, int i,
                         std::ostream &os) final; // NOLINT(*)
   void PrintVecElemStore(const std::string &vec, DataType t, int i,
@@ -70,6 +71,9 @@ protected:
                        std::ostream &os) final; // NOLINT(*)
 
 private:
+  void PrintPackedInt4Load(const BufferNode *buffer, const std::string &index,
+                           std::ostream &os); // NOLINT(*)
+
   // Handle volatile loads
   void HandleVolatileLoads(const std::string &value, const BufferLoadNode *op,
                            std::ostream &os) final;

--- a/src/rocm/codegen/codegen_hip.h
+++ b/src/rocm/codegen/codegen_hip.h
@@ -33,8 +33,9 @@ public:
                          std::ostream &os) final; // NOLINT(*)
   void PrintVecBinaryOp(const std::string &op, DataType t, PrimExpr lhs,
                         PrimExpr rhs,
-                        std::ostream &os) final;      // NOLINT(*)
-  void PrintType(DataType t, std::ostream &os) final; // NOLINT(*)
+                        std::ostream &os) final;                // NOLINT(*)
+  void PrintType(DataType t, std::ostream &os) final;           // NOLINT(*)
+  void PrintVecConstructor(DataType t, std::ostream &os) final; // NOLINT(*)
   void PrintVecElemLoad(const std::string &vec, DataType t, int i,
                         std::ostream &os) final; // NOLINT(*)
   void PrintVecElemStore(const std::string &vec, DataType t, int i,
@@ -53,6 +54,7 @@ public:
   void VisitExpr_(const NotNode *op, std::ostream &os) final;
   void VisitExpr_(const SelectNode *op, std::ostream &os) final;
   void VisitExpr_(const ShuffleNode *op, std::ostream &os) final; // NOLINT(*)
+  void VisitExpr_(const BufferLoadNode *op, std::ostream &os) final;
   void VisitStmt_(const AllocBufferNode *op) final;
   void VisitStmt_(const AttrStmtNode *op) final;
   void VisitStmt_(const BufferStoreNode *op) final;

--- a/src/rocm/op/copy.cc
+++ b/src/rocm/op/copy.cc
@@ -128,10 +128,15 @@ private:
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
+    Optional<PrimExpr> predicate =
+        par_op->GetPredicate(lower_args.thread_index);
+    ValidatePacked4BitStoreOwnership(
+        par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
+        predicate, lower_args.buffer_remap, lower_args.layout_map);
     Stmt lowered_loop = LowerParallelLoop(
         par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
-        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
+        lower_args.layout_map, predicate, /*parallel_loop=*/true,
+        par_op->LoopLayoutRequiresPaddingGuard());
 
     auto inject_result =
         InjectROCmAsyncCopy(lowered_loop, /*async_without_async_commit_wait=*/

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -181,6 +181,50 @@ __device__ __forceinline__ float16_t __habs(float16_t a) {
   return result;
 }
 
+// TileLang lowers scalar int4/uint4 storage through byte-packed buffers, where
+// each byte carries two logical 4-bit elements.
+TL_DEVICE int8_t tl_pack_int4x2(int low, int high) {
+  unsigned int packed = (static_cast<unsigned int>(low) & 0xFu) |
+                        ((static_cast<unsigned int>(high) & 0xFu) << 4);
+  return static_cast<int8_t>(packed);
+}
+
+TL_DEVICE uint8_t tl_pack_uint4x2(unsigned int low, unsigned int high) {
+  return static_cast<uint8_t>((low & 0xFu) | ((high & 0xFu) << 4));
+}
+
+TL_DEVICE int tl_int4_packed_load(const signed char *packed, int idx) {
+  unsigned char byte = static_cast<unsigned char>(packed[idx >> 1]);
+  unsigned int shift = (idx & 1) * 4;
+  int value = static_cast<int>((byte >> shift) & 0xFu);
+  return (value ^ 8) - 8;
+}
+
+TL_DEVICE unsigned int tl_uint4_packed_load(const unsigned char *packed,
+                                            int idx) {
+  unsigned char byte = packed[idx >> 1];
+  unsigned int shift = (idx & 1) * 4;
+  return (byte >> shift) & 0xFu;
+}
+
+TL_DEVICE void tl_int4_packed_store(signed char *packed, int idx, int val) {
+  unsigned int shift = (idx & 1) * 4;
+  unsigned char mask = static_cast<unsigned char>(0xFu << shift);
+  unsigned char nibble = static_cast<unsigned char>(
+      (static_cast<unsigned int>(val) & 0xFu) << shift);
+  unsigned char byte = static_cast<unsigned char>(packed[idx >> 1]);
+  packed[idx >> 1] = static_cast<signed char>((byte & ~mask) | nibble);
+}
+
+TL_DEVICE void tl_uint4_packed_store(unsigned char *packed, int idx,
+                                     unsigned int val) {
+  unsigned int shift = (idx & 1) * 4;
+  unsigned char mask = static_cast<unsigned char>(0xFu << shift);
+  unsigned char nibble = static_cast<unsigned char>((val & 0xFu) << shift);
+  unsigned char byte = packed[idx >> 1];
+  packed[idx >> 1] = static_cast<unsigned char>((byte & ~mask) | nibble);
+}
+
 namespace tl {
 
 // Scalar max/min. The float/double overloads use the fmax/fmin builtins so

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -193,7 +193,7 @@ TL_DEVICE uint8_t tl_pack_uint4x2(unsigned int low, unsigned int high) {
   return static_cast<uint8_t>((low & 0xFu) | ((high & 0xFu) << 4));
 }
 
-TL_DEVICE int tl_int4_packed_load(const signed char *packed, int idx) {
+TL_DEVICE int tl_int4_packed_load(const signed char *packed, int64_t idx) {
   unsigned char byte = static_cast<unsigned char>(packed[idx >> 1]);
   unsigned int shift = (idx & 1) * 4;
   int value = static_cast<int>((byte >> shift) & 0xFu);
@@ -201,13 +201,13 @@ TL_DEVICE int tl_int4_packed_load(const signed char *packed, int idx) {
 }
 
 TL_DEVICE unsigned int tl_uint4_packed_load(const unsigned char *packed,
-                                            int idx) {
+                                            int64_t idx) {
   unsigned char byte = packed[idx >> 1];
   unsigned int shift = (idx & 1) * 4;
   return (byte >> shift) & 0xFu;
 }
 
-TL_DEVICE void tl_int4_packed_store(signed char *packed, int idx, int val) {
+TL_DEVICE void tl_int4_packed_store(signed char *packed, int64_t idx, int val) {
   unsigned int shift = (idx & 1) * 4;
   unsigned char mask = static_cast<unsigned char>(0xFu << shift);
   unsigned char nibble = static_cast<unsigned char>(
@@ -216,7 +216,7 @@ TL_DEVICE void tl_int4_packed_store(signed char *packed, int idx, int val) {
   packed[idx >> 1] = static_cast<signed char>((byte & ~mask) | nibble);
 }
 
-TL_DEVICE void tl_uint4_packed_store(unsigned char *packed, int idx,
+TL_DEVICE void tl_uint4_packed_store(unsigned char *packed, int64_t idx,
                                      unsigned int val) {
   unsigned int shift = (idx & 1) * 4;
   unsigned char mask = static_cast<unsigned char>(0xFu << shift);

--- a/src/transform/layout_inference/layout_inference.cc
+++ b/src/transform/layout_inference/layout_inference.cc
@@ -1340,8 +1340,7 @@ private:
                 const LayoutMap &base_layout_map,
                 const LayoutMap &strict_layout_map,
                 const std::vector<std::pair<Buffer, Fragment>> &seed_layouts,
-                const LayoutCostModel &cost_model,
-                std::optional<std::string> *last_layout_conflict) {
+                const LayoutCostModel &cost_model) {
     auto back_infer_list = BackupInferList();
     LayoutMap tmp_layout_map = base_layout_map;
     std::deque<int> q;
@@ -1369,9 +1368,6 @@ private:
     } catch (const LayoutConflictException &e) {
       ok = false;
       failure = e.what();
-      if (last_layout_conflict != nullptr) {
-        *last_layout_conflict = failure;
-      }
     } catch (const NormalizeIterException &e) {
       ok = false;
       failure = e.what();
@@ -1467,7 +1463,6 @@ private:
       AttemptCost best_cost;
       bool has_best = false;
       int best_infer_root = -1;
-      std::optional<std::string> last_layout_conflict;
 
       auto adopt = [&](AttemptOutcome &&outcome, int attempt_root) {
         best_infer_list = std::move(outcome.infer_list);
@@ -1481,9 +1476,9 @@ private:
       for (int attempt_infer_root : members) {
         DLOG(INFO) << "----------------------- try root " << attempt_infer_root
                    << " members " << members.size() << '\n';
-        auto outcome = RunOneAttempt(attempt_infer_root, members, layout_map,
-                                     strict_layout_map, /*seed_layouts=*/{},
-                                     *cost_model, &last_layout_conflict);
+        auto outcome =
+            RunOneAttempt(attempt_infer_root, members, layout_map,
+                          strict_layout_map, /*seed_layouts=*/{}, *cost_model);
         if (!outcome) {
           continue;
         }
@@ -1516,15 +1511,11 @@ private:
           DLOG(INFO) << "[InferInFreeMode] all attempts failed; retrying with "
                      << "wide fallback dst layouts";
           auto outcome = RunOneAttempt(members.front(), members, layout_map,
-                                       strict_layout_map, seeds, *cost_model,
-                                       &last_layout_conflict);
+                                       strict_layout_map, seeds, *cost_model);
           if (outcome) {
             adopt(std::move(*outcome), members.front());
           }
         }
-      }
-      if (!has_best && last_layout_conflict.has_value()) {
-        throw LayoutConflictException(*last_layout_conflict);
       }
       ICHECK(has_best) << "no available layout found" << '\n';
       // Apply the best plan for this component

--- a/src/transform/layout_inference/layout_inference.cc
+++ b/src/transform/layout_inference/layout_inference.cc
@@ -1340,10 +1340,12 @@ private:
                 const LayoutMap &base_layout_map,
                 const LayoutMap &strict_layout_map,
                 const std::vector<std::pair<Buffer, Fragment>> &seed_layouts,
-                const LayoutCostModel &cost_model, std::deque<int> &q,
-                std::vector<bool> &in_queue) {
+                const LayoutCostModel &cost_model,
+                std::optional<std::string> *last_layout_conflict) {
     auto back_infer_list = BackupInferList();
     LayoutMap tmp_layout_map = base_layout_map;
+    std::deque<int> q;
+    std::vector<bool> in_queue(infer_list_.size(), false);
     for (const auto &[buffer, fragment] : seed_layouts) {
       if (!tmp_layout_map.count(buffer)) {
         tmp_layout_map.Set(buffer, fragment);
@@ -1367,6 +1369,9 @@ private:
     } catch (const LayoutConflictException &e) {
       ok = false;
       failure = e.what();
+      if (last_layout_conflict != nullptr) {
+        *last_layout_conflict = failure;
+      }
     } catch (const NormalizeIterException &e) {
       ok = false;
       failure = e.what();
@@ -1451,9 +1456,6 @@ private:
 
     // For each component, try each op as root, and determine the least
     // replicated one
-    std::deque<int> q;
-    std::vector<bool> in_queue(infer_list_.size(), false);
-
     std::unique_ptr<LayoutCostModel> cost_model =
         LayoutCostModel::Create(tl_config::LayoutCostModelName(), target_);
     DLOG(INFO) << "[InferInFreeMode] cost model: " << cost_model->Name();
@@ -1465,6 +1467,7 @@ private:
       AttemptCost best_cost;
       bool has_best = false;
       int best_infer_root = -1;
+      std::optional<std::string> last_layout_conflict;
 
       auto adopt = [&](AttemptOutcome &&outcome, int attempt_root) {
         best_infer_list = std::move(outcome.infer_list);
@@ -1480,7 +1483,7 @@ private:
                    << " members " << members.size() << '\n';
         auto outcome = RunOneAttempt(attempt_infer_root, members, layout_map,
                                      strict_layout_map, /*seed_layouts=*/{},
-                                     *cost_model, q, in_queue);
+                                     *cost_model, &last_layout_conflict);
         if (!outcome) {
           continue;
         }
@@ -1512,13 +1515,16 @@ private:
         if (!seeds.empty()) {
           DLOG(INFO) << "[InferInFreeMode] all attempts failed; retrying with "
                      << "wide fallback dst layouts";
-          auto outcome =
-              RunOneAttempt(members.front(), members, layout_map,
-                            strict_layout_map, seeds, *cost_model, q, in_queue);
+          auto outcome = RunOneAttempt(members.front(), members, layout_map,
+                                       strict_layout_map, seeds, *cost_model,
+                                       &last_layout_conflict);
           if (outcome) {
             adopt(std::move(*outcome), members.front());
           }
         }
+      }
+      if (!has_best && last_layout_conflict.has_value()) {
+        throw LayoutConflictException(*last_layout_conflict);
       }
       ICHECK(has_best) << "no available layout found" << '\n';
       // Apply the best plan for this component

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1362,9 +1362,9 @@ private:
     bool parallel_loop = has_non_local_store || has_fragment_access;
 
     if (TargetIsRocm(target_)) {
-      // Validate only after visiting the loop body, when buffer layouts have
-      // been applied to `for_node`. Logical indices seen during layout
-      // inference do not necessarily identify neighboring physical nibbles.
+      // Direct BufferStores have their physical layouts applied while visiting
+      // the loop body. Tile operators validate their generated SIMT loops in
+      // their LowerTileOp-time lowering before thread partitioning.
       ValidatePacked4BitStoreOwnership(
           for_node, loop_layout, CurrentThreadIndex(), analyzer_, predicate);
     }

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1362,6 +1362,9 @@ private:
     bool parallel_loop = has_non_local_store || has_fragment_access;
 
     if (TargetIsRocm(target_)) {
+      // Validate only after visiting the loop body, when buffer layouts have
+      // been applied to `for_node`. Logical indices seen during layout
+      // inference do not necessarily identify neighboring physical nibbles.
       ValidatePacked4BitStoreOwnership(
           for_node, loop_layout, CurrentThreadIndex(), analyzer_, predicate);
     }

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -22,8 +22,10 @@
 #include "../op/gemm.h"
 #include "../op/gemm_sp.h"
 #include "../op/operator.h"
+#include "../op/parallel.h"
 #include "../op/utils.h"
 #include "../span_utils.h"
+#include "backend/common/target_utils.h"
 #include "cuda/op/builtin.h"
 #include "cuda/target_utils.h"
 #include "cuda/transform/ptx_async_copy_injector.h"
@@ -1358,6 +1360,11 @@ private:
     // fragment index is lowered to a physical per-thread slot, the logical loop
     // iteration has to be owned by the corresponding thread.
     bool parallel_loop = has_non_local_store || has_fragment_access;
+
+    if (TargetIsRocm(target_)) {
+      ValidatePacked4BitStoreOwnership(
+          for_node, loop_layout, CurrentThreadIndex(), analyzer_, predicate);
+    }
 
     Stmt lowered = LowerParallelLoop(
         for_node, loop_layout, CurrentThreadIndex(), analyzer_, layout_map_,

--- a/testing/python/amd/test_tilelang_hip_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_codegen.py
@@ -754,14 +754,14 @@ def test_pipelined_multi_stage_fp16_gemm(num_stages):
 
 # ---------------------------------------------------------------------------
 # Fix 7 — src/rocm/codegen/codegen_hip.cc
-#   Packed scalar int4/uint4 use one int32 storage word per eight elements.
+#   Packed scalar int4/uint4 use one byte per two logical elements.
 # ---------------------------------------------------------------------------
 
 
 @tilelang.testing.requires_rocm
 @pytest.mark.parametrize(
     "dtype,storage_type",
-    [(T.int4, "int"), (T.dtype("uint4"), "uint")],
+    [(T.int4, "signed char"), (T.dtype("uint4"), "uchar")],
 )
 def test_static_packed_int4_shared_allocation_rounds_up(dtype, storage_type):
     @T.prim_func
@@ -772,7 +772,7 @@ def test_static_packed_int4_shared_allocation_rounds_up(dtype, storage_type):
 
     artifact = tilelang.lower(kernel, target="hip")
 
-    assert f"{storage_type} A_shared[16];" in artifact.kernel_source
+    assert f"{storage_type} A_shared[64];" in artifact.kernel_source
 
 
 # ---------------------------------------------------------------------------

--- a/testing/python/amd/test_tilelang_hip_int4_ownership.py
+++ b/testing/python/amd/test_tilelang_hip_int4_ownership.py
@@ -45,6 +45,31 @@ def _odd_nibble_copy_kernel(dtype, n):
     return kernel
 
 
+def _local_to_packed_global_copy_kernel(dtype, values_per_thread=1):
+    n = 128 * values_per_thread
+
+    @T.prim_func
+    def kernel(output: T.Tensor((n,), dtype)):
+        with T.Kernel(1, threads=128):
+            tx = T.get_thread_binding()
+            local = T.alloc_local((values_per_thread,), dtype)
+            for i in T.serial(values_per_thread):
+                local[i] = 0
+            T.copy(local, output[tx * values_per_thread])
+
+    return kernel
+
+
+def _im2col_to_packed_shared_kernel(dtype):
+    @T.prim_func
+    def kernel(source: T.Tensor((1, 1, 1, 128), dtype)):
+        with T.Kernel(1, threads=128):
+            shared = T.alloc_shared((1, 128), dtype)
+            T.im2col(source, shared, 0, 0, 1, 1, 1, 0)
+
+    return kernel
+
+
 @tilelang.testing.requires_rocm
 @pytest.mark.parametrize("dtype", ["int4", "uint4"])
 @pytest.mark.parametrize("through_shared", [False, True])
@@ -75,6 +100,45 @@ def test_packed_int4_copy_rejects_split_byte_ownership(dtype):
         tilelang.compile(
             _copy_kernel(dtype, 128, threads=128),
             out_idx=[1],
+            target="hip",
+        )
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+def test_local_to_packed_global_copy_rejects_split_byte_ownership(dtype):
+    with pytest.raises(
+        Exception,
+        match="logical elements that share a writable byte",
+    ):
+        tilelang.compile(
+            _local_to_packed_global_copy_kernel(dtype),
+            target="hip",
+        )
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+def test_local_to_packed_global_copy_accepts_byte_ownership(dtype):
+    compiled = tilelang.compile(
+        _local_to_packed_global_copy_kernel(dtype, values_per_thread=2),
+        out_idx=[0],
+        target="hip",
+    )
+    result = compiled()
+
+    assert torch.all(result.view(torch.uint8) == 0)
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+def test_im2col_to_packed_shared_rejects_split_byte_ownership(dtype):
+    with pytest.raises(
+        Exception,
+        match="logical elements that share a writable byte",
+    ):
+        tilelang.compile(
+            _im2col_to_packed_shared_kernel(dtype),
             target="hip",
         )
 

--- a/testing/python/amd/test_tilelang_hip_int4_ownership.py
+++ b/testing/python/amd/test_tilelang_hip_int4_ownership.py
@@ -1,0 +1,103 @@
+import pytest
+import torch
+
+import tilelang
+import tilelang.testing
+from tilelang import language as T
+
+
+@pytest.fixture(autouse=True)
+def _disable_tilelang_cache():
+    tilelang.disable_cache()
+    try:
+        yield
+    finally:
+        tilelang.enable_cache()
+
+
+def _copy_kernel(dtype, n, threads, *, through_shared=False):
+    @T.prim_func
+    def kernel(
+        source: T.Tensor((n,), dtype),
+        output: T.Tensor((n,), dtype),
+    ):
+        with T.Kernel(1, threads=threads):
+            if through_shared:
+                shared = T.alloc_shared((n,), dtype)
+                T.copy(source, shared)
+                T.copy(shared, output)
+            else:
+                T.copy(source, output)
+
+    return kernel
+
+
+def _odd_nibble_copy_kernel(dtype, n):
+    @T.prim_func
+    def kernel(
+        source: T.Tensor((n,), dtype),
+        output: T.Tensor((n,), dtype),
+    ):
+        with T.Kernel(1, threads=n // 2):
+            for i in T.Parallel(n // 2):
+                output[2 * i + 1] = source[2 * i + 1]
+
+    return kernel
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+@pytest.mark.parametrize("through_shared", [False, True])
+def test_packed_int4_copy_uses_byte_owned_x2_stores(dtype, through_shared):
+    n = 256
+    compiled = tilelang.compile(
+        _copy_kernel(dtype, n, threads=128, through_shared=through_shared),
+        out_idx=[1],
+        target="hip",
+    )
+    source = torch.arange(n // 2, dtype=torch.uint8, device="cuda")
+    if dtype == "int4":
+        source = source.view(torch.int8)
+
+    result = compiled(source)
+
+    assert torch.equal(result.view(torch.uint8), source.view(torch.uint8))
+    assert f"tl_{dtype}_packed_store(" not in compiled.get_kernel_source()
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+def test_packed_int4_copy_rejects_split_byte_ownership(dtype):
+    with pytest.raises(
+        Exception,
+        match="logical elements that share a writable byte",
+    ):
+        tilelang.compile(
+            _copy_kernel(dtype, 128, threads=128),
+            out_idx=[1],
+            target="hip",
+        )
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+def test_packed_int4_single_nibble_per_byte_has_one_owner(dtype):
+    n = 128
+    compiled = tilelang.compile(
+        _odd_nibble_copy_kernel(dtype, n),
+        target="hip",
+    )
+    source = torch.arange(n // 2, dtype=torch.uint8, device="cuda")
+    output = torch.zeros_like(source)
+    if dtype == "int4":
+        source = source.view(torch.int8)
+        output = output.view(torch.int8)
+
+    compiled(source, output)
+
+    assert torch.equal(output.view(torch.uint8) & 0xF0, source.view(torch.uint8) & 0xF0)
+    assert torch.all((output.view(torch.uint8) & 0x0F) == 0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/amd/test_tilelang_hip_int4_packed.py
+++ b/testing/python/amd/test_tilelang_hip_int4_packed.py
@@ -93,6 +93,19 @@ def _packed_vector_store_source(dtype, base, stride, lanes=2):
     return _build_source(name, func)
 
 
+def _packed_ldg_source(dtype, index, index_dtype="int32"):
+    name = f"packed_{dtype}_ldg"
+    buffer = tirx.decl_buffer((index + 1,), dtype=dtype, name="input")
+    load = tirx.BufferLoad(buffer, [tirx.const(index, index_dtype)])
+    body = tirx.call_intrin(dtype, tirx.op.Op.get("tl.__ldg"), load)
+    func = tirx.PrimFunc(
+        [buffer.data],
+        tirx.Evaluate(body),
+        buffer_map={buffer.data: buffer},
+    )
+    return _build_source(name, func)
+
+
 def _packed_x2_broadcast_kernel(dtype, value):
     @T.prim_func
     def kernel(output: T.Tensor((2,), dtype)):
@@ -150,6 +163,19 @@ def _packed_scalar_load_kernel():
     return kernel
 
 
+def _packed_ldg_kernel(dtype):
+    @T.prim_func
+    def kernel(
+        source: T.Tensor((4,), dtype),
+        output: T.Tensor((4,), "int32"),
+    ):
+        with T.Kernel(1, threads=1):
+            for i in T.serial(4):
+                output[i] = T.cast(T.__ldg(source[i]), "int32")
+
+    return kernel
+
+
 @tilelang.testing.requires_rocm
 @pytest.mark.parametrize("dtype", ["int4", "uint4"])
 def test_packed_int4_scalar_load_codegen(dtype):
@@ -163,6 +189,45 @@ def test_packed_int4_scalar_load_codegen(dtype):
 
     assert _generated_call_count(source, f"tl_{dtype}_packed_load") == 1
     assert " + 3 / 8" not in source
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+def test_packed_int4_ldg_codegen_preserves_int64_index(dtype):
+    index = 2**31 + 1
+    source = _packed_ldg_source(dtype, index, "int64")
+    calls = _generated_call_lines(source, f"tl_{dtype}_packed_load")
+
+    assert len(calls) == 1
+    assert str(index) in calls[0]
+
+
+@tilelang.testing.requires_rocm
+def test_packed_int4_helper_index_types():
+    from tilelang.contrib import hipcc
+    from tilelang.env import TILELANG_TEMPLATE_PATH
+
+    source = r"""
+#include <stdint.h>
+#include <type_traits>
+#include <tl_templates/hip/common.h>
+
+static_assert(std::is_same_v<decltype(tl_int4_packed_load),
+                             int(const signed char *, int64_t)>);
+static_assert(std::is_same_v<decltype(tl_uint4_packed_load),
+                             unsigned int(const unsigned char *, int64_t)>);
+static_assert(std::is_same_v<decltype(tl_int4_packed_store),
+                             void(signed char *, int64_t, int)>);
+static_assert(std::is_same_v<decltype(tl_uint4_packed_store),
+                             void(unsigned char *, int64_t, unsigned int)>);
+
+extern "C" __global__ void main_kernel() {}
+"""
+    binary = hipcc.compile_hip(
+        source,
+        options=["-std=c++17", f"-I{TILELANG_TEMPLATE_PATH}"],
+    )
+    assert binary
 
 
 @tilelang.testing.requires_rocm
@@ -242,6 +307,29 @@ def test_packed_int4_scalar_load_sign_extension():
     expected = torch.tensor([-8, -1, 0, 7], dtype=torch.int32, device="cuda")
 
     assert torch.equal(result, expected)
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize(
+    ("dtype", "expected"),
+    [
+        ("int4", [-8, -1, 0, 7]),
+        ("uint4", [8, 15, 0, 7]),
+    ],
+)
+def test_packed_int4_ldg_runtime(dtype, expected):
+    compiled = tilelang.compile(
+        _packed_ldg_kernel(dtype),
+        out_idx=[1],
+        target="hip",
+    )
+    source = torch.tensor([0xF8, 0x70], dtype=torch.uint8, device="cuda")
+    if dtype == "int4":
+        source = source.view(torch.int8)
+
+    result = compiled(source)
+
+    assert torch.equal(result, torch.tensor(expected, dtype=torch.int32, device="cuda"))
 
 
 @tilelang.testing.requires_rocm

--- a/testing/python/amd/test_tilelang_hip_int4_packed.py
+++ b/testing/python/amd/test_tilelang_hip_int4_packed.py
@@ -1,0 +1,334 @@
+import pytest
+import torch
+
+import tilelang
+import tilelang.testing
+from tilelang import language as T, tvm
+from tvm import tirx
+
+
+@pytest.fixture(autouse=True)
+def _disable_tilelang_cache():
+    tilelang.disable_cache()
+    try:
+        yield
+    finally:
+        tilelang.enable_cache()
+
+
+def _build_source(name, func):
+    func = func.with_attr("global_symbol", name)
+    func = func.with_attr(
+        "calling_conv",
+        tvm.ir.CallingConv.DEVICE_KERNEL_LAUNCH,
+    )
+    mod = tvm.IRModule({name: func})
+    build = tvm.get_global_func("target.build.tilelang_hip_without_compile")
+    return build(mod, tvm.target.Target("rocm")).inspect_source()
+
+
+def _generated_call_lines(source, function):
+    return [line for line in source.splitlines() if f"{function}(" in line and not line.lstrip().startswith("TL_DEVICE")]
+
+
+def _generated_call_count(source, function):
+    return sum(line.count(f"{function}(") for line in _generated_call_lines(source, function))
+
+
+def _packed_x2_constructor_source(dtype, constructor):
+    name = f"packed_{dtype}_x2_{constructor}"
+    if constructor == "broadcast":
+        value = -3 if dtype == "int4" else 13
+        body = tirx.Broadcast(tirx.const(value, dtype), 2)
+        params = []
+    elif constructor == "scalar_load":
+        buffer = tirx.decl_buffer((4,), dtype=dtype, name="input")
+        index = tirx.Ramp(tirx.const(0, "int32"), tirx.const(2, "int32"), 2)
+        body = tirx.BufferLoad(buffer, [index])
+        params = [buffer.data]
+    elif constructor == "shuffle":
+        low = tirx.Var("low", dtype)
+        high = tirx.Var("high", dtype)
+        body = tirx.Shuffle([low, high], [0, 1])
+        params = [low, high]
+    elif constructor == "ramp":
+        body = tirx.Ramp(tirx.const(0, dtype), tirx.const(1, dtype), 2)
+        params = []
+    else:
+        raise ValueError(f"Unknown constructor: {constructor}")
+
+    return _build_source(name, tirx.PrimFunc(params, tirx.Evaluate(body)))
+
+
+def _packed_vector_load_source(dtype, base, stride, lanes=2):
+    name = f"packed_{dtype}_x{lanes}_load"
+    buffer = tirx.decl_buffer((64,), dtype=dtype, name="input")
+    index = tirx.Ramp(
+        tirx.const(base, "int32"),
+        tirx.const(stride, "int32"),
+        lanes,
+    )
+    func = tirx.PrimFunc(
+        [buffer.data],
+        tirx.Evaluate(tirx.BufferLoad(buffer, [index])),
+        buffer_map={buffer.data: buffer},
+    )
+    return _build_source(name, func)
+
+
+def _packed_vector_store_source(dtype, base, stride, lanes=2):
+    name = f"packed_{dtype}_x{lanes}_store"
+    buffer = tirx.decl_buffer((64,), dtype=dtype, name="output")
+    value = tirx.Var("value", f"{dtype}x{lanes}")
+    index = tirx.Ramp(
+        tirx.const(base, "int32"),
+        tirx.const(stride, "int32"),
+        lanes,
+    )
+    func = tirx.PrimFunc(
+        [buffer.data, value],
+        tirx.BufferStore(buffer, value, [index]),
+        buffer_map={buffer.data: buffer},
+    )
+    return _build_source(name, func)
+
+
+def _packed_x2_broadcast_kernel(dtype, value):
+    @T.prim_func
+    def kernel(output: T.Tensor((2,), dtype)):
+        with T.Kernel(1, threads=1):
+            for i in T.vectorized(2):
+                output[i] = T.cast(value, dtype)
+
+    return kernel
+
+
+def _packed_x2_ramp_kernel(dtype, offset):
+    @T.prim_func
+    def kernel(output: T.Tensor((2,), dtype)):
+        with T.Kernel(1, threads=1):
+            for i in T.vectorized(2):
+                output[i] = T.cast(i + offset, dtype)
+
+    return kernel
+
+
+def _packed_vector_gather_kernel(dtype, lanes, base, stride):
+    @T.prim_func
+    def kernel(
+        source: T.Tensor((64,), dtype),
+        output: T.Tensor((lanes,), dtype),
+    ):
+        with T.Kernel(1, threads=1):
+            output[T.Ramp(0, 1, lanes)] = source[T.Ramp(base, stride, lanes)]
+
+    return kernel
+
+
+def _packed_x2_store_kernel(dtype):
+    @T.prim_func
+    def kernel(
+        source: T.Tensor((2,), dtype),
+        output: T.Tensor((8,), dtype),
+    ):
+        with T.Kernel(1, threads=1):
+            output[T.Ramp(2, 1, 2)] = source[T.Ramp(0, 1, 2)]
+
+    return kernel
+
+
+def _packed_scalar_load_kernel():
+    @T.prim_func
+    def kernel(
+        source: T.Tensor((4,), "int4"),
+        output: T.Tensor((4,), "int32"),
+    ):
+        with T.Kernel(1, threads=1):
+            for i in T.serial(4):
+                output[i] = T.cast(source[i], "int32")
+
+    return kernel
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+def test_packed_int4_scalar_load_codegen(dtype):
+    buffer = tirx.decl_buffer((8,), dtype=dtype, name="input")
+    func = tirx.PrimFunc(
+        [buffer.data],
+        tirx.Evaluate(tirx.BufferLoad(buffer, [tirx.const(3, "int32")])),
+        buffer_map={buffer.data: buffer},
+    )
+    source = _build_source(f"packed_{dtype}_scalar_load", func)
+
+    assert _generated_call_count(source, f"tl_{dtype}_packed_load") == 1
+    assert " + 3 / 8" not in source
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("constructor", ["broadcast", "scalar_load", "shuffle", "ramp"])
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+def test_packed_int4x2_constructor_codegen(dtype, constructor):
+    source = _packed_x2_constructor_source(dtype, constructor)
+    helper = f"tl_pack_{dtype}x2"
+
+    assert len(_generated_call_lines(source, helper)) == 1
+    assert "make_int8_t(" not in source
+    assert "make_uint8_t(" not in source
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize(
+    ("dtype", "storage_type"),
+    [("int4", "int8_t"), ("uint4", "uint8_t")],
+)
+@pytest.mark.parametrize("lanes", [2, 4, 8, 16, 32])
+def test_packed_int4_aligned_load_keeps_direct_path(dtype, storage_type, lanes):
+    source = _packed_vector_load_source(dtype, base=lanes, stride=1, lanes=lanes)
+    carrier_type = {
+        2: storage_type,
+        4: "uint16_t" if dtype == "uint4" else "int16_t",
+        8: "uint" if dtype == "uint4" else "int",
+        16: "uint2" if dtype == "uint4" else "int2",
+        32: "uint4" if dtype == "uint4" else "int4",
+    }[lanes]
+
+    assert f"(({carrier_type}*)input)" in source
+    assert not _generated_call_lines(source, f"tl_{dtype}_packed_load")
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+@pytest.mark.parametrize("lanes", [2, 4, 8])
+def test_packed_int4_gather_uses_logical_indices(dtype, lanes):
+    source = _packed_vector_load_source(dtype, base=1, stride=2, lanes=lanes)
+
+    assert _generated_call_count(source, f"tl_{dtype}_packed_load") == lanes
+    if lanes == 2:
+        assert len(_generated_call_lines(source, f"tl_pack_{dtype}x2")) == 1
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+@pytest.mark.parametrize("lanes", [2, 4, 8, 16, 32])
+def test_packed_int4_unsafe_store_rejected(dtype, lanes):
+    with pytest.raises(
+        tvm.TVMError,
+        match="provably divisible by the vector lane count",
+    ):
+        _packed_vector_store_source(dtype, base=1, stride=1, lanes=lanes)
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+@pytest.mark.parametrize("lanes", [2, 4, 8, 16, 32])
+def test_packed_int4_aligned_store_keeps_direct_path(dtype, lanes):
+    source = _packed_vector_store_source(dtype, base=lanes, stride=1, lanes=lanes)
+
+    assert f"tl_{dtype}_packed_store(" not in source
+    assert "= value;" in source
+
+
+@tilelang.testing.requires_rocm
+def test_packed_int4_scalar_load_sign_extension():
+    compiled = tilelang.compile(
+        _packed_scalar_load_kernel(),
+        out_idx=[1],
+        target="hip",
+    )
+    source = torch.tensor([0xF8, 0x70], dtype=torch.uint8, device="cuda").view(torch.int8)
+
+    result = compiled(source)
+    expected = torch.tensor([-8, -1, 0, 7], dtype=torch.int32, device="cuda")
+
+    assert torch.equal(result, expected)
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize(("dtype", "value"), [("int4", -3), ("uint4", 13)])
+def test_packed_int4x2_broadcast_runtime(dtype, value):
+    compiled = tilelang.compile(
+        _packed_x2_broadcast_kernel(dtype, value),
+        target="hip",
+    )
+    storage_dtype = torch.uint8 if dtype == "uint4" else torch.int8
+    output = torch.empty((1,), dtype=storage_dtype, device="cuda")
+
+    compiled(output)
+
+    assert output.view(torch.uint8).item() == 0xDD
+    assert f"tl_pack_{dtype}x2(" in compiled.get_kernel_source()
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize(
+    ("dtype", "offset", "expected"),
+    [("int4", -3, 0xED), ("uint4", 2, 0x32)],
+)
+def test_packed_int4x2_distinct_lane_runtime(dtype, offset, expected):
+    compiled = tilelang.compile(
+        _packed_x2_ramp_kernel(dtype, offset),
+        target="hip",
+    )
+    storage_dtype = torch.uint8 if dtype == "uint4" else torch.int8
+    output = torch.empty((1,), dtype=storage_dtype, device="cuda")
+
+    compiled(output)
+
+    assert output.view(torch.uint8).item() == expected
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+@pytest.mark.parametrize("lanes", [2, 4, 8])
+def test_packed_int4_strided_gather_runtime(dtype, lanes):
+    base = 1
+    stride = 2
+    compiled = tilelang.compile(
+        _packed_vector_gather_kernel(dtype, lanes, base, stride),
+        out_idx=[1],
+        target="hip",
+    )
+    logical = [i % 16 for i in range(64)]
+    packed = [logical[i] | (logical[i + 1] << 4) for i in range(0, 64, 2)]
+    source = torch.tensor(packed, dtype=torch.uint8, device="cuda")
+    if dtype == "int4":
+        source = source.view(torch.int8)
+
+    result = compiled(source)
+    gathered = [logical[base + i * stride] for i in range(lanes)]
+    expected = torch.tensor(
+        [gathered[i] | (gathered[i + 1] << 4) for i in range(0, lanes, 2)],
+        dtype=torch.uint8,
+        device="cuda",
+    )
+
+    assert torch.equal(result.view(torch.uint8), expected)
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+def test_packed_int4x2_aligned_store_preserves_neighboring_bytes(dtype):
+    compiled = tilelang.compile(_packed_x2_store_kernel(dtype), target="hip")
+    source = torch.tensor([0x21], dtype=torch.uint8, device="cuda")
+    output = torch.tensor(
+        [0xBA, 0xDC, 0xFE, 0x98],
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    if dtype == "int4":
+        source = source.view(torch.int8)
+        output = output.view(torch.int8)
+
+    compiled(source, output)
+
+    expected = torch.tensor(
+        [0xBA, 0x21, 0xFE, 0x98],
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    assert torch.equal(output.view(torch.uint8), expected)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

- add HIP code generation for packed `int4x2` and `uint4x2` values, including constructors, scalar logical loads, strided gathers, aligned vector loads/stores, and runtime coverage
- enforce physical-byte ownership before lowering packed 4-bit stores on ROCm
- reject layouts where different threads could read-modify-write neighboring nibbles of the same byte
- keep the FP8 shuffle work out of this PR; that remains a separate change

The ownership enforcement is intentionally included with the codegen support. Without it, enabling scalar packed stores can silently introduce neighboring-nibble write races when two threads own different logical 4-bit elements in the same physical byte.

## Relationship to #3046

This PR overlaps with draft #3046, which also addresses packed sub-byte byte ownership. I am happy to follow either maintainer-preferred path:

1. Review this self-contained ROCm PR now, including its ownership enforcement.
2. Merge #3046 first, then I will rebase this PR and retain only the HIP enablement and relevant tests that remain necessary.

## Validation

- MI300X, full AMD test suite on the original two-commit branch before the upstream rebase: **207 passed, 24 skipped**
- rebased onto current `main` (`cff78136`)
- repository pre-commit hooks passed for every changed file after the rebase
- `git diff --check` passed
- clean merge-tree check against current `main`

The rebase kept the codegen commit patch-equivalent. The only manual integration was adapting the ownership error propagation to the newer layout-inference attempt helper: each attempt retains fresh queue state, and the specific ownership `LayoutConflictException` is surfaced if every candidate layout fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added ROCm/HIP code generation for packed `int4x2` and `uint4x2` values.
- Added packed constructors, scalar loads, strided gathers, and aligned vector loads and stores.
- Added HIP helpers for packing, unpacking, and nibble-preserving stores.
- Added physical-byte ownership validation for packed 4-bit stores.
- Rejects layouts where multiple threads can update neighboring nibbles in the same byte.
- Added code generation, runtime, and ownership tests for `int4` and `uint4`.
- Updated shared allocation expectations for byte-packed storage.
- Improved layout conflict handling during inference.
- AMD gfx942 validation passed: 2,262 tests passed and 1,508 tests were skipped.
- Covered signed and unsigned `T.__ldg` loads, large indices, helper signatures, safe ownership cases, and unsafe split-byte cases.

## C++ style / lint notes

- The PR changes C++ implementation and public C++ declarations.
- It does not change `docs/developer_guide/cpp_style.md`.
- The **C++ API Style Audit (warning only)** CI step remains advisory.
- No blocking correctness or build issue is identified.
- No new blocking style issue is identified. Advisory TLCPP003/TLCPP004 findings should not block merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->