### PR TITLE
[ROCm] Preserve FP8 bits in warp shuffles

### DIFF
--- a/src/tl_templates/hip/hip_fp8.h
+++ b/src/tl_templates/hip/hip_fp8.h
@@ -99,6 +99,44 @@ struct fp8_e5_t {
   }
 };
 
+// HIP's shuffle builtins do not provide exact overloads for TileLang's FP8
+// wrappers. Carry the raw byte through the native unsigned-int overload so the
+// exact FP8 bit pattern is preserved without widening through float.
+#define TL_DEFINE_FP8_SHFL_OVERLOADS(TYPE)                                     \
+  __device__ __forceinline__ TYPE __shfl(TYPE value, int src_lane,             \
+                                         int width = warpSize) {               \
+    TYPE result;                                                               \
+    result.data = static_cast<unsigned char>(                                  \
+        __shfl(static_cast<unsigned int>(value.data), src_lane, width));       \
+    return result;                                                             \
+  }                                                                            \
+  __device__ __forceinline__ TYPE __shfl_xor(TYPE value, int lane_mask,        \
+                                             int width = warpSize) {           \
+    TYPE result;                                                               \
+    result.data = static_cast<unsigned char>(                                  \
+        __shfl_xor(static_cast<unsigned int>(value.data), lane_mask, width));  \
+    return result;                                                             \
+  }                                                                            \
+  __device__ __forceinline__ TYPE __shfl_down(TYPE value, unsigned int delta,  \
+                                              int width = warpSize) {          \
+    TYPE result;                                                               \
+    result.data = static_cast<unsigned char>(                                  \
+        __shfl_down(static_cast<unsigned int>(value.data), delta, width));     \
+    return result;                                                             \
+  }                                                                            \
+  __device__ __forceinline__ TYPE __shfl_up(TYPE value, unsigned int delta,    \
+                                            int width = warpSize) {            \
+    TYPE result;                                                               \
+    result.data = static_cast<unsigned char>(                                  \
+        __shfl_up(static_cast<unsigned int>(value.data), delta, width));       \
+    return result;                                                             \
+  }
+
+TL_DEFINE_FP8_SHFL_OVERLOADS(fp8_e4_t)
+TL_DEFINE_FP8_SHFL_OVERLOADS(fp8_e5_t)
+
+#undef TL_DEFINE_FP8_SHFL_OVERLOADS
+
 template <typename ScalarType, typename PackedType>
 __device__ __forceinline__ ScalarType
 tl_fp8x2_get_lane(const PackedType &packed, int lane) {

--- a/testing/python/language/test_tilelang_language_warp_sync.py
+++ b/testing/python/language/test_tilelang_language_warp_sync.py
@@ -87,6 +87,45 @@ _MANTISSAS = (1.0, 1.25, 1.5, 1.75)
 _GRID = [sign * mant * 2.0**exp for exp in range(4) for mant in _MANTISSAS for sign in (1, -1)]
 LANE_VALUES = [-0.0, *_GRID[1:]]
 
+# Include zero, sign-bit, infinity, NaN, and ordinary encodings. HIP's implicit
+# FP8 -> float -> FP8 fallback happens to round-trip these bytes on gfx942, so
+# the compile-time return-type test below separately verifies exact overload
+# selection.
+ROCM_FP8_BYTE_VALUES = (
+    0x00,
+    0x80,
+    0x7F,
+    0xFF,
+    0x7C,
+    0xFC,
+    0x7D,
+    0x7E,
+    0xFD,
+    0xFE,
+    0x01,
+    0x81,
+    0x04,
+    0x84,
+    0x08,
+    0x88,
+    0x10,
+    0x90,
+    0x20,
+    0xA0,
+    0x30,
+    0xB0,
+    0x40,
+    0xC0,
+    0x50,
+    0xD0,
+    0x60,
+    0xE0,
+    0x70,
+    0xF0,
+    0x55,
+    0xAA,
+)
+
 
 def shfl_all_ops_kernel(dtype):
     @T.prim_func
@@ -141,6 +180,74 @@ def test_shfl_narrow_float_dtypes(dtype):
             assert torch.equal(got_bytes, ref_bytes), (
                 f"{builtin} ({form} form) shuffled the wrong lane: got {got_bytes.tolist()}, expected {ref_bytes.tolist()}"
             )
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("dtype", [T.float8_e4m3, T.float8_e5m2])
+def test_shfl_fp8_rocm(dtype):
+    kernel = tilelang.compile(shfl_all_ops_kernel(dtype))
+    source = kernel.get_kernel_source()
+
+    torch_dtype = dtype.as_torch()
+    input_bytes = torch.tensor(ROCM_FP8_BYTE_VALUES, device="cuda", dtype=torch.uint8)
+    values = input_bytes.view(torch_dtype)
+    rows = len(SHFL_TEMP_OPS) + len(SHFL_INLINE_OPS)
+    b = torch.empty(rows, 32, device="cuda", dtype=torch_dtype)
+    kernel(values, b)
+
+    # HIP ignores the CUDA-style mask and lowers to the corresponding native
+    # builtin. The explicit width=32 preserves logical-warp behavior on wave64.
+    body = source[source.rindex("__global__") :]
+    for cuda_builtin, _ in SHFL_TEMP_OPS:
+        hip_builtin = cuda_builtin.removesuffix("_sync")
+        assert body.count(f"{hip_builtin}(") == 2
+
+    for base, ops, form in (
+        (0, SHFL_TEMP_OPS, "temporary"),
+        (len(SHFL_TEMP_OPS), SHFL_INLINE_OPS, "inline"),
+    ):
+        for offset, (cuda_builtin, src_lane) in enumerate(ops):
+            got_bytes = b[base + offset].view(torch.uint8)
+            ref_bytes = input_bytes[[src_lane(lane) for lane in range(32)]]
+            hip_builtin = cuda_builtin.removesuffix("_sync")
+            assert torch.equal(got_bytes, ref_bytes), (
+                f"{hip_builtin} ({form} form) shuffled the wrong lane: got {got_bytes.tolist()}, expected {ref_bytes.tolist()}"
+            )
+
+
+@tilelang.testing.requires_rocm
+def test_shfl_fp8_rocm_builtin_return_types():
+    from tilelang.contrib import hipcc
+    from tilelang.env import TILELANG_TEMPLATE_PATH
+
+    source = r"""
+#include <hip/hip_runtime.h>
+#include <type_traits>
+#include <utility>
+#include <tl_templates/hip/hip_fp8.h>
+
+#define TL_ASSERT_FP8_SHFL_RETURN_TYPES(TYPE)                                 \
+  static_assert(std::is_same_v<                                               \
+                decltype(__shfl(std::declval<TYPE>(), 0, 32)), TYPE>);         \
+  static_assert(std::is_same_v<                                               \
+                decltype(__shfl_xor(std::declval<TYPE>(), 1, 32)), TYPE>);     \
+  static_assert(std::is_same_v<                                               \
+                decltype(__shfl_down(std::declval<TYPE>(), 1, 32)), TYPE>);    \
+  static_assert(std::is_same_v<                                               \
+                decltype(__shfl_up(std::declval<TYPE>(), 1, 32)), TYPE>)
+
+TL_ASSERT_FP8_SHFL_RETURN_TYPES(fp8_e4_t);
+TL_ASSERT_FP8_SHFL_RETURN_TYPES(fp8_e5_t);
+
+#undef TL_ASSERT_FP8_SHFL_RETURN_TYPES
+
+extern "C" __global__ void main_kernel() {}
+"""
+    binary = hipcc.compile_hip(
+        source,
+        options=["-std=c++17", f"-I{TILELANG_TEMPLATE_PATH}"],
+    )
+    assert binary
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add exact HIP shuffle overloads for TileLang's `fp8_e4_t` and `fp8_e5_t` wrappers
- carry the raw FP8 byte through HIP's native unsigned-integer shuffle overloads instead of widening through `float`
- cover `__shfl`, `__shfl_xor`, `__shfl_down`, and `__shfl_up`
- add ROCm runtime checks over zero, sign-bit, infinity, NaN, subnormal, and ordinary FP8 encodings
- add compile-time checks that every overload returns the original FP8 wrapper type

## Why

HIP does not provide exact shuffle overloads for TileLang's FP8 wrapper types. Without these overloads, C++ overload resolution can use the wrappers' floating-point conversions, so a shuffle may widen through `float` and return the wrong type instead of transporting the original encoded byte.

The new overloads shuffle `value.data` as `unsigned int`, truncate the result back to one byte, and reconstruct the same wrapper type. This preserves the FP8 representation without changing FP8 arithmetic or conversion behavior.

## Scope

This is intentionally separate from the packed INT4/UINT4 work in #3103. It changes only the HIP FP8 template and the existing warp-shuffle test file; the CUDA path is unchanged.

PR #2847 also touches `src/tl_templates/hip/hip_fp8.h`, but in the target-specific FP8 type-selection section. This PR adds shuffle overloads in a separate section and is currently cleanly mergeable with `main`. If #2847 lands first, I will rebase as needed.

## Validation

- rebased onto current `main` (`cff78136`); the rebased commit is patch-equivalent to the original
- repository pre-commit hooks passed for both changed files
- `git diff --check` passed
- clean merge-tree check against current `main`
- ROCm runtime and HIP compilation tests are included and will run on the upstream gfx942 CI leg

The local development machine is macOS and has no ROCm runtime, so post-rebase hardware execution is delegated to the upstream ROCm CI job rather than claimed from the local checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added exact HIP warp-shuffle overloads for `fp8_e4_t` and `fp8_e5_t`.
- Preserved raw FP8 bytes through native unsigned-integer shuffle operations.
- Added ROCm runtime tests for representative FP8 encodings.
- Added compile-time checks for FP8 shuffle return types.
- CUDA behavior and FP8 arithmetic remain unchanged.

## Validation

- Pre-commit hooks passed.
- `git diff --check` passed.
- Merge-tree validation passed.
- ROCm runtime and HIP compilation tests were added for gfx942 CI.

## C++ style / lint notes

- The PR changes C++ code but does not modify rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step may report advisory findings.
- No correctness or build issues are introduced by these warning-only checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->