### PR TITLE
[Compiler][Z3] Bump 3rdparty/tvm to materialize Z3 solvers lazily

### DIFF
--- a/testing/python/arith/test_arith_hard.py
+++ b/testing/python/arith/test_arith_hard.py
@@ -1,6 +1,6 @@
 import tilelang.testing
 import tilelang.language as T
-from tvm.arith import Analyzer, Z3ContextScope
+from tvm.arith import Analyzer
 from tvm.ir.expr import Range
 from tvm.tirx.expr import Not, Or
 from tvm import tirx
@@ -10,17 +10,15 @@ def implies(x, y):
     return Or(Not(x), y)
 
 
-def test_z3_context_scope_clone_outlives_scope():
+def test_cloned_analyzer_outlives_source():
     x = T.Var("x", T.int32)
 
-    with Z3ContextScope():
-        analyzer = Analyzer()
-        analyzer.bind(x, Range.from_min_extent(0, 16))
+    analyzer = Analyzer()
+    analyzer.bind(x, Range.from_min_extent(0, 16))
 
-    # Clone while a different compile scope is active. CopyFrom must retain
-    # the source Analyzer's context rather than mixing Z3 handles.
-    with Z3ContextScope():
-        cloned = analyzer.clone()
+    # CopyFrom must keep the clone's Z3 handles valid on their own context
+    # even after the source Analyzer is destroyed.
+    cloned = analyzer.clone()
 
     del analyzer
     assert cloned.can_prove(x >= 0)

--- a/tilelang/autotuner/grouped_compile.py
+++ b/tilelang/autotuner/grouped_compile.py
@@ -36,8 +36,8 @@ def compile_grouped_unit_tvm_ffi(
 
     Flow:
     1. Elaborate each config into a PrimFunc.
-    2. Lower each PrimFunc and build its host module in a fresh Z3 context.
-    3. Merge all device IR and compile it once in a separate fresh Z3 context.
+    2. Lower each PrimFunc and build its host module.
+    3. Merge all device IR and compile it once.
     4. Import the shared device module into each host runtime module.
     5. Construct per-config JITKernel objects that share the grouped device module.
     """
@@ -71,26 +71,25 @@ def compile_grouped_unit_tvm_ffi(
                     *create_pass_instruments(context=lower_context),
                     *base_pass_instruments,
                 ]
-                with tvm.arith.Z3ContextScope():
-                    with (
-                        tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=config_instruments),
-                        compile_args.target,
-                    ):
-                        host_mod, device_mod, params, normalized_target, normalized_target_host = lower_to_host_device_ir(
-                            program,
-                            backend_context,
-                        )
+                with (
+                    tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=config_instruments),
+                    compile_args.target,
+                ):
+                    host_mod, device_mod, params, normalized_target, normalized_target_host = lower_to_host_device_ir(
+                        program,
+                        backend_context,
+                    )
 
-                    host_context = f"stage=grouped-host, config={idx}, kernel={unique_symbol}"
-                    host_instruments = [
-                        *create_pass_instruments(context=host_context),
-                        *base_pass_instruments,
-                    ]
-                    with (
-                        tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=host_instruments),
-                        normalized_target,
-                    ):
-                        host_rt_mod = host_codegen(host_mod, backend_context)
+                host_context = f"stage=grouped-host, config={idx}, kernel={unique_symbol}"
+                host_instruments = [
+                    *create_pass_instruments(context=host_context),
+                    *base_pass_instruments,
+                ]
+                with (
+                    tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=host_instruments),
+                    normalized_target,
+                ):
+                    host_rt_mod = host_codegen(host_mod, backend_context)
 
                 lowered_items.append(
                     {
@@ -136,7 +135,6 @@ def compile_grouped_unit_tvm_ffi(
                 *base_pass_instruments,
             ]
             with (
-                tvm.arith.Z3ContextScope(),
                 tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=device_instruments),
                 reference_target,
             ):

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -161,7 +161,7 @@ def lower_with_context(
     has_session = current_compile_pass_instrumentation() is not None
     with compile_pass_instrumentation(name="lower-with-context"):
         attach_instruments = nullcontext() if has_session else instrument_current_pass_context()
-        with attach_instruments, tvm.arith.Z3ContextScope():
+        with attach_instruments:
             return _lower_with_context_impl(
                 func_or_mod,
                 context,


### PR DESCRIPTION
## Motivation

`arith::Analyzer` carries a `Z3Prover` whose implementation eagerly creates a `z3::solver` at construction and translates every `Bind`/`EnterConstraint` into z3 constraints up front. Analyzers are scratch objects created in huge numbers during lowering — `InverseWithLevel`, `OutputShape`, per-op inference analyzers, etc. — so a single reducer-heavy kernel compile creates **~67k Z3 solvers** and issues **~100k z3 asserts**, while instrumentation shows only **~0.3% of analyzers ever reach the Z3 fallback** of `CanProve`. Profiling attributes 40%+ of such compiles to Z3 solver init and bind translation.

This became prominent after #3093: PartialFragment layouts disabled the fully-replicated shortcut in `ProveFragmentContains`, roughly doubling the number of analyzer-heavy containment proofs during layout inference, which regressed reducer-heavy kernel compiles by up to ~2x.

## What this bumps

tile-ai/tvm#68 — Z3 solvers are now materialized lazily: binds and constraints are journaled (reusing the existing `scope_stack_` bookkeeping), and the first operation that actually needs the solver creates it and replays the journal in order. Semantics are preserved exactly; see the tvm PR for the full design and edge cases (assume-mode side effects, `CopyFrom`, replay ordering).

## Results

On a suite of 17 downstream reducer-heavy production kernels (H100, cold compiles, kernel cache disabled), the worst #3093 regressors improve 40-60% end-to-end and land **below their pre-#3093 compile times**:

| kernel (end-to-end, incl. ~6.6s fixed test overhead) | pre-#3093 | #3093 | this PR |
|---|---|---|---|
| reducer kernel #1 | 15.3s | 23.7s | **12.9s** |
| reducer kernel #2 | 15.2s | 18.8s | **11.2s** |
| reducer kernel #3 | 11.1s | 14.3s | **10.5s** |

`tilelang.lower` roughly halves across the board, including non-reducer kernels (toy GEMM 0.23s → 0.13s, elementwise 0.18s → 0.06s).

## Validation

- Language suite: 1168 passed, 137 skipped; reducer_v2 suite: 75 passed; arith suite: 89 passed.
- All 17 downstream reducer kernels compile and pass numerics, including three whose layout inference genuinely depends on Z3 proofs.
- Generated CUDA byte-identical to the eager build under disabled ASLR (the only ASLR-dependent deltas are AllReduce workspace slot permutations from a pre-existing pointer-order nondeterminism in shared-memory planning — independent issue).

## Merge order

Depends on tile-ai/tvm#68. The submodule currently points at the PR branch commit (`ea9f9b426`) so CI can validate; once the tvm PR is squash-merged, the pointer here will be updated to the merged SHA before this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated `3rdparty/tvm` to commit `3b59464d`.
- Materialized Z3 solvers lazily.
- Journaled bindings and constraints, then replayed them when Z3 was first required.
- Used a private Z3 context for each materialized solver.
- Reduced eager solver initialization and constraint translation.
- Improved analyzer-heavy compilation by 40–60% in affected reducer kernels.
- Approximately halved `tilelang.lower` time across tested kernels.
- Preserved existing semantics and generated CUDA output.
- Removed TileLang-side `Z3ContextScope` wrappers.
- Updated the analyzer lifetime test to verify cloned handles after source destruction.
- Includes the complete fixes from `tile-ai/tvm#68` and follow-up `#69`.

## Validation

- Passed the language, `reducer_v2`, arithmetic, and layout suites.
- Compiled all 17 downstream reducer kernels.
- Passed numerical checks.
- Produced byte-identical CUDA with ASLR disabled.
- Passed Z3 context-isolation tests with private solver contexts.

## C++ style / lint notes

- The PR does not modify C++ source, `docs/developer_guide/cpp_style.md`, or CI lint rules.
- The “C++ API Style Audit (warning only)” CI step is not affected.
- No new C++ style warnings were identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->