### PR TITLE
[CUDA] Unify TMA copy lowering on CuTe algebra

### DIFF
--- a/src/cuda/op/atomic_add.cc
+++ b/src/cuda/op/atomic_add.cc
@@ -71,7 +71,6 @@ bool IsValidTMAReduceAddDtype(DataType dtype) {
 
 struct TMAAtomicAddPlan {
   int tensor_map_dtype;
-  SwizzleMode swizzle_mode;
 };
 
 struct TMAAtomicAddAnalysis {
@@ -119,10 +118,7 @@ TMAAtomicAddAnalysis AnalyzeTMAAtomicAdd(const AtomicAddNode &op, Target target,
     return UnsupportedTMAAtomicAdd(reason.str());
   }
 
-  TMAAtomicAddPlan plan{
-      to_CUtensorMapDataType(dtype),
-      layout_analysis.encoding.value().swizzle_mode,
-  };
+  TMAAtomicAddPlan plan{to_CUtensorMapDataType(dtype)};
   return {std::move(plan), ""};
 }
 
@@ -385,130 +381,54 @@ struct AtomicAdd {
     Array<Range> shared_range = op.src_range;
     Array<Range> global_range = op.dst_range;
 
-    TMADesc desc;
-    desc.rank = global_tensor->shape.size();
-    ICHECK(desc.rank >= 1 && desc.rank <= 5)
-        << "TMA reduce only supports 1-5 dimensions, got " << desc.rank;
-
+    // The reduce dtype whitelist is stricter than plain TMA copies.
     Layout shared_layout = MakeLinearLayout(shared_tensor->shape);
     if (lower_args.layout_map.count(shared_tensor)) {
       shared_layout = lower_args.layout_map.at(shared_tensor);
-      ICHECK(lower_args.buffer_remap.count(shared_tensor))
-          << "shared_tensor: " << shared_tensor->name
-          << " not found in buffer_remap";
-      shared_tensor = lower_args.buffer_remap.at(shared_tensor);
     }
-
     TMAAtomicAddAnalysis analysis =
         AnalyzeTMAAtomicAdd(op, lower_args.target, shared_layout);
     ICHECK(analysis.plan.has_value())
         << analysis.reason << SpanHintSuffix({op.dst->span, op.src->span});
-    const TMAAtomicAddPlan &plan = analysis.plan.value();
 
-    desc.data_type = plan.tensor_map_dtype;
-    desc.global_addr = global_tensor->data;
-    desc.global_shape = ReverseArray(global_tensor->shape);
-    Array<PrimExpr> global_coords =
-        ReverseArray(global_range.Map([](Range r) { return r->min; }));
+    TMABulkCopyAnalysis bulk_analysis = AnalyzeTMABulkCopy(
+        lower_args, global_tensor, shared_tensor, global_range, shared_range);
+    ICHECK(bulk_analysis.plan.has_value())
+        << "TMA atomic add cannot lower the copy: " << bulk_analysis.reason
+        << SpanHintSuffix({op.dst->span, op.src->span});
+    const TMABulkCopyPlan &plan = bulk_analysis.plan.value();
 
-    if (!global_tensor->strides.empty()) {
-      desc.global_stride = ReverseArray(global_tensor->strides);
-    } else {
-      PrimExpr stride = 1;
-      desc.global_stride.reserve(desc.rank);
-      for (size_t i = 0; i < desc.rank; i++) {
-        desc.global_stride.push_back(stride);
-        stride *= desc.global_shape[i];
-      }
-    }
-    desc.global_stride = desc.global_stride.Map([&](PrimExpr e) {
-      return cast(DataType::Int(64), e) * global_tensor->dtype.bytes();
-    });
-
-    desc.smem_box =
-        ReverseArray(global_range.Map([](Range r) { return r->extent; }));
-    desc.smem_stride = Array<PrimExpr>(desc.rank, PrimExpr(1));
+    TMADesc desc = plan.desc;
+    desc.data_type = analysis.plan.value().tensor_map_dtype;
     desc.l2_promotion = static_cast<int>(CU_TENSOR_MAP_L2_PROMOTION_L2_128B);
     desc.oob_fill = static_cast<int>(CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
     desc.interleave = static_cast<int>(CU_TENSOR_MAP_INTERLEAVE_NONE);
-    desc.swizzle = plan.swizzle_mode.CanonicalOrdinal();
-    RequireTMASmemAlignment(lower_args, shared_tensor, plan.swizzle_mode);
-
-    auto inner_box_dim = as_const_int(desc.smem_box[0]);
-    ICHECK(inner_box_dim != nullptr)
-        << "inner_box_dim must be a constant integer for TMA atomic add";
-    int instruction_dim = *inner_box_dim;
-    if (!plan.swizzle_mode.IsNone()) {
-      instruction_dim =
-          plan.swizzle_mode.ByteWidth() / shared_tensor->dtype.bytes();
-    }
-    if (instruction_dim > 256) {
-      ICHECK((*inner_box_dim) % 256 == 0)
-          << "inner_box_dim: " << *inner_box_dim << " is not divisible by 256";
-      instruction_dim = 256;
-    }
-    ICHECK((*inner_box_dim) % instruction_dim == 0)
-        << "inner_box_dim: " << *inner_box_dim
-        << " is not divisible by instruction_dim: " << instruction_dim;
-    desc.smem_box.Set(0, PrimExpr(instruction_dim));
-
-    // Physical offset of the region base under the shared layout.
-    Array<PrimExpr> shared_indices = shared_layout->Forward(
-        shared_range.Map([](const Range &r) { return r->min; }));
-    Array<PrimExpr> physical_shape = shared_layout->OutputShape();
-    PrimExpr shared_offset = 0;
-    for (size_t i = 0; i < shared_indices.size(); i++) {
-      shared_offset = shared_offset * physical_shape[i] + shared_indices[i];
-    }
+    shared_tensor = plan.shared_tensor;
 
     Call create_descriptor = Call(DataType::Handle(), create_tma_descriptor(),
                                   desc.EncodeCallArgs());
 
-    PrimExpr total_elements = 1;
-    for (auto e : desc.smem_box) {
-      total_elements *= e;
-    }
+    PrimExpr total_elements = IntImm(DataType::Int(32), plan.box_size);
 
     auto op_annotations = op.annotations;
     op_annotations.erase("use_tma");
 
-    Stmt tma_reduce;
-    if ((*inner_box_dim) != instruction_dim) {
-      Var loop_var("i");
-      int loop_extent = (*inner_box_dim) / instruction_dim;
+    auto make_copy = [&](std::optional<PrimExpr> rest_idx) {
+      Array<PrimExpr> args;
+      args.reserve(desc.rank + 4);
+      args.push_back(create_descriptor);
+      args.push_back(shared_tensor.access_ptr(1, DataType::Handle(), 1,
+                                              plan.SharedOffset(rest_idx),
+                                              total_elements));
+      for (auto coord : plan.TmaCoords(rest_idx))
+        args.push_back(coord);
+      args.push_back(1); // reduce (add)
+      args.push_back(0); // eviction policy
+      return Evaluate(
+          Call(DataType::Handle(), tma_store(), args, op_annotations));
+    };
 
-      Array<PrimExpr> args;
-      args.reserve(desc.rank + 4);
-      args.push_back(create_descriptor);
-      PrimExpr shared_addr = shared_tensor.access_ptr(
-          1, DataType::Handle(), 1, shared_offset + total_elements * loop_var,
-          total_elements);
-      args.push_back(shared_addr);
-      Array<PrimExpr> loop_global_coords = global_coords;
-      loop_global_coords.Set(0, global_coords[0] + instruction_dim * loop_var);
-      for (auto coord : loop_global_coords) {
-        args.push_back(coord);
-      }
-      args.push_back(1);
-      args.push_back(0);
-      tma_reduce = For(loop_var, 0, loop_extent, ForKind::kUnrolled,
-                       Evaluate(Call(DataType::Handle(), tma_store(), args,
-                                     op_annotations)));
-    } else {
-      Array<PrimExpr> args;
-      args.reserve(desc.rank + 4);
-      args.push_back(create_descriptor);
-      PrimExpr shared_addr = shared_tensor.access_ptr(
-          1, DataType::Handle(), 1, shared_offset, total_elements);
-      args.push_back(shared_addr);
-      for (auto coord : global_coords) {
-        args.push_back(coord);
-      }
-      args.push_back(1);
-      args.push_back(0);
-      tma_reduce =
-          Evaluate(Call(DataType::Handle(), tma_store(), args, op_annotations));
-    }
+    Stmt tma_reduce = plan.EmitInstructions(make_copy);
 
     Array<Stmt> seq;
     seq.reserve(3);

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -1735,38 +1735,54 @@ BulkCopyTile ComputeBulkCopyTile(const Array<PrimExpr> &shared_shape,
 
 } // namespace
 
-Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
-                     arith::Analyzer *analyzer, CopyInst copy_inst) {
-  const Buffer &src = op.src;
-  const Buffer &dst = op.dst;
-  const Array<Range> &src_range = op.src_range;
-  const Array<Range> &dst_range = op.dst_range;
-  const Map<String, ObjectRef> &annotations = op.annotations;
+PrimExpr TMABulkCopyPlan::SharedOffset(std::optional<PrimExpr> rest_idx) const {
+  cute::IntTuple off = shared_offset;
+  if (rest_idx.has_value())
+    off += rest_to_smem(*rest_idx);
+  return cute::AsConstOrPrimExpr(off, DataType::Int(32));
+}
 
-  ICHECK(copy_inst == CopyInst::kBulkLoad || copy_inst == CopyInst::kBulkStore)
-      << "Invalid copy inst " << static_cast<int>(copy_inst);
-  bool is_load = copy_inst == CopyInst::kBulkLoad;
-  Buffer global_tensor = is_load ? src : dst;
-  Buffer shared_tensor = is_load ? dst : src;
-  Array<Range> global_range = is_load ? src_range : dst_range;
-  Array<Range> shared_range = is_load ? dst_range : src_range;
+Array<PrimExpr>
+TMABulkCopyPlan::TmaCoords(std::optional<PrimExpr> rest_idx) const {
+  cute::IntTuple coords = tma_coords;
+  if (rest_idx.has_value())
+    coords += rest_to_tma_mode(*rest_idx);
+  Array<PrimExpr> out;
+  out.reserve(desc.rank);
+  for (int64_t i = 0; i < static_cast<int64_t>(desc.rank); i++)
+    out.push_back(cute::AsConstOrPrimExpr(coords[i], DataType::Int(32)));
+  return out;
+}
 
-  auto fallback_to_normal = [&](const std::string &reason) -> Stmt {
-    if (GetIsTmaCopy(op)) {
-      LOG(FATAL) << "T.tma_copy() cannot fall back to normal copy in "
-                 << "LowerBulk: " << reason << ", src=" << src->name
-                 << ", dst=" << dst->name;
-    }
-    return LowerNormal(op, lower_args, analyzer);
+Stmt TMABulkCopyPlan::EmitInstructions(
+    const std::function<Stmt(std::optional<PrimExpr>)> &make_copy) const {
+  if (rest_size > 1) {
+    Var loop_var("i", DataType::Int(32));
+    int loop_extent = rest_size;
+    return For(loop_var, 0, loop_extent, ForKind::kUnrolled,
+               make_copy(loop_var));
+  }
+  return make_copy(std::nullopt);
+}
+
+TMABulkCopyAnalysis
+AnalyzeTMABulkCopy(const LowerArgs &lower_args, const Buffer &global_tensor,
+                   Buffer shared_tensor, const Array<Range> &global_range,
+                   const Array<Range> &shared_range,
+                   const std::vector<int64_t> &box_dim_caps) {
+  auto unsupported = [&](const std::string &reason) -> TMABulkCopyAnalysis {
+    DLOG(WARNING) << "TMA bulk copy between " << global_tensor->name << " and "
+                  << shared_tensor->name << " unsupported: " << reason;
+    return {std::nullopt, reason};
   };
 
   if (lower_args.layout_map.count(global_tensor)) {
-    DLOG(WARNING) << "TMA bulk copy cannot support a non-swizzled global "
-                     "layout, fallback to normal copy.";
-    return fallback_to_normal("non-swizzled global layout");
+    return unsupported("global tensor " + std::string(global_tensor->name) +
+                       " has a non-trivial layout");
   }
 
   Array<PrimExpr> global_shape = global_tensor->shape;
+  ICHECK(box_dim_caps.empty() || box_dim_caps.size() == global_shape.size());
   Array<PrimExpr> global_stride;
   if (!global_tensor->strides.empty()) {
     global_stride = global_tensor->strides;
@@ -1782,19 +1798,9 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
         shared_logical_offset, global_logical_coords] =
       ComputeBulkCopyTile(shared_tensor->shape, shared_range, global_range);
 
-  TMADesc desc;
-  ICHECK(
-      IsValidTMADtypePair(is_load, global_tensor->dtype, shared_tensor->dtype))
-      << "Copy between buffer " << global_tensor->name << " and "
-      << shared_tensor->name << " with incompatible data type "
-      << global_tensor->dtype << " and " << shared_tensor->dtype;
-
-  desc.data_type =
-      TensorMapDataTypeForTMA(global_tensor->dtype, shared_tensor->dtype);
+  TMABulkCopyPlan plan;
+  TMADesc &desc = plan.desc;
   desc.global_addr = global_tensor->data;
-  desc.l2_promotion = static_cast<int>(CU_TENSOR_MAP_L2_PROMOTION_L2_128B);
-  desc.oob_fill = static_cast<int>(CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
-  desc.interleave = static_cast<int>(CU_TENSOR_MAP_INTERLEAVE_NONE);
 
   Array<PrimExpr> shared_shape = shared_tensor->shape;
   // logical shared -> physical shared, in TileLang convention
@@ -1813,25 +1819,15 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
   TMASharedLayoutAnalysis layout_analysis =
       AnalyzeTMASharedLayout(shared_layout, shared_tensor->dtype);
   if (!layout_analysis.encoding.has_value()) {
-    DLOG(WARNING) << "Shared layout for src: " << src->name
-                  << ", dst: " << dst->name
-                  << " cannot be encoded for TMA: " << layout_analysis.reason
-                  << ", fallback to normal copy";
-    return fallback_to_normal(layout_analysis.reason);
+    return unsupported("shared layout cannot be encoded for TMA: " +
+                       layout_analysis.reason);
   }
   const TMASharedLayoutEncoding &layout_encoding =
       layout_analysis.encoding.value();
-  desc.swizzle = layout_encoding.swizzle_mode.CanonicalOrdinal();
+  // The box loop below may widen the mode; desc.swizzle and the alignment
+  // requirement are recorded once the mode is final.
+  SwizzleMode swizzle_mode = layout_encoding.swizzle_mode;
   int elem_bits = shared_tensor->dtype.bits();
-  const cute::SwizzleNode *sw = layout_encoding.composed_bytes->swizzle.get();
-
-  // The TMA unit applies the descriptor's swizzle pattern relative to the
-  // shared-memory base address, so the base must sit on a swizzle-pattern
-  // repeat boundary or the data lands with a shifted phase (silently wrong
-  // results, no fault). Report the requirement implied by the chosen swizzle
-  // mode so MergeSharedMemoryAllocations can align the buffer accordingly.
-  RequireTMASmemAlignment(lower_args, shared_tensor,
-                          layout_encoding.swizzle_mode);
 
   // logical shared -> physical shared (without swizzle)
   // E.g., smem_plain = (64,64,8):(64,1,4096)
@@ -1858,9 +1854,13 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
 
   // physical shared (without swizzle) -> tile -> logical global mode
   // E.g, physical_shared_to_global_mode = (64,64,8):(1@2,1@1,64@2)
-  auto physical_shared_to_global_mode =
-      cute::Coalesce(cute::Composition(tile_to_global_mode, smem_plain_to_tile),
-                     kTmaMaxBoxDim);
+  // Merged runs may not exceed the largest per-dim cap; the box loop below
+  // enforces the exact cap of whichever dim a run belongs to.
+  int64_t coalesce_cap = kTmaMaxBoxDim;
+  for (int64_t c : box_dim_caps)
+    coalesce_cap = std::max(coalesce_cap, c);
+  auto physical_shared_to_global_mode = cute::Coalesce(
+      cute::Composition(tile_to_global_mode, smem_plain_to_tile), coalesce_cap);
 
   // Truncate, because we do not want to start in the middle of a global mode.
   // E.g., smem_rank = 2
@@ -1875,9 +1875,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
   }
 
   if (smem_rank == 0) {
-    DLOG(WARNING) << "TMA bulk copy requires a contiguous innermost stride for "
-                     "SMEM, fallback to normal copy.";
-    return fallback_to_normal("non-contiguous SMEM innermost stride");
+    return unsupported("non-contiguous SMEM innermost stride");
   }
 
   // physical shared (without swizzle) -> logical global mode (no > 1 stride)
@@ -1900,77 +1898,96 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
   // meet some requirements if we need to. This is the modified tile_gbasis.
   Array<cute::IntTuple> box_shape, box_stride;
   for (int64_t i = 0; i < smem_rank; i++) {
-    int64_t cap = kTmaMaxBoxDim;
-    bool is_swizzle_inner = (i == 0 && sw->IsSwizzled());
-    if (is_swizzle_inner) {
-      int64_t span_bits = sw->Granularity() * 8;
-      cap = std::max<int64_t>(1, span_bits / elem_bits);
-    }
-    int64_t box_dim = cute::AsConst(tile_gbasis->shape[i]);
-    if (box_dim > cap) {
-      // This exceeds the hardware constraint. But we can make it work by
-      // splitting a mode.
-      // Only the slowest box mode has leftover the rest loop can absorb;
-      // shrinking a faster mode would gap the contiguous shared prefix.
-      int64_t inner = -1;
-      if (i == smem_rank - 1) {
-        for (int64_t d = cap; d > 1; --d) {
-          if (box_dim % d == 0) {
-            inner = d;
-            break;
-          }
-        }
-      }
-      if (inner != -1) {
-        box_dim = inner;
-      }
-    }
-    if (is_swizzle_inner) {
-      ICHECK_EQ(box_dim, cap)
-          << "The innermost box dim of a BulkCopy is not the swizzle "
-             "granularity: "
-          << "shared_layout = " << shared_layout << ", "
-          << "tile_to_smem_plain = " << tile_to_smem_plain << ", "
-          << "physical_shared_to_global_mode = "
-          << physical_shared_to_global_mode << ", "
-          << "tile_gbasis = " << tile_gbasis << ". "
-          << "Currently the automatically generated swizzling do not violate "
-             "this constraint. If you are annotating the layout, please make "
-             "sure the contiguous SMEM tile mode has size of your swizzle "
-             "granularity.";
-    } else {
-      if (box_dim > cap) {
-        DLOG(WARNING)
-            << "TMA box dim " << box_dim << " (mode " << i
-            << ") exceeds the cap " << cap
-            << " and cannot be cleanly split, fallback to normal copy";
-        return fallback_to_normal("box dim exceeds cap");
-      }
-    }
-    // The innermost box dim must be a whole 16-byte multiple: TMA transfers the
-    // innermost box as 16-byte vectors.
-    if (i == 0 &&
-        TMABytesFromElements(box_dim, shared_tensor->dtype) % 16 != 0) {
-      DLOG(WARNING) << "TMA innermost box dim " << box_dim << " (="
-                    << TMABytesFromElements(box_dim, shared_tensor->dtype)
-                    << " bytes) is not 16-byte aligned for src: " << src->name
-                    << ", dst: " << dst->name << ", fallback to normal copy";
-      return fallback_to_normal("inner box not 16-byte aligned");
-    }
-    box_shape.push_back(cute::IntTuple(box_dim));
-    box_stride.push_back(tile_gbasis->stride[i]);
-
     // Collect the global mode information.
     auto basis = cute::BasisPath(tile_gbasis->stride[i]);
     ICHECK(basis.size() == 1);
     auto mode = basis[0];
     ICHECK(!visited_global_modes[mode]);
+
+    int64_t box_dim = cute::AsConst(tile_gbasis->shape[i]);
+    int64_t cap = box_dim_caps.empty() ? kTmaMaxBoxDim : box_dim_caps[mode];
+    if (i == 0 && !swizzle_mode.IsNone()) {
+      // A TensorMap requires the innermost box bytes to fit within the
+      // swizzle span. Recovery reports the narrowest pattern observable in
+      // the buffer; a wider mode describes the same layout iff its extra XOR
+      // source bits lie beyond the buffer, so when the contiguous run wants
+      // more than the span, ask the decoder to prove the widest useful mode
+      // first (failure is monotone in the width: wider sources are a
+      // superset).
+      int64_t run_bytes =
+          std::min(box_dim, cap) * elem_bits / 8; // 16B-multiple check below
+      int64_t want_bytes = 32;
+      while (want_bytes < run_bytes && want_bytes < 128)
+        want_bytes *= 2;
+      for (int64_t bytes = want_bytes; bytes > swizzle_mode.ByteWidth();
+           bytes /= 2) {
+        SwizzleMode wider =
+            SwizzleMode::FromOrdinal(__builtin_ctzll(bytes) - 4);
+        if (auto widened = WidenTMASharedLayout(
+                shared_layout, shared_tensor->dtype, layout_encoding, wider)) {
+          // Widening preserves the plain layout, so the pairing above stays
+          // valid; only the descriptor mode (and base alignment) changes.
+          swizzle_mode = widened->swizzle_mode;
+          break;
+        }
+      }
+      int64_t span_elems =
+          std::max<int64_t>(1, swizzle_mode.ByteWidth() * 8 / elem_bits);
+      cap = std::min(cap, span_elems);
+    }
+    bool truncate_box = false;
+    if (box_dim > cap) {
+      // Cap the mode at its largest clean divisor. The leftover and every
+      // slower mode fall to the rest loop: the capped mode becomes the box's
+      // outermost, so the shared prefix stays contiguous.
+      int64_t inner = -1;
+      for (int64_t d = cap; d > 1; --d) {
+        if (box_dim % d == 0) {
+          inner = d;
+          break;
+        }
+      }
+      if (inner == -1) {
+        std::ostringstream oss;
+        oss << "TMA box dim " << box_dim << " (mode " << i
+            << ") exceeds the cap " << cap << " and cannot be cleanly split";
+        return unsupported(oss.str());
+      }
+      box_dim = inner;
+      truncate_box = true;
+    }
+    // The innermost box dim must be a whole 16-byte multiple: TMA transfers the
+    // innermost box as 16-byte vectors.
+    if (i == 0 &&
+        TMABytesFromElements(box_dim, shared_tensor->dtype) % 16 != 0) {
+      std::ostringstream oss;
+      oss << "TMA innermost box dim " << box_dim
+          << " (=" << TMABytesFromElements(box_dim, shared_tensor->dtype)
+          << " bytes) is not a whole 16-byte multiple";
+      return unsupported(oss.str());
+    }
+    box_shape.push_back(cute::IntTuple(box_dim));
+    box_stride.push_back(tile_gbasis->stride[i]);
     visited_global_modes[mode] = true;
     gmode_to_tma_mode_stride.Set(mode, cute::E({i}));
     tma_mode_to_gmode[i] = mode;
+    if (truncate_box)
+      break;
   }
 
+  desc.swizzle = swizzle_mode.CanonicalOrdinal();
+  // The TMA unit applies the descriptor's swizzle pattern to absolute
+  // shared-memory addresses, so the buffer base must sit on a swizzle-pattern
+  // repeat boundary or the data lands with a shifted phase (silently wrong
+  // results, no fault). Report the requirement implied by the chosen swizzle
+  // mode so MergeSharedMemoryAllocations can align the buffer accordingly.
+  // With an aligned base, per-instruction phases are exactly the ones the
+  // recovered global swizzle encodes, so rest instructions may start at any
+  // in-buffer position.
+  RequireTMASmemAlignment(lower_args, shared_tensor, swizzle_mode);
+
   // Adopt the validated/shrunk box dims (a no-op when nothing was shrunk).
+  smem_rank = static_cast<int64_t>(box_shape.size());
   tile_gbasis = cute::Layout(cute::IntTupleTuple(std::move(box_shape)),
                              cute::IntTupleTuple(std::move(box_stride)));
 
@@ -2007,23 +2024,26 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
 
   // The size in the box.
   // E.g., box_size = 4096
-  const int64_t box_size =
-      cute::AsConst(cute::Size(tile_gbasis)); // also tma_gbasis
+  plan.box_size = cute::AsConst(cute::Size(tile_gbasis)); // also tma_gbasis
   // The size out of the box.
   // E.g., rest_size = 8
-  const int64_t rest_size =
-      cute::AsConst(cute::Size(tile_to_shared_logical)) / box_size;
+  plan.rest_size =
+      cute::AsConst(cute::Size(tile_to_shared_logical)) / plan.box_size;
+
+  // Physical shared offset of the tile base.
+  plan.shared_offset = smem_plain(shared_logical_offset);
 
   // Rest index -> physical shared
   // E.g., 8:4096
-  auto rest_to_smem = cute::Coalesce(cute::Layout(rest_size, box_size));
+  plan.rest_to_smem =
+      cute::Coalesce(cute::Layout(plan.rest_size, plan.box_size));
   // Rest index -> physical shared -> logical global mode
   // E.g., 8:64@2
   auto rest_to_gmode =
-      cute::Composition(physical_shared_to_global_mode, rest_to_smem);
+      cute::Composition(physical_shared_to_global_mode, plan.rest_to_smem);
   // Rest index -> logical global mode -> global mode in TMA's view
   // E.g., 8:64@0
-  auto rest_to_tma_mode =
+  plan.rest_to_tma_mode =
       cute::Coalesce(cute::Composition(gmode_to_tma_mode, rest_to_gmode));
 
   desc.global_shape = Array<PrimExpr>();
@@ -2039,27 +2059,87 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
 
     PrimExpr elem_stride = global_stride[tma_mode_to_gmode[i]];
     if (i == 0 && !is_one(elem_stride)) {
-      DLOG(WARNING)
-          << "TMA innermost global stride " << elem_stride
-          << " != 1 element for src: " << src->name << ", dst: " << dst->name
-          << " (transposed/non-contiguous box), fallback to normal copy";
-      return fallback_to_normal("non-contiguous innermost TMA box");
+      std::ostringstream oss;
+      oss << "TMA innermost global stride " << elem_stride
+          << " != 1 element (transposed/non-contiguous box)";
+      return unsupported(oss.str());
     }
     PrimExpr byte_stride =
         TMAGlobalBytesFromElements(elem_stride, global_tensor->dtype);
     if (i >= 1) {
       if (auto s = as_const_int(byte_stride)) {
         if (*s % 16 != 0 || *s >= (1LL << 40)) {
-          DLOG(WARNING) << "TMA global stride " << byte_stride
-                        << " unsupported for src: " << src->name
-                        << ", dst: " << dst->name
-                        << ", fallback to normal copy";
-          return fallback_to_normal("unsupported global stride");
+          std::ostringstream oss;
+          oss << "TMA global stride " << byte_stride
+              << " must be a 16-byte multiple below 2^40";
+          return unsupported(oss.str());
         }
       }
     }
     desc.global_stride.push_back(byte_stride);
   }
+
+  // TMA coords
+  {
+    Array<cute::IntTuple> modes;
+    modes.reserve(tma_rank);
+    for (int64_t i = 0; i < tma_rank; i++)
+      modes.push_back(global_logical_coords[tma_mode_to_gmode[i]]);
+    plan.tma_coords = cute::IntTupleTuple(std::move(modes));
+  }
+
+  plan.shared_tensor = shared_tensor;
+  return {std::move(plan), ""};
+}
+
+Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
+                     arith::Analyzer *analyzer, CopyInst copy_inst) {
+  const Buffer &src = op.src;
+  const Buffer &dst = op.dst;
+  const Array<Range> &src_range = op.src_range;
+  const Array<Range> &dst_range = op.dst_range;
+  const Map<String, ObjectRef> &annotations = op.annotations;
+
+  ICHECK(copy_inst == CopyInst::kBulkLoad || copy_inst == CopyInst::kBulkStore)
+      << "Invalid copy inst " << static_cast<int>(copy_inst);
+  bool is_load = copy_inst == CopyInst::kBulkLoad;
+  Buffer global_tensor = is_load ? src : dst;
+  Buffer shared_tensor = is_load ? dst : src;
+  Array<Range> global_range = is_load ? src_range : dst_range;
+  Array<Range> shared_range = is_load ? dst_range : src_range;
+
+  auto fallback_to_normal = [&](const std::string &reason) -> Stmt {
+    if (GetIsTmaCopy(op)) {
+      LOG(FATAL) << "T.tma_copy() cannot fall back to normal copy in "
+                 << "LowerBulk: " << reason << ", src=" << src->name
+                 << ", dst=" << dst->name;
+    }
+    return LowerNormal(op, lower_args, analyzer);
+  };
+
+  ICHECK(
+      IsValidTMADtypePair(is_load, global_tensor->dtype, shared_tensor->dtype))
+      << "Copy between buffer " << global_tensor->name << " and "
+      << shared_tensor->name << " with incompatible data type "
+      << global_tensor->dtype << " and " << shared_tensor->dtype;
+
+  TMABulkCopyAnalysis bulk_analysis = AnalyzeTMABulkCopy(
+      lower_args, global_tensor, shared_tensor, global_range, shared_range);
+  if (!bulk_analysis.plan.has_value()) {
+    DLOG(WARNING) << "TMA bulk copy unsupported for src: " << src->name
+                  << ", dst: " << dst->name << ": " << bulk_analysis.reason
+                  << ", fallback to normal copy";
+    return fallback_to_normal(bulk_analysis.reason);
+  }
+  const TMABulkCopyPlan &plan = bulk_analysis.plan.value();
+
+  TMADesc desc = plan.desc;
+  desc.data_type =
+      TensorMapDataTypeForTMA(global_tensor->dtype, shared_tensor->dtype);
+  desc.l2_promotion = static_cast<int>(CU_TENSOR_MAP_L2_PROMOTION_L2_128B);
+  desc.oob_fill = static_cast<int>(CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  desc.interleave = static_cast<int>(CU_TENSOR_MAP_INTERLEAVE_NONE);
+  shared_tensor = plan.shared_tensor;
 
   Call create_descriptor =
       Call(DataType::Handle(), create_tma_descriptor(), desc.EncodeCallArgs());
@@ -2089,16 +2169,25 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
     }
   }
 
-  Array<PrimExpr> args;
-  args.reserve(desc.rank + 4);
-  args.push_back(create_descriptor);
-  if (is_load)
-    args.push_back(barrier_base_id >= 0 ? mbar_handle : PrimExpr(0));
   auto tma_op = is_load ? tma_load() : tma_store();
+  PrimExpr total_elements = IntImm(DataType::Int(32), plan.box_size);
 
-  Stmt tma_copy;
-
-  PrimExpr total_elements = IntImm(DataType::Int(32), box_size);
+  auto make_args = [&](std::optional<PrimExpr> rest_idx) {
+    Array<PrimExpr> args;
+    args.reserve(desc.rank + 4);
+    args.push_back(create_descriptor);
+    if (is_load)
+      args.push_back(barrier_base_id >= 0 ? mbar_handle : PrimExpr(0));
+    args.push_back(shared_tensor.access_ptr(is_load ? 2 : 1, DataType::Handle(),
+                                            1, plan.SharedOffset(rest_idx),
+                                            total_elements));
+    for (auto coord : plan.TmaCoords(rest_idx))
+      args.push_back(coord);
+    if (!is_load)
+      args.push_back(0); // need_reduce
+    args.push_back(GetEvictionPolicy(op));
+    return args;
+  };
 
   auto build_multicast_args = [&](const Array<PrimExpr> &regular_args) {
     Array<PrimExpr> mc_args;
@@ -2113,85 +2202,39 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
     return mc_args;
   };
 
-  // physical shared offset
-  cute::IntTuple shared_offset = smem_plain(shared_logical_offset);
-  auto make_shared_offset = [&](std::optional<PrimExpr> rest_idx) {
-    cute::IntTuple off = shared_offset;
-    if (rest_idx.has_value())
-      off += rest_to_smem(*rest_idx);
-    return cute::AsConstOrPrimExpr(off, DataType::Int(32));
+  // The leading CTA in the mask issues the multicast; CTAs outside the mask
+  // replay the regular copy.
+  auto wrap_multicast = [&](Stmt regular, Stmt multicast) {
+    int min_cta_rank = MinRankInClusterMask(cluster_mask);
+    PrimExpr block_rank = Call(DataType::Int(32), block_rank_in_cluster(), {});
+    PrimExpr mask_imm = IntImm(DataType::Int(32), cluster_mask);
+    PrimExpr not_in_mask = EQ(bitwise_and(right_shift(mask_imm, block_rank),
+                                          IntImm(DataType::Int(32), 1)),
+                              IntImm(DataType::Int(32), 0));
+    Stmt regular_or_noop = IfThenElse(not_in_mask, regular, std::nullopt);
+    return IfThenElse(EQ(block_rank, IntImm(DataType::Int(32), min_cta_rank)),
+                      multicast, regular_or_noop);
   };
 
-  // TMA coords
-  cute::IntTuple tma_coords;
-  {
-    Array<cute::IntTuple> modes;
-    modes.reserve(tma_rank);
-    for (int64_t i = 0; i < tma_rank; i++)
-      modes.push_back(global_logical_coords[tma_mode_to_gmode[i]]);
-    tma_coords = cute::IntTupleTuple(std::move(modes));
-  }
-  auto make_tma_coords = [&](std::optional<PrimExpr> rest_idx) {
-    cute::IntTuple coords = tma_coords;
-    if (rest_idx.has_value())
-      coords += rest_to_tma_mode(*rest_idx);
-    Array<PrimExpr> out;
-    out.reserve(tma_rank);
-    for (int64_t i = 0; i < tma_rank; i++)
-      out.push_back(cute::AsConstOrPrimExpr(coords[i], DataType::Int(32)));
-    return out;
-  };
-
-  if (rest_size > 1) {
+  Stmt tma_copy;
+  if (plan.rest_size > 1) {
     Var loop_var("i", DataType::Int(32));
-    int loop_extent = rest_size;
-
-    PrimExpr shared_addr =
-        shared_tensor.access_ptr(is_load ? 2 : 1, DataType::Handle(), 1,
-                                 make_shared_offset(loop_var), total_elements);
-    args.push_back(shared_addr);
-    for (auto coord : make_tma_coords(loop_var))
-      args.push_back(coord);
-    int need_reduce = 0;
-    if (!is_load)
-      args.push_back(need_reduce);
-    args.push_back(GetEvictionPolicy(op));
-    Map<String, ObjectRef> ann_loop;
+    int loop_extent = plan.rest_size;
+    Array<PrimExpr> args = make_args(loop_var);
+    Map<String, ObjectRef> ann;
     if (is_cluster_barrier && TargetIsSm100(lower_args.target) && is_load) {
-      ann_loop.Set("use_2cta", IntImm(DataType::Int(32), 1));
+      ann.Set("use_2cta", IntImm(DataType::Int(32), 1));
     }
     tma_copy = For(loop_var, 0, loop_extent, ForKind::kUnrolled,
-                   Evaluate(Call(DataType::Handle(), tma_op, args, ann_loop)));
-
+                   Evaluate(Call(DataType::Handle(), tma_op, args, ann)));
     if (use_multicast) {
-      Array<PrimExpr> mc_args = build_multicast_args(args);
-      Stmt multicast_copy = For(
-          loop_var, 0, loop_extent, ForKind::kUnrolled,
-          Evaluate(Call(DataType::Handle(), tma_load_multicast(), mc_args)));
-
-      int min_cta_rank = MinRankInClusterMask(cluster_mask);
-      PrimExpr block_rank =
-          Call(DataType::Int(32), block_rank_in_cluster(), {});
-      PrimExpr mask_imm = IntImm(DataType::Int(32), cluster_mask);
-      PrimExpr not_in_mask = EQ(bitwise_and(right_shift(mask_imm, block_rank),
-                                            IntImm(DataType::Int(32), 1)),
-                                IntImm(DataType::Int(32), 0));
-      Stmt regular_or_noop = IfThenElse(not_in_mask, tma_copy, std::nullopt);
-      tma_copy =
-          IfThenElse(EQ(block_rank, IntImm(DataType::Int(32), min_cta_rank)),
-                     multicast_copy, regular_or_noop);
+      tma_copy = wrap_multicast(
+          tma_copy, For(loop_var, 0, loop_extent, ForKind::kUnrolled,
+                        Evaluate(Call(DataType::Handle(), tma_load_multicast(),
+                                      build_multicast_args(args)))));
     }
   } else {
-    PrimExpr shared_addr = shared_tensor.access_ptr(
-        is_load ? 2 : 1, DataType::Handle(), 1,
-        make_shared_offset(std::nullopt), total_elements);
-    args.push_back(shared_addr);
-    for (auto coord : make_tma_coords(std::nullopt))
-      args.push_back(coord);
-    int need_reduce = 0;
-    if (!is_load)
-      args.push_back(need_reduce);
-    args.push_back(GetEvictionPolicy(op));
+    Array<PrimExpr> args = make_args(std::nullopt);
     Map<String, ObjectRef> ann;
     if (TargetIsSm100(lower_args.target) && is_load &&
         (annotations.find("use_2cta") != annotations.end() ||
@@ -2199,23 +2242,10 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
       ann.Set("use_2cta", IntImm(DataType::Int(32), 1));
     }
     tma_copy = Evaluate(Call(DataType::Handle(), tma_op, args, ann));
-
     if (use_multicast) {
-      Array<PrimExpr> mc_args = build_multicast_args(args);
-      Stmt multicast_copy =
-          Evaluate(Call(DataType::Handle(), tma_load_multicast(), mc_args));
-
-      int min_cta_rank = MinRankInClusterMask(cluster_mask);
-      PrimExpr block_rank =
-          Call(DataType::Int(32), block_rank_in_cluster(), {});
-      PrimExpr mask_imm = IntImm(DataType::Int(32), cluster_mask);
-      PrimExpr not_in_mask = EQ(bitwise_and(right_shift(mask_imm, block_rank),
-                                            IntImm(DataType::Int(32), 1)),
-                                IntImm(DataType::Int(32), 0));
-      Stmt regular_or_noop = IfThenElse(not_in_mask, tma_copy, std::nullopt);
-      tma_copy =
-          IfThenElse(EQ(block_rank, IntImm(DataType::Int(32), min_cta_rank)),
-                     multicast_copy, regular_or_noop);
+      tma_copy = wrap_multicast(
+          tma_copy, Evaluate(Call(DataType::Handle(), tma_load_multicast(),
+                                  build_multicast_args(args))));
     }
   }
 
@@ -2233,8 +2263,8 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
 
   if (is_load && barrier_base_id >= 0) {
     PrimExpr total_bytes;
-    if (rest_size > 1) {
-      int loop_extent = rest_size;
+    if (plan.rest_size > 1) {
+      int loop_extent = plan.rest_size;
       total_bytes = TMATransactionBytesFromElements(
           total_elements * loop_extent, shared_tensor->dtype);
     } else {
@@ -2326,7 +2356,6 @@ Stmt Copy::LowerBulkGather4(const CopyNode &op, const LowerArgs &lower_args,
 
   Buffer global_tensor = is_load ? op.src : op.dst;
   Buffer shared_tensor = is_load ? op.dst : op.src;
-  Buffer shared_tensor_unmapped = shared_tensor;
 
   ICHECK_EQ(global_tensor->shape.size(), 2u);
   ICHECK_EQ(shared_tensor->shape.size(), 2u);
@@ -2341,117 +2370,71 @@ Stmt Copy::LowerBulkGather4(const CopyNode &op, const LowerArgs &lower_args,
   ICHECK_EQ(rows.size(), 4u);
   ICHECK(col.defined());
 
-  TMADesc desc;
-  desc.rank = 2;
+  // Same decomposition as LowerBulk, over a virtual 4-row view of the global
+  // tensor: the gathered rows act as global mode 0 whose coordinates are
+  // given per instruction, and columns start at `col`.
+  PrimExpr K = shared_tensor->shape[1];
+  TMABulkCopyAnalysis bulk_analysis = AnalyzeTMABulkCopy(
+      lower_args, global_tensor, shared_tensor,
+      /*global_range=*/
+      {Range::FromMinExtent(0, 4), Range::FromMinExtent(col, K)},
+      /*shared_range=*/
+      {Range::FromMinExtent(0, 4), Range::FromMinExtent(0, K)});
+  ICHECK(bulk_analysis.plan.has_value())
+      << "tma_gather4/scatter4 cannot lower the shared tile of "
+      << shared_tensor->name << ": " << bulk_analysis.reason;
+  const TMABulkCopyPlan &plan = bulk_analysis.plan.value();
+
+  TMADesc desc = plan.desc;
   desc.data_type = to_CUtensorMapDataType(global_tensor->dtype);
-  desc.global_addr = global_tensor->data;
-  desc.global_shape = ReverseArray(global_tensor->shape);
+  desc.l2_promotion = static_cast<int>(CU_TENSOR_MAP_L2_PROMOTION_L2_128B);
+  desc.oob_fill = static_cast<int>(CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  desc.interleave = static_cast<int>(CU_TENSOR_MAP_INTERLEAVE_NONE);
 
-  if (!global_tensor->strides.empty()) {
-    desc.global_stride = ReverseArray(global_tensor->strides);
-  } else {
-    PrimExpr stride = 1;
-    desc.global_stride.reserve(2);
-    for (size_t i = 0; i < global_tensor->shape.size(); ++i) {
-      desc.global_stride.push_back(stride);
-      stride *= global_tensor->shape[global_tensor->shape.size() - 1 - i];
-    }
-  }
-  ICHECK(is_one(desc.global_stride[0]))
-      << "tma_gather4/scatter4 requires unit innermost global stride, got "
-      << desc.global_stride;
-  desc.global_stride = desc.global_stride.Map([&](PrimExpr e) {
-    return TMAGlobalBytesFromElements(e, global_tensor->dtype);
-  });
-  for (size_t i = 1; i < desc.global_stride.size(); ++i) {
-    if (auto stride = desc.global_stride[i].as<IntImmNode>()) {
-      ICHECK(stride->value % 16 == 0 && stride->value < (1LL << 40))
-          << "tma_gather4/scatter4 global stride[" << i
-          << "] = " << stride->value
-          << " bytes must be 16-byte aligned and < 2^40";
-    }
-  }
-
+  auto row_box = as_const_int(desc.smem_box[1]);
+  ICHECK(row_box != nullptr && *row_box == 4)
+      << "tma_gather4/scatter4 requires the 4 gathered rows to sit right "
+         "above the contiguous row chunk in shared memory, got box "
+      << desc.smem_box;
   // The descriptor's row box-dim must be 1, not 4. The four-row pack is
   // implicit in the cp.async.bulk.tensor.tile::gather4 PTX, which takes 4
   // row coordinates and materializes them into 4 logical rows of the shared
   // tile. Setting box[1]=4 here would describe a contiguous 4-row strip; the
-  // gather4 unrolling would then read OOB → CUDA_ERROR_ILLEGAL_INSTRUCTION.
-  PrimExpr K_box = shared_tensor->shape[1];
-  if (auto k = as_const_int(K_box)) {
-    int64_t k_bytes = TMABytesFromElements(*k, shared_tensor->dtype);
-    ICHECK(k_bytes % 16 == 0)
-        << "tma_gather4/scatter4 K_box * dtype.bytes() = " << k_bytes
-        << " must be 16-byte aligned";
-  }
-  desc.smem_box = {K_box, IntImm(DataType::Int(32), 1)};
-  desc.smem_stride = {IntImm(DataType::Int(32), 1),
-                      IntImm(DataType::Int(32), 1)};
-  desc.interleave = static_cast<int>(CU_TENSOR_MAP_INTERLEAVE_NONE);
-  desc.l2_promotion = static_cast<int>(CU_TENSOR_MAP_L2_PROMOTION_L2_128B);
-  desc.oob_fill = static_cast<int>(CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
-
-  Layout shared_layout;
-  if (lower_args.layout_map.count(shared_tensor)) {
-    shared_layout = lower_args.layout_map.at(shared_tensor);
-    ICHECK(lower_args.buffer_remap.count(shared_tensor));
-    shared_tensor = lower_args.buffer_remap.at(shared_tensor);
-  }
-  desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
-  if (shared_layout.defined() && shared_layout->InputDim() >= 2) {
-    SwizzleMode mode = DetectSwizzleMode(shared_layout, shared_tensor_unmapped);
-    if (mode == SwizzleMode::Swizzle32B()) {
-      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
-    } else if (mode == SwizzleMode::Swizzle64B()) {
-      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B);
-    } else if (mode == SwizzleMode::Swizzle128B()) {
-      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B);
-    }
-  }
-  if (auto k = as_const_int(K_box)) {
-    int64_t k_bytes = TMABytesFromElements(*k, shared_tensor->dtype);
-    int max_bytes = 0;
-    if (desc.swizzle == static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B))
-      max_bytes = 32;
-    else if (desc.swizzle == static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B))
-      max_bytes = 64;
-    else if (desc.swizzle == static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B))
-      max_bytes = 128;
-    if (max_bytes > 0) {
-      ICHECK(k_bytes <= max_bytes)
-          << "tma_gather4/scatter4 K_box * dtype.bytes() = " << k_bytes
-          << " exceeds " << max_bytes << "B swizzle limit";
-    }
-  }
-  RequireTMASmemAlignment(lower_args, shared_tensor,
-                          SwizzleMode::FromOrdinal(desc.swizzle));
+  // gather4 unrolling would then read OOB -> CUDA_ERROR_ILLEGAL_INSTRUCTION.
+  desc.smem_box.Set(1, IntImm(DataType::Int(32), 1));
 
   Call create_descriptor =
       Call(DataType::Handle(), create_tma_descriptor(), desc.EncodeCallArgs());
 
-  PrimExpr total_elements = 4 * K_box;
-  PrimExpr smem_addr =
-      shared_tensor.access_ptr(is_load ? 2 : 1, DataType::Handle(), 1,
-                               IntImm(DataType::Int(32), 0), total_elements);
-
-  Array<PrimExpr> args;
-  args.push_back(create_descriptor);
+  PrimExpr user_barrier;
   if (is_load) {
-    auto user_barrier = op.annotations.Get("barrier");
-    ICHECK(user_barrier.has_value())
+    auto barrier = op.annotations.Get("barrier");
+    ICHECK(barrier.has_value())
         << "tma_gather4 requires a 'barrier' annotation";
-    args.push_back(Downcast<PrimExpr>(user_barrier.value()));
+    user_barrier = Downcast<PrimExpr>(barrier.value());
   }
-  args.push_back(smem_addr);
-  args.push_back(col);
-  for (auto r : rows)
-    args.push_back(r);
-  args.push_back(IntImm(DataType::Int(32), GetEvictionPolicy(op)));
+
+  PrimExpr total_elements = IntImm(DataType::Int(32), plan.box_size);
+  Buffer shared_physical = plan.shared_tensor;
+  auto tl_op = is_load ? tma_load_gather4() : tma_store_scatter4();
+  auto make_copy = [&](std::optional<PrimExpr> rest_idx) {
+    Array<PrimExpr> args;
+    args.push_back(create_descriptor);
+    if (is_load)
+      args.push_back(user_barrier);
+    args.push_back(shared_physical.access_ptr(
+        is_load ? 2 : 1, DataType::Handle(), 1, plan.SharedOffset(rest_idx),
+        total_elements));
+    args.push_back(plan.TmaCoords(rest_idx)[0]); // column coordinate
+    for (auto r : rows)
+      args.push_back(r);
+    args.push_back(IntImm(DataType::Int(32), GetEvictionPolicy(op)));
+    return Evaluate(Call(DataType::Handle(), tl_op, args));
+  };
 
   // Fire-and-forget: caller manages mbarrier_expect_tx / wait (loads) and
   // tma_store_arrive / wait (stores), and the leader-thread guard.
-  auto tl_op = is_load ? tma_load_gather4() : tma_store_scatter4();
-  return Evaluate(Call(DataType::Handle(), tl_op, args));
+  return plan.EmitInstructions(make_copy);
 }
 
 Stmt Copy::LowerBulk1D(const CopyNode &op, const LowerArgs &lower_args,
@@ -2646,81 +2629,23 @@ Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &lower_args,
 
   size_t ndim = dst_region->region.size();
   ICHECK(ndim >= 2) << "im2col dstRegion must have at least 2 dims";
-  Layout shared_layout;
-  if (lower_args.layout_map.count(dst)) {
-    shared_layout = lower_args.layout_map[dst];
-  }
 
   TMAIm2ColDesc desc;
   desc.rank = src->shape.size();
   desc.data_type = to_CUtensorMapDataType(src->dtype);
   desc.global_addr = src->data;
   desc.global_shape = ReverseArray(src->shape);
-
-  if (!src->strides.empty()) {
-    desc.global_stride = ReverseArray(src->strides);
-  } else {
-    PrimExpr stride = 1;
-    desc.global_stride.reserve(desc.rank);
-    for (size_t i = 0; i < desc.rank; i++) {
-      desc.global_stride.push_back(stride);
-      stride *= desc.global_shape[i];
-    }
-  }
+  desc.global_stride = ReverseArray(
+      src->strides.empty() ? makeRowMajorStrides(src->shape) : src->strides);
   ICHECK(is_one(desc.global_stride[0])) << desc.global_stride;
   desc.global_stride = desc.global_stride.Map(
       [&](PrimExpr e) { return TMAGlobalBytesFromElements(e, src->dtype); });
   desc.elem_stride = {1, op.stride_, op.stride_, 1};
   desc.lower_corner = {-op.padding_, -op.padding_};
   desc.upper_corner = {-op.padding_, -op.padding_};
-  desc.smem_box_pixel =
-      Downcast<IntImm>(dst_region->region[ndim - 2]->extent)->value;
-  desc.smem_box_channel =
-      Downcast<IntImm>(dst_region->region[ndim - 1]->extent)->value;
   desc.l2_promotion = static_cast<int>(CU_TENSOR_MAP_L2_PROMOTION_L2_128B);
   desc.oob_fill = static_cast<int>(CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
   desc.interleave = static_cast<int>(CU_TENSOR_MAP_INTERLEAVE_NONE);
-  if (!shared_layout.defined()) {
-    desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
-  } else {
-    ICHECK(shared_layout->InputDim() >= 2) << "Cannot detect TMA layout.";
-    if (StructuralEqual()(shared_layout, MakeQuarterBankSwizzleLayout(dst))) {
-      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
-    } else if (StructuralEqual()(shared_layout,
-                                 MakeHalfBankSwizzleLayout(dst))) {
-      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B);
-    } else if (StructuralEqual()(shared_layout,
-                                 MakeFullBankSwizzleLayout(dst))) {
-      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B);
-    } else {
-      LOG(FATAL) << "Cannot detect TMA layout.";
-    }
-  }
-  RequireTMASmemAlignment(
-      lower_args,
-      lower_args.buffer_remap.count(dst) ? lower_args.buffer_remap[dst] : dst,
-      SwizzleMode::FromOrdinal(desc.swizzle));
-
-  Call create_desc = Call(DataType::Handle(), create_tma_im2col_descriptor(),
-                          desc.EncodeCallArgs());
-
-  Array<PrimExpr> global_coords;
-  Array<PrimExpr> image_offset;
-  global_coords.reserve(desc.rank);
-
-  ICHECK(analyzer->CanProveEqual(
-      FloorMod(desc.global_shape[0], desc.smem_box_channel), 0))
-      << "Currently can only support divisible channel case";
-
-  global_coords.push_back(
-      FloorMod(op.c_step_ * desc.smem_box_channel, desc.global_shape[0]));
-  image_offset.push_back(op.dilation_ *
-                         FloorMod(FloorDiv(op.c_step_ * desc.smem_box_channel,
-                                           desc.global_shape[0]),
-                                  op.kernel_));
-  image_offset.push_back(op.dilation_ *
-                         FloorDiv(op.c_step_ * desc.smem_box_channel,
-                                  desc.global_shape[0] * op.kernel_));
 
   PrimExpr h_dim = FloorDiv(src->shape[1] + 2 * op.padding_ -
                                 (op.kernel_ - 1) * op.dilation_ - 1,
@@ -2730,15 +2655,41 @@ Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &lower_args,
                                 (op.kernel_ - 1) * op.dilation_ - 1,
                             op.stride_) +
                    1;
-  global_coords.push_back(
-      op.stride_ * FloorMod(op.nhw_step_ * desc.smem_box_pixel, w_dim) -
-      op.padding_);
-  global_coords.push_back(
-      op.stride_ *
-          FloorMod(FloorDiv(op.nhw_step_ * desc.smem_box_pixel, w_dim), h_dim) -
-      op.padding_);
-  global_coords.push_back(
-      FloorDiv(op.nhw_step_ * desc.smem_box_pixel, w_dim * h_dim));
+
+  // Same decomposition as LowerBulk, over a virtual (pixels, channels) view
+  // of the global tensor: the composed shared layout decides the box and the
+  // per-instruction coordinate steps; only the descriptor encoding is
+  // im2col-specific.
+  PrimExpr channels = src->shape[3];
+  PrimExpr box_pixel = dst_region->region[ndim - 2]->extent;
+  PrimExpr box_channel = dst_region->region[ndim - 1]->extent;
+  Buffer gmem_view(src->data, src->dtype,
+                   {src->shape[0] * h_dim * w_dim, channels}, {channels, 1},
+                   PrimExpr(), "im2col_gmem_view", src->data_alignment,
+                   src->offset_factor, src->buffer_type);
+  TMABulkCopyAnalysis bulk_analysis = AnalyzeTMABulkCopy(
+      lower_args, gmem_view, dst,
+      /*global_range=*/
+      {Range::FromMinExtent(op.nhw_step_ * box_pixel, box_pixel),
+       Range::FromMinExtent(op.c_step_ * box_channel, box_channel)},
+      /*shared_range=*/dst_region->region,
+      /*box_dim_caps=*/{kTmaMaxIm2ColPixelsPerColumn, kTmaMaxBoxDim});
+  ICHECK(bulk_analysis.plan.has_value())
+      << "im2col cannot lower the shared tile of " << dst->name << ": "
+      << bulk_analysis.reason;
+  const TMABulkCopyPlan &plan = bulk_analysis.plan.value();
+
+  desc.smem_box_channel = Downcast<IntImm>(plan.desc.smem_box[0])->value;
+  desc.smem_box_pixel = Downcast<IntImm>(plan.desc.smem_box[1])->value;
+  desc.swizzle = plan.desc.swizzle;
+
+  Call create_desc = Call(DataType::Handle(), create_tma_im2col_descriptor(),
+                          desc.EncodeCallArgs());
+
+  // Channel steps stay inside one box_channel window (box_channel divides the
+  // channel count), so the filter-tap decomposition is per-copy constant.
+  ICHECK(analyzer->CanProveEqual(FloorMod(channels, box_channel), 0))
+      << "Currently can only support divisible channel case";
 
   int barrier_base_id = -1;
   PrimExpr mbar_handle;
@@ -2752,39 +2703,38 @@ Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &lower_args,
     mbar_handle = BufferLoad(lower_args.mbarrier_buffer->value(), {mbar_idx});
   }
 
-  Array<PrimExpr> args;
-  args.reserve(desc.rank * 2 + 2);
-  args.push_back(create_desc);
-  args.push_back(barrier_base_id >= 0 ? mbar_handle : PrimExpr(0));
-  Buffer dst_buffer =
-      lower_args.buffer_remap.count(dst) ? lower_args.buffer_remap[dst] : dst;
-  PrimExpr flat_offset = IntImm(DataType::Int(32), 0);
-  {
-    PrimExpr stride = IntImm(DataType::Int(32), 1);
-    for (int i = static_cast<int>(ndim) - 1; i >= 0; --i) {
-      flat_offset = flat_offset + dst_region->region[i]->min * stride;
-      stride = stride * dst->shape[i];
-    }
-  }
-  PrimExpr tile_elems =
-      IntImm(DataType::Int(32), desc.smem_box_pixel * desc.smem_box_channel);
-  PrimExpr shared_addr = dst_buffer.access_ptr(
-      /*access_mask=*/2, /*dtype=*/DataType::Handle(), /*content_lanes=*/1,
-      /*offset=*/flat_offset, /*extent=*/tile_elems);
-  args.push_back(shared_addr);
-  for (auto coord : global_coords)
-    args.push_back(coord);
-  for (auto offset : image_offset)
-    args.push_back(offset);
-  args.push_back(op.eviction_policy_);
-  Stmt tma_copy_stmt =
-      Evaluate(Call(DataType::Handle(), tma_load_im2col(), args));
+  PrimExpr tile_elems = IntImm(DataType::Int(32), plan.box_size);
+  Buffer shared_physical = plan.shared_tensor;
+  auto make_copy = [&](std::optional<PrimExpr> rest_idx) {
+    Array<PrimExpr> coords = plan.TmaCoords(rest_idx);
+    PrimExpr channel_pos = coords[0];
+    PrimExpr pixel_pos = coords[1];
+
+    Array<PrimExpr> args;
+    args.reserve(desc.rank * 2 + 2);
+    args.push_back(create_desc);
+    args.push_back(barrier_base_id >= 0 ? mbar_handle : PrimExpr(0));
+    args.push_back(shared_physical.access_ptr(
+        /*access_mask=*/2, /*dtype=*/DataType::Handle(), /*content_lanes=*/1,
+        /*offset=*/plan.SharedOffset(rest_idx), /*extent=*/tile_elems));
+    args.push_back(FloorMod(channel_pos, channels));
+    args.push_back(op.stride_ * FloorMod(pixel_pos, w_dim) - op.padding_);
+    args.push_back(op.stride_ * FloorMod(FloorDiv(pixel_pos, w_dim), h_dim) -
+                   op.padding_);
+    args.push_back(FloorDiv(pixel_pos, w_dim * h_dim));
+    args.push_back(op.dilation_ *
+                   FloorMod(FloorDiv(channel_pos, channels), op.kernel_));
+    args.push_back(op.dilation_ * FloorDiv(channel_pos, channels * op.kernel_));
+    args.push_back(op.eviction_policy_);
+    return Evaluate(Call(DataType::Handle(), tma_load_im2col(), args));
+  };
+
+  Stmt tma_copy_stmt = plan.EmitInstructions(make_copy);
 
   if (barrier_base_id >= 0) {
     bool ws_barrier = op.annotations_.Get("barrier").has_value();
     PrimExpr total_bytes = TMABytesFromElements(
-        IntImm(DataType::Int(32), desc.smem_box_pixel * desc.smem_box_channel),
-        dst->dtype);
+        IntImm(DataType::Int(32), plan.box_size * plan.rest_size), dst->dtype);
 
     Stmt barrier_before_tma_stmt = Evaluate(Call(
         DataType::Handle(), mbarrier_expect_tx(), {mbar_handle, total_bytes}));

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -1897,6 +1897,7 @@ AnalyzeTMABulkCopy(const LowerArgs &lower_args, const Buffer &global_tensor,
   // We have some hardware restrictions on tile_gbasis. But we can shrink it to
   // meet some requirements if we need to. This is the modified tile_gbasis.
   Array<cute::IntTuple> box_shape, box_stride;
+  int64_t box_elems = 1; // running product of the accepted box dims
   for (int64_t i = 0; i < smem_rank; i++) {
     // Collect the global mode information.
     auto basis = cute::BasisPath(tile_gbasis->stride[i]);
@@ -1910,26 +1911,21 @@ AnalyzeTMABulkCopy(const LowerArgs &lower_args, const Buffer &global_tensor,
       // A TensorMap requires the innermost box bytes to fit within the
       // swizzle span. Recovery reports the narrowest pattern observable in
       // the buffer; a wider mode describes the same layout iff its extra XOR
-      // source bits lie beyond the buffer, so when the contiguous run wants
-      // more than the span, ask the decoder to prove the widest useful mode
-      // first (failure is monotone in the width: wider sources are a
-      // superset).
+      // source bits lie beyond the buffer (then it also recovers the same
+      // plain layout, so the pairing above stays valid). Widen one mode at a
+      // time while the contiguous run wants more than the span; the recovery
+      // proof gates each step. b_bits is recast-invariant, so the byte-space
+      // width binds the element-space recovery directly.
       int64_t run_bytes =
-          std::min(box_dim, cap) * elem_bits / 8; // 16B-multiple check below
-      int64_t want_bytes = 32;
-      while (want_bytes < run_bytes && want_bytes < 128)
-        want_bytes *= 2;
-      for (int64_t bytes = want_bytes; bytes > swizzle_mode.ByteWidth();
-           bytes /= 2) {
-        SwizzleMode wider =
-            SwizzleMode::FromOrdinal(__builtin_ctzll(bytes) - 4);
-        if (auto widened = WidenTMASharedLayout(
-                shared_layout, shared_tensor->dtype, layout_encoding, wider)) {
-          // Widening preserves the plain layout, so the pairing above stays
-          // valid; only the descriptor mode (and base alignment) changes.
-          swizzle_mode = widened->swizzle_mode;
+          TMABytesFromElements(std::min(box_dim, cap), shared_tensor->dtype);
+      while (swizzle_mode.ByteWidth() < 128 &&
+             run_bytes > swizzle_mode.ByteWidth()) {
+        int b_bits = swizzle_mode.BBits() + 1;
+        if (!cute::ComposedLayoutFromTileLang(shared_layout, b_bits)
+                 .defined()) {
           break;
         }
+        swizzle_mode = SwizzleMode::FromBBits(b_bits);
       }
       int64_t span_elems =
           std::max<int64_t>(1, swizzle_mode.ByteWidth() * 8 / elem_bits);
@@ -1939,10 +1935,15 @@ AnalyzeTMABulkCopy(const LowerArgs &lower_args, const Buffer &global_tensor,
     if (box_dim > cap) {
       // Cap the mode at its largest clean divisor. The leftover and every
       // slower mode fall to the rest loop: the capped mode becomes the box's
-      // outermost, so the shared prefix stays contiguous.
+      // outermost, so the shared prefix stays contiguous. Rest instructions
+      // step the shared tile by the box size, so the divisor must also keep
+      // the box a whole kTmaSmemAddrAlign multiple.
       int64_t inner = -1;
       for (int64_t d = cap; d > 1; --d) {
-        if (box_dim % d == 0) {
+        if (box_dim % d == 0 &&
+            TMABytesFromElements(box_elems * d, shared_tensor->dtype) %
+                    kTmaSmemAddrAlign ==
+                0) {
           inner = d;
           break;
         }
@@ -2029,6 +2030,18 @@ AnalyzeTMABulkCopy(const LowerArgs &lower_args, const Buffer &global_tensor,
   // E.g., rest_size = 8
   plan.rest_size =
       cute::AsConst(cute::Size(tile_to_shared_logical)) / plan.box_size;
+
+  // Rest instructions step the shared tile by the box size; the divisor
+  // search above keeps split boxes aligned, but a box formed from unpaired
+  // slower modes may still violate the instruction address alignment.
+  int64_t box_bytes = TMABytesFromElements(plan.box_size, shared_tensor->dtype);
+  if (plan.rest_size > 1 && box_bytes % kTmaSmemAddrAlign != 0) {
+    std::ostringstream oss;
+    oss << "TMA rest instructions step the shared tile by " << box_bytes
+        << " bytes, which is not a whole " << kTmaSmemAddrAlign
+        << "-byte multiple";
+    return unsupported(oss.str());
+  }
 
   // Physical shared offset of the tile base.
   plan.shared_offset = smem_plain(shared_logical_offset);

--- a/src/cuda/op/copy.h
+++ b/src/cuda/op/copy.h
@@ -6,11 +6,16 @@
 #ifndef TVM_TL_BACKEND_CUDA_OP_COPY_H_
 #define TVM_TL_BACKEND_CUDA_OP_COPY_H_
 
+#include "cuda/op/tma_layout.h"
+#include "layout/cute_layout.h"
 #include "op/copy.h"
+#include "op/operator.h"
 #include "support/check.h"
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <optional>
 #include <string>
 
 namespace tvm {
@@ -76,6 +81,47 @@ struct TMADesc {
     return args;
   }
 };
+
+// Geometry of a descriptor-based bulk tensor copy between a shared-memory
+// tile and a global region, derived with CuTe layout algebra. Every TMADesc
+// field is filled except data_type, l2_promotion, oob_fill and interleave,
+// which are op policy. The copy issues `rest_size` TMA instructions of
+// `box_size` elements each; SharedOffset/TmaCoords give the arguments of
+// instruction `rest_idx` (std::nullopt when rest_size == 1).
+struct TMABulkCopyPlan {
+  TMADesc desc;
+  Buffer shared_tensor;          // physical (remapped) shared buffer
+  int64_t box_size;              // elements per TMA instruction
+  int64_t rest_size;             // TMA instructions per copy
+  cute::IntTuple shared_offset;  // physical offset of the tile base
+  cute::IntTuple tma_coords;     // global coords of the tile base per TMA mode
+  cute::Layout rest_to_smem;     // instruction index -> smem offset step
+  cute::Layout rest_to_tma_mode; // instruction index -> TMA coord steps
+
+  PrimExpr SharedOffset(std::optional<PrimExpr> rest_idx) const;
+  Array<PrimExpr> TmaCoords(std::optional<PrimExpr> rest_idx) const;
+
+  // One statement per TMA instruction: `make_copy` receives the rest index
+  // (std::nullopt when the copy is a single box) and the results replay in an
+  // unrolled loop.
+  Stmt EmitInstructions(
+      const std::function<Stmt(std::optional<PrimExpr>)> &make_copy) const;
+};
+
+struct TMABulkCopyAnalysis {
+  std::optional<TMABulkCopyPlan> plan;
+  std::string reason;
+};
+
+// Derive the TMA boxes for copying `global_range` <-> `shared_range` given
+// the inferred shared layout, or report why the copy cannot be a bulk TMA.
+// `box_dim_caps` overrides the per-global-dim box limit of kTmaMaxBoxDim
+// (im2col allows 1024 pixels per column).
+TMABulkCopyAnalysis
+AnalyzeTMABulkCopy(const LowerArgs &lower_args, const Buffer &global_tensor,
+                   Buffer shared_tensor, const Array<Range> &global_range,
+                   const Array<Range> &shared_range,
+                   const std::vector<int64_t> &box_dim_caps = {});
 
 struct CopyAnalysisContext {
   Target target;

--- a/src/cuda/op/tma_layout.cc
+++ b/src/cuda/op/tma_layout.cc
@@ -39,6 +39,27 @@ TMASharedLayoutAnalysis AnalyzeTMASharedLayout(const Layout &layout,
   return {std::move(encoding), ""};
 }
 
+std::optional<TMASharedLayoutEncoding>
+WidenTMASharedLayout(const Layout &layout, DataType dtype,
+                     const TMASharedLayoutEncoding &encoding,
+                     const SwizzleMode &mode) {
+  // TensorMap modes are Sw<b,4,3> on byte addresses with b = the mode
+  // ordinal; Recast keeps b, so require the same least width in element
+  // space.
+  ffi::Optional<cute::ComposedLayout> composed =
+      cute::ComposedLayoutFromTileLang(layout, mode.CanonicalOrdinal());
+  if (!composed.defined())
+    return std::nullopt;
+  ICHECK(ffi::StructuralEqual()(composed.value()->layout,
+                                encoding.composed->layout))
+      << "widening the swizzle of " << layout << " to " << mode
+      << " changed the plain layout";
+  cute::ComposedLayout composed_bytes =
+      composed.value().Recast(dtype.bits(), /*new_bits=*/8);
+  return TMASharedLayoutEncoding{composed.value(), composed_bytes,
+                                 composed_bytes->swizzle->ToSwizzleMode()};
+}
+
 void RequireTMASmemAlignment(const LowerArgs &lower_args,
                              const tirx::Buffer &shared_tensor,
                              const SwizzleMode &swizzle_mode) {

--- a/src/cuda/op/tma_layout.cc
+++ b/src/cuda/op/tma_layout.cc
@@ -39,27 +39,6 @@ TMASharedLayoutAnalysis AnalyzeTMASharedLayout(const Layout &layout,
   return {std::move(encoding), ""};
 }
 
-std::optional<TMASharedLayoutEncoding>
-WidenTMASharedLayout(const Layout &layout, DataType dtype,
-                     const TMASharedLayoutEncoding &encoding,
-                     const SwizzleMode &mode) {
-  // TensorMap modes are Sw<b,4,3> on byte addresses with b = the mode
-  // ordinal; Recast keeps b, so require the same least width in element
-  // space.
-  ffi::Optional<cute::ComposedLayout> composed =
-      cute::ComposedLayoutFromTileLang(layout, mode.CanonicalOrdinal());
-  if (!composed.defined())
-    return std::nullopt;
-  ICHECK(ffi::StructuralEqual()(composed.value()->layout,
-                                encoding.composed->layout))
-      << "widening the swizzle of " << layout << " to " << mode
-      << " changed the plain layout";
-  cute::ComposedLayout composed_bytes =
-      composed.value().Recast(dtype.bits(), /*new_bits=*/8);
-  return TMASharedLayoutEncoding{composed.value(), composed_bytes,
-                                 composed_bytes->swizzle->ToSwizzleMode()};
-}
-
 void RequireTMASmemAlignment(const LowerArgs &lower_args,
                              const tirx::Buffer &shared_tensor,
                              const SwizzleMode &swizzle_mode) {

--- a/src/cuda/op/tma_layout.h
+++ b/src/cuda/op/tma_layout.h
@@ -32,6 +32,17 @@ struct TMASharedLayoutAnalysis {
 TMASharedLayoutAnalysis AnalyzeTMASharedLayout(const Layout &layout,
                                                DataType dtype);
 
+// Try to re-encode `layout` with its swizzle widened to at least `mode`.
+// Recovery returns the narrowest observed swizzle; a wider TensorMap mode
+// describes the same layout iff the extra XOR source bits never contradict
+// it within the buffer — the recovery proof gates this. A passing proof
+// implies those bits never fire in-domain, so the plain layout is unchanged
+// and any box decomposition computed from the original encoding stays valid.
+std::optional<TMASharedLayoutEncoding>
+WidenTMASharedLayout(const Layout &layout, DataType dtype,
+                     const TMASharedLayoutEncoding &encoding,
+                     const SwizzleMode &mode);
+
 // Record the shared-memory base alignment required by the selected TensorMap
 // swizzle so later allocation merging cannot shift the swizzle phase.
 void RequireTMASmemAlignment(const LowerArgs &lower_args,
@@ -40,6 +51,10 @@ void RequireTMASmemAlignment(const LowerArgs &lower_args,
 
 // A TensorMap box dimension holds at most 256 elements.
 inline constexpr int64_t kTmaMaxBoxDim = 256;
+
+// An im2col TensorMap accesses up to 1024 pixels per column; its
+// channels-per-pixel stays under the ordinary box limit.
+inline constexpr int64_t kTmaMaxIm2ColPixelsPerColumn = 1024;
 
 // Unswizzled shared-memory layout whose copied modes are tiled at the TMA box
 // cap. Dimensions fixed by `region` stay outermost so a versioned slice

--- a/src/cuda/op/tma_layout.h
+++ b/src/cuda/op/tma_layout.h
@@ -32,17 +32,6 @@ struct TMASharedLayoutAnalysis {
 TMASharedLayoutAnalysis AnalyzeTMASharedLayout(const Layout &layout,
                                                DataType dtype);
 
-// Try to re-encode `layout` with its swizzle widened to at least `mode`.
-// Recovery returns the narrowest observed swizzle; a wider TensorMap mode
-// describes the same layout iff the extra XOR source bits never contradict
-// it within the buffer — the recovery proof gates this. A passing proof
-// implies those bits never fire in-domain, so the plain layout is unchanged
-// and any box decomposition computed from the original encoding stays valid.
-std::optional<TMASharedLayoutEncoding>
-WidenTMASharedLayout(const Layout &layout, DataType dtype,
-                     const TMASharedLayoutEncoding &encoding,
-                     const SwizzleMode &mode);
-
 // Record the shared-memory base alignment required by the selected TensorMap
 // swizzle so later allocation merging cannot shift the swizzle phase.
 void RequireTMASmemAlignment(const LowerArgs &lower_args,
@@ -51,6 +40,9 @@ void RequireTMASmemAlignment(const LowerArgs &lower_args,
 
 // A TensorMap box dimension holds at most 256 elements.
 inline constexpr int64_t kTmaMaxBoxDim = 256;
+
+// Every tile-mode TMA instruction requires a 128-byte-aligned SMEM address.
+inline constexpr int64_t kTmaSmemAddrAlign = 128;
 
 // An im2col TensorMap accesses up to 1024 pixels per column; its
 // channels-per-pixel stays under the ordinary box limit.

--- a/src/cuda/transform/inject_fence_proxy.cc
+++ b/src/cuda/transform/inject_fence_proxy.cc
@@ -99,6 +99,8 @@ bool IsAsyncIntrinsic(const CallNode *call) {
   // TileLang async intrinsics
   if (call->op.same_as(tma_load()) || call->op.same_as(tma_load_im2col()) ||
       call->op.same_as(tma_load_multicast()) || call->op.same_as(tma_store()) ||
+      call->op.same_as(tma_load_gather4()) ||
+      call->op.same_as(tma_store_scatter4()) ||
       call->op.same_as(ptx_wgmma_ss()) || call->op.same_as(ptx_wgmma_rs()) ||
       call->op.same_as(ptx_tcgen05_mma_ss()) ||
       call->op.same_as(ptx_tcgen05_mma_ts())) {

--- a/src/layout/cute_layout.cc
+++ b/src/layout/cute_layout.cc
@@ -1975,7 +1975,8 @@ Optional<Layout> LayoutFromTileLangHierarchical(const tvm::tl::Layout &layout) {
 //
 // Then recover the plain layout and prove equivalence via RecoverPlainLayout.
 Optional<ComposedLayout>
-ComposedLayoutFromTileLang(const tvm::tl::Layout &layout) {
+ComposedLayoutFromTileLang(const tvm::tl::Layout &layout,
+                           std::optional<int> least_b_bits) {
   AddrProbe A(layout);
   if (A.shape().empty())
     return std::nullopt;
@@ -1987,17 +1988,13 @@ ComposedLayoutFromTileLang(const tvm::tl::Layout &layout) {
   if (!A0)
     return std::nullopt;
 
-  // Collect the image column of every power-of-two bit-atom. Probe bit p of dim
-  // k (one-hot 1 << p) for p < ctz(shape[k]): only then does 2^(p+1) divide the
-  // extent, so bit p toggles cleanly within the dim and the one-hot isolates a
-  // single mode. A non-pow2 extent still contributes its low bits (192 = 64*3
-  // -> p < 6); an odd extent contributes none.
+  // Collect the image column of every power-of-two bit-atom.
   std::vector<uint64_t> cols;
   uint64_t weight1 = 0; // bit positions that are some atom's identity image.
   for (int64_t k = 0; k < n; ++k) {
     ICHECK_GT(shape[k], 0); // ctz is undefined at 0; extents are >= 1.
-    int max_p = __builtin_ctz(static_cast<uint32_t>(shape[k]));
-    for (int p = 0; p < max_p; ++p) {
+    int clean_p = __builtin_ctz(static_cast<uint32_t>(shape[k]));
+    for (int p = 0; (int64_t(1) << p) < shape[k]; ++p) {
       std::vector<int32_t> x(n, 0);
       x[k] = int32_t(1) << p;
       std::optional<int32_t> a = A(x);
@@ -2005,7 +2002,7 @@ ComposedLayoutFromTileLang(const tvm::tl::Layout &layout) {
         return std::nullopt;
       uint64_t col = static_cast<uint64_t>(*a ^ *A0);
       cols.push_back(col);
-      if (__builtin_popcountll(col) == 1)
+      if (p < clean_p && __builtin_popcountll(col) == 1)
         weight1 |= col;
     }
   }
@@ -2031,6 +2028,8 @@ ComposedLayoutFromTileLang(const tvm::tl::Layout &layout) {
          it != s_at.end() && it->second == s_shift;
          it = s_at.find(m_base + b_bits))
       ++b_bits;
+    if (least_b_bits.has_value())
+      b_bits = std::max(b_bits, *least_b_bits);
     if (s_shift < b_bits)
       return std::nullopt; // source and target bit regions must not overlap.
     swizzle = Swizzle(b_bits, m_base, s_shift);
@@ -2288,8 +2287,11 @@ TVM_FFI_STATIC_INIT_BLOCK() {
              return LayoutFromTileLangHierarchical(layout);
            })
       .def("tl.cute.composed_layout_from_tilelang",
-           [](const tvm::tl::Layout &layout) {
-             return ComposedLayoutFromTileLang(layout);
+           [](const tvm::tl::Layout &layout, Optional<int64_t> least_b_bits) {
+             return ComposedLayoutFromTileLang(
+                 layout, least_b_bits ? std::optional<int>(
+                                            static_cast<int>(*least_b_bits))
+                                      : std::nullopt);
            })
       .def("tl.cute.restrict",
            [](const Layout &layout, const Array<Range> &range) {

--- a/src/layout/cute_layout.h
+++ b/src/layout/cute_layout.h
@@ -617,7 +617,8 @@ Optional<Layout> LayoutFromTileLangHierarchical(const tvm::tl::Layout &layout);
 /// @note Addresses are element-offset positions; recast with
 ///       `.Recast(dtype.bits(), 8)` for the byte-address uses.
 Optional<ComposedLayout>
-ComposedLayoutFromTileLang(const tvm::tl::Layout &layout);
+ComposedLayoutFromTileLang(const tvm::tl::Layout &layout,
+                           std::optional<int> least_b_bits = std::nullopt);
 
 /// Restrict the layout to a sublayout defined by a region.
 /// @return result.sublayout(coords_in_region) + result.offset

--- a/src/layout/swizzle_mode.h
+++ b/src/layout/swizzle_mode.h
@@ -55,6 +55,11 @@ public:
     return static_cast<int>(operator->()->_value);
   }
 
+  // The byte-space Sw<b,4,3> width: none->0, 32B->1, 64B->2, 128B->3.
+  int BBits() const { return CanonicalOrdinal(); }
+
+  static SwizzleMode FromBBits(int b_bits) { return FromOrdinal(b_bits); }
+
   bool IsNone() const { return CanonicalOrdinal() == 0; }
 
   // GMMA descriptor layout type field: none->0, 32B->3, 64B->2, 128B->1.

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -725,7 +725,9 @@ private:
     if (op->op.same_as(tl::tma_load()) ||
         op->op.same_as(tl::tma_load_im2col()) ||
         op->op.same_as(tl::tma_load_multicast()) ||
-        op->op.same_as(tl::tma_store())) {
+        op->op.same_as(tl::tma_store()) ||
+        op->op.same_as(tl::tma_load_gather4()) ||
+        op->op.same_as(tl::tma_store_scatter4())) {
       // skip tma related calls, as they were transformed implicitly.
       has_tma_ = true;
       in_tma_context_ = true;

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -1063,7 +1063,8 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
         const Op &call_op = opt.value();
         return call_op.same_as(tl::tma_load()) ||
                call_op.same_as(tl::tma_load_im2col()) ||
-               call_op.same_as(tl::tma_load_multicast());
+               call_op.same_as(tl::tma_load_multicast()) ||
+               call_op.same_as(tl::tma_load_gather4());
       }
       return false;
     }();

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -255,6 +255,46 @@ def test_tma_copy_uses_descriptor_for_padded_multirow_region():
     torch.testing.assert_close(padded_destination[:, cols:], torch.full_like(padded_destination[:, cols:], -1.0))
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_copy_box_split_respects_smem_alignment():
+    """Rest instructions step the shared tile by the box size, and the TMA
+    unit requires every instruction's shared address to be 128-byte aligned.
+    A 384-element int8 run therefore splits into 128-byte boxes (6
+    instructions), not the 16-byte-clean but misaligned 192; a 464-element
+    run has no 128-byte divisor at all and falls back to a normal copy."""
+    import torch
+
+    def make_load(cols, row_stride=512, rows=2):
+
+        @T.prim_func
+        def load(
+            A: T.StridedTensor((rows, cols), (row_stride, 1), T.int8),
+            B: T.Tensor((rows, cols), T.int8),
+        ):
+            with T.Kernel(1, threads=32):
+                a_shared = T.alloc_shared((rows, cols), T.int8)
+                T.copy(A, a_shared, prefer_instruction="tma")
+                T.copy(a_shared, B, prefer_instruction="sync")
+
+        return load
+
+    def run(cols, kernel):
+        padded = torch.randint(-128, 127, (2, 512), dtype=torch.int8, device="cuda")
+        strided = padded[:, :cols]
+        torch.testing.assert_close(kernel(strided), strided)
+
+    split_kernel = tilelang.compile(make_load(384), out_idx=[1])
+    src = split_kernel.get_kernel_source()
+    assert "CUtensorMap" in src
+    assert re.search(r"for \(int \w+ = 0; \w+ < 6; \+\+\w+\) \{\n\s*tl::tma_load\(", src)
+    run(384, split_kernel)
+
+    fallback_kernel = tilelang.compile(make_load(464), out_idx=[1])
+    assert "CUtensorMap" not in fallback_kernel.get_kernel_source()
+    run(464, fallback_kernel)
+
+
 def _assert_two_box_tma_loop(source, instruction):
     assert re.search(
         rf"for \(int \w+ = 0; \w+ < 2; \+\+\w+\) \{{\n\s*tl::{instruction}\(",

--- a/testing/python/language/test_tilelang_language_tma_gather_scatter.py
+++ b/testing/python/language/test_tilelang_language_tma_gather_scatter.py
@@ -170,5 +170,141 @@ def test_gather_scatter_swizzled(K_box, swizzle_kind):
     run_gather_scatter_swizzled(N=64, K=K_box, K_box=K_box, swizzle_kind=swizzle_kind)
 
 
+def gather_readback_program(N: int, K: int, swizzle_kind: str, in_dtype: str = "float16"):
+    """Gather via TMA, then read shared memory back with a sync copy so a
+    descriptor/layout mismatch is not masked by a TMA->TMA roundtrip."""
+    from tilelang.layout import (
+        make_half_bank_swizzled_layout,
+        make_quarter_bank_swizzled_layout,
+    )
+
+    make_layout = {
+        "32B": make_quarter_bank_swizzled_layout,
+        "64B": make_half_bank_swizzled_layout,
+    }[swizzle_kind]
+
+    @T.prim_func
+    def main(
+        Src: T.Tensor((N, K), in_dtype),
+        Idx: T.Tensor((4,), "int32"),
+        Out: T.Tensor((4, K), in_dtype),
+    ):
+        with T.Kernel(1, 1, threads=128) as (bx, by):
+            smem = T.alloc_shared((4, K), in_dtype)
+            T.annotate_layout({smem: make_layout(smem)})
+            mbar = T.alloc_barrier(1)
+            r0, r1, r2, r3 = Idx[0], Idx[1], Idx[2], Idx[3]
+            if T.shuffle_elect(128):
+                T.mbarrier_expect_tx(mbar, T.tma_gather4_bytes(K, in_dtype))
+                T.tma_gather4(Src, smem, 0, [r0, r1, r2, r3], barrier=mbar)
+                T.barrier_arrive(mbar)
+            T.mbarrier_wait_parity(mbar, 0)
+            T.copy(smem, Out, prefer_instruction="sync")
+
+    return main
+
+
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_gather_blocked_layout_multi_instruction():
+    """A 32B-blocked layout on 128B rows has no XOR on a 4-row tile but a
+    tc-blocked placement: the copy decomposes into four box-sized gather4
+    instructions stepping the column coordinate."""
+    import re
+
+    import torch
+
+    program = gather_readback_program(N=64, K=64, swizzle_kind="32B")
+    kernel = tilelang.compile(
+        program,
+        target="cuda",
+        pass_configs={
+            tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        },
+    )
+    src = kernel.get_kernel_source()
+    assert re.search(r"for \(int \w+ = 0; \w+ < 4; \+\+\w+\) \{\n\s*tl::tma_load_gather4\(", src)
+
+    Src = torch.randn(64, 64, dtype=torch.float16, device="cuda")
+    Idx = torch.tensor([5, 17, 42, 9], dtype=torch.int32, device="cuda")
+    Out = torch.zeros(4, 64, dtype=torch.float16, device="cuda")
+    kernel(Src, Idx, Out)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(Out, Src[Idx.long()])
+
+
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_gather_position_independent_swizzle_is_rejected():
+    """The truncated half-bank atom restarts its XOR pattern per 32-column
+    block, which is not one global hardware swizzle: recovery keeps the 32B
+    mode, whose span truncates the box before the gathered rows."""
+    program = gather_readback_program(N=64, K=64, swizzle_kind="64B")
+    with pytest.raises(Exception, match="4 gathered rows"):
+        tilelang.compile(
+            program,
+            target="cuda",
+            pass_configs={
+                tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+            },
+        )
+
+
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_gather_position_dependent_swizzle_multi_instruction():
+    """A 64B swizzle whose XOR phase advances across the two column blocks
+    (position-dependent, as the hardware applies it) gathers with two
+    phase-shifted instructions."""
+    import re
+
+    import torch
+
+    from tilelang.layout import Layout
+
+    def posdep_halfbank(i, j):
+        c = (j // 8) % 4
+        s = 2 * (j // 32) + i // 2
+        return (j // 32) * 128 + i * 32 + (j % 8) + (c ^ s) * 8
+
+    N, K = 64, 64
+
+    @T.prim_func
+    def main(
+        Src: T.Tensor((N, K), T.float16),
+        Idx: T.Tensor((4,), "int32"),
+        Out: T.Tensor((4, K), T.float16),
+    ):
+        with T.Kernel(1, 1, threads=128) as (bx, by):
+            smem = T.alloc_shared((4, K), T.float16)
+            T.annotate_layout({smem: Layout((4, K), posdep_halfbank)})
+            mbar = T.alloc_barrier(1)
+            r0, r1, r2, r3 = Idx[0], Idx[1], Idx[2], Idx[3]
+            if T.shuffle_elect(128):
+                T.mbarrier_expect_tx(mbar, T.tma_gather4_bytes(K, T.float16))
+                T.tma_gather4(Src, smem, 0, [r0, r1, r2, r3], barrier=mbar)
+                T.barrier_arrive(mbar)
+            T.mbarrier_wait_parity(mbar, 0)
+            for i, j in T.Parallel(4, K):
+                Out[i, j] = smem[i, j]
+
+    kernel = tilelang.compile(
+        main,
+        target="cuda",
+        pass_configs={
+            tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        },
+    )
+    src = kernel.get_kernel_source()
+    assert re.search(r"for \(int \w+ = 0; \w+ < 2; \+\+\w+\) \{\n\s*tl::tma_load_gather4\(", src)
+
+    Src = torch.randn(N, K, dtype=torch.float16, device="cuda")
+    Idx = torch.tensor([5, 17, 42, 9], dtype=torch.int32, device="cuda")
+    Out = torch.zeros(4, K, dtype=torch.float16, device="cuda")
+    kernel(Src, Idx, Out)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(Out, Src[Idx.long()])
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_tma_gather_scatter.py
+++ b/testing/python/language/test_tilelang_language_tma_gather_scatter.py
@@ -238,9 +238,10 @@ def test_gather_blocked_layout_multi_instruction():
 def test_gather_position_independent_swizzle_is_rejected():
     """The truncated half-bank atom restarts its XOR pattern per 32-column
     block, which is not one global hardware swizzle: recovery keeps the 32B
-    mode, whose span truncates the box before the gathered rows."""
+    mode, whose 16-element span admits no box split with 128-byte-aligned
+    instruction steps."""
     program = gather_readback_program(N=64, K=64, swizzle_kind="64B")
-    with pytest.raises(Exception, match="4 gathered rows"):
+    with pytest.raises(Exception, match="cannot be cleanly split"):
         tilelang.compile(
             program,
             target="cuda",

--- a/testing/python/layout/test_tilelang_cute.py
+++ b/testing/python/layout/test_tilelang_cute.py
@@ -917,6 +917,43 @@ def test_swizzle_with_nonzero_base_offset(OFFSET):
     assert mode.offset == OFFSET
 
 
+def test_decoder_nonpow2_quotient_keeps_linear_layout():
+    # Splitting a 768-wide dim at 256 gives the version dim stride 768 =
+    # 256 + 512, a two-bit column. The probe past the non-pow2 quotient
+    # (j = 256) lands on bit 8 of the serialization too, and must not vouch
+    # it as an identity image, or the plain version stride would masquerade
+    # as a swizzle (regression: three-stage wide-linear WS kernels).
+    L = Layout((3, 768), lambda v, j: [v, j // 256, j % 256])
+    mode = cute.ComposedLayout.from_tilelang(L)
+    assert mode is not None and not mode.swizzle.is_swizzled
+
+
+def test_decoder_observes_swizzle_through_odd_extent():
+    # An odd extent (5) has no pow2 sub-mode, but its in-range one-hot probes
+    # (1, 2, 4) still expose the XOR source bits living in that dim: the exact
+    # Sw<2,3,3> over (5,2,64) sources bit 7 from the odd dim and is recovered.
+    mode = cute.ComposedLayout.from_tilelang(_build_swizzled_layout((5, 2, 64), lambda a, b, j: a * 128 + b * 64 + j, 2, 3, 3))
+    assert mode is not None and _swizzle(mode) == (2, 3, 3)
+
+
+def test_decoder_least_width():
+    # (4,64) under an exact Sw<2,3,3> keeps every wider source bit beyond its
+    # 256-element domain: the observed recovery is the minimal width, and
+    # raising the least width to 3 proves (and preserves the plain layout).
+    # A least width at or below the observed one is a no-op; on (8,64) bit 8
+    # is a real, unswizzled row bit, so the wider pattern contradicts the
+    # layout.
+    small = _build_swizzled_layout((4, 64), lambda i, j: i * 64 + j, 2, 3, 3)
+    observed = cute.ComposedLayout.from_tilelang(small)
+    assert _swizzle(observed) == (2, 3, 3)
+    widened = cute.ComposedLayout.from_tilelang(small, least_b_bits=3)
+    assert widened is not None and _swizzle(widened) == (3, 3, 3)
+    assert tvm.ir.structural_equal(widened.layout, observed.layout)
+    assert _swizzle(cute.ComposedLayout.from_tilelang(small, least_b_bits=1)) == (2, 3, 3)
+    big = _build_swizzled_layout((8, 64), lambda i, j: i * 64 + j, 2, 3, 3)
+    assert cute.ComposedLayout.from_tilelang(big, least_b_bits=3) is None
+
+
 @pytest.mark.parametrize(
     "b_bits,m_base,s_shift",
     [(b, m, s) for b in (1, 2, 3) for m in (0, 2, 4) for s in (1, 3, 4) if s >= b],
@@ -1042,6 +1079,87 @@ def test_tma_load_with_explicit_swizzled_layout():
     kernel = tilelang.compile(copy_swizzled, out_idx=[1])
     src = kernel.get_kernel_source()
     assert re.search(r"for \(int \w+ = 0; \w+ < 8; \+\+\w+\) \{\n\s*tl::tma_load\(", src), "expected an 8-iteration TMA load loop"
+
+    ii = torch.arange(M, device="cuda").view(M, 1)
+    jj = torch.arange(N, device="cuda").view(1, N)
+    X = ((ii * N + jj) % 2048).to(torch.float16)
+    ok = kernel(X)
+    assert int(ok.min()) == 1, f"{(ok == 0).sum().item()} shared elements mismatched"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end TMA load through a position-dependent swizzle: the XOR phase
+# advances across the two column blocks, so the second box (at half the
+# pattern period) must land phase-shifted — which the hardware does for free.
+# ---------------------------------------------------------------------------
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_load_with_position_dependent_swizzle():
+    import torch
+    import tilelang
+    import tilelang.language as T
+
+    M, N = 4, 64
+
+    def posdep_halfbank(i, j):
+        c = (j // 8) % 4
+        s = 2 * (j // 32) + i // 2
+        return (j // 32) * 128 + i * 32 + (j % 8) + (c ^ s) * 8
+
+    @T.prim_func
+    def copy_posdep(X: T.Tensor((M, N), "float16"), ok: T.Tensor((M, N), "int32")):
+        with T.Kernel(1, threads=128) as _:
+            S = T.alloc_shared((M, N), "float16")
+            T.annotate_layout({S: Layout((M, N), posdep_halfbank)})
+            T.copy(X, S, prefer_instruction="tma")
+            for i, j in T.Parallel(M, N):
+                ok[i, j] = T.if_then_else(S[i, j] == T.cast((i * N + j) % 2048, "float16"), 1, 0)
+
+    kernel = tilelang.compile(copy_posdep, out_idx=[1])
+    src = kernel.get_kernel_source()
+    assert re.search(r"for \(int \w+ = 0; \w+ < 2; \+\+\w+\) \{\n\s*tl::tma_load\(", src)
+
+    ii = torch.arange(M, device="cuda").view(M, 1)
+    jj = torch.arange(N, device="cuda").view(1, N)
+    X = ((ii * N + jj) % 2048).to(torch.float16)
+    ok = kernel(X)
+    assert int(ok.min()) == 1, f"{(ok == 0).sum().item()} shared elements mismatched"
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_copy_widened_full_tile_and_narrow_slice():
+    """One buffer, two descriptors. (4,64) fp16 under an exact Sw<2,3,3>
+    (64B span): the full-tile load carries a 128-byte contiguous run, so the
+    planner widens the descriptor to the 128B mode (the extra XOR source bit
+    lies beyond the buffer) and issues one box instead of an 8-step rest
+    loop. The 32-column slice load is narrower than even the 64B span, which
+    is legal (PTX bounds the inner box bytes by the span from above only)."""
+    import torch
+    import tilelang
+    import tilelang.language as T
+
+    M, N = 4, 64
+
+    def sw233(i, j):
+        addr = i * N + j
+        return addr ^ ((addr & (3 << 6)) >> 3)
+
+    @T.prim_func
+    def copy_slices(X: T.Tensor((M, N), "float16"), ok: T.Tensor((M, N), "int32")):
+        with T.Kernel(1, threads=128) as _:
+            S = T.alloc_shared((M, N), "float16")
+            T.annotate_layout({S: Layout((M, N), sw233)})
+            T.copy(X, S, prefer_instruction="tma")
+            T.copy(X[0, 0:32], S[1, 0:32], prefer_instruction="tma")
+            for i, j in T.Parallel(M, N):
+                ref = T.if_then_else((i == 1) and (j < 32), X[0, j], X[i, j])
+                ok[i, j] = T.if_then_else(S[i, j] == ref, 1, 0)
+
+    kernel = tilelang.compile(copy_slices, out_idx=[1])
+    src = kernel.get_kernel_source()
+    assert src.count("tl::tma_load(") == 2
+    assert not re.search(r"for [^\n]*\{\n\s*tl::tma_load\(", src)
 
     ii = torch.arange(M, device="cuda").view(M, 1)
     jj = torch.arange(N, device="cuda").view(1, N)

--- a/testing/python/transform/test_tilelang_transform_im2col_fallback.py
+++ b/testing/python/transform/test_tilelang_transform_im2col_fallback.py
@@ -87,6 +87,29 @@ def test_im2col_tall_pixel_block_uses_single_box():
 
 
 @tilelang.testing.requires_cuda
+def test_im2col_single_channel_rejects_pixel_inner_pairing():
+    """With channels == 1 the pixel mode can pair as TMA mode 0; the channel
+    dim then sits at a one-element global stride, which the non-innermost
+    16-byte stride rule rejects before any descriptor is built — never a
+    silently swapped channel/pixel encoding."""
+    N, C, H, W, K = 1, 1, 8, 8, 3
+    block_M, block_K = 16, 1
+
+    @T.prim_func
+    def kern(
+        data: T.Tensor((N, H, W, C), T.float16),
+        out: T.Tensor((block_M, block_K), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            sh = T.alloc_shared((block_M, block_K), T.float16)
+            T.im2col(data, sh, 0, 0, K, 1, 1, 1)
+            T.copy(sh, out)
+
+    with pytest.raises(Exception, match="im2col cannot lower.*16-byte multiple"):
+        _lower_to_cuda_source(kern, "sm_90")
+
+
+@tilelang.testing.requires_cuda
 def test_c2d_im2col_alias_warns_and_uses_new_tileop():
     with pytest.warns(DeprecationWarning, match="T.c2d_im2col is deprecated"):
         func = _make_im2col_kernel(use_deprecated_alias=True)

--- a/testing/python/transform/test_tilelang_transform_im2col_fallback.py
+++ b/testing/python/transform/test_tilelang_transform_im2col_fallback.py
@@ -6,10 +6,10 @@ import tilelang.language as T
 import tilelang.testing
 
 
-def _make_im2col_kernel(use_deprecated_alias=False):
-    N, C, H, W, F, K = 1, 32, 8, 8, 32, 3
+def _make_im2col_kernel(use_deprecated_alias=False, channels=32, block_K=32, block_M=16, hw=8):
+    N, C, H, W, F, K = 1, channels, hw, hw, 32, 3
     S, D, P = 1, 1, 1
-    block_M, block_N, block_K = 16, 32, 32
+    block_N = 32
     KH, KW = K, K
     OH = (H + 2 * P - D * (K - 1) - 1) // S + 1
     OW = (W + 2 * P - D * (K - 1) - 1) // S + 1
@@ -63,6 +63,27 @@ def test_im2col_uses_simt_fallback_before_hopper():
 def test_im2col_uses_tma_on_hopper():
     src = _lower_to_cuda_source(_make_im2col_kernel(), "sm_90")
     assert "tma_load_im2col" in src
+
+
+@tilelang.testing.requires_cuda
+def test_im2col_wide_channel_block_uses_multiple_boxes():
+    """128 fp16 channels exceed the 64-element full-bank box, so the copy
+    issues two tma_load_im2col instructions stepping the channel coordinate."""
+    import re
+
+    src = _lower_to_cuda_source(_make_im2col_kernel(channels=128, block_K=128), "sm_90")
+    assert re.search(r"for \(int \w+ = 0; \w+ < 2; \+\+\w+\) \{\n\s*tl::tma_load_im2col\(", src)
+
+
+@tilelang.testing.requires_cuda
+def test_im2col_tall_pixel_block_uses_single_box():
+    """An im2col TensorMap accesses up to 1024 pixels per column (unlike the
+    256-element tiled box cap), so a 320-pixel block is one instruction."""
+    import re
+
+    src = _lower_to_cuda_source(_make_im2col_kernel(block_M=320, hw=20), "sm_90")
+    assert "tma_load_im2col" in src
+    assert not re.search(r"for [^\n]*\{\n\s*tl::tma_load_im2col\(", src)
 
 
 @tilelang.testing.requires_cuda

--- a/tilelang/layout/cute.py
+++ b/tilelang/layout/cute.py
@@ -297,8 +297,8 @@ class ComposedLayout(Node, Scriptable):
         return _cute_ffi_api.composed_layout_recast(self, int(old_bits), int(new_bits))
 
     @staticmethod
-    def from_tilelang(layout, buffer: BufferLikeType = None) -> ComposedLayout | None:
-        mode = _cute_ffi_api.composed_layout_from_tilelang(layout)
+    def from_tilelang(layout, buffer: BufferLikeType = None, least_b_bits: int | None = None) -> ComposedLayout | None:
+        mode = _cute_ffi_api.composed_layout_from_tilelang(layout, least_b_bits)
         if buffer is None or mode is None:
             return mode
         from tilelang.layout.swizzle import _get_buffer_info


### PR DESCRIPTION
Every descriptor-based TMA path (bulk copy, atomic add, gather4/scatter4, im2col) now shares one CuTe-algebra box decomposition. Boxes follow the driver contract (inner box bytes at most the swizzle span, per-dim caps), and the recovered swizzle is widened on demand under an equivalence proof, so general annotated layouts -- including phase-shifted swizzles -- lower correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Unified descriptor-based TMA lowering for bulk copy, atomic add, gather4/scatter4, and im2col through `AnalyzeTMABulkCopy` and `TMABulkCopyPlan`.
- Added CuTe-algebra box decomposition with driver limits, per-dimension caps, alignment-aware splitting, rest handling, and shared instruction emission.
- Added swizzle-width recovery and widening through `least_b_bits`, including support for phase-shifted swizzles.
- Added TMA alignment and im2col pixel-limit constants.
- Updated TMA context, synchronization, and fence-proxy handling for gather4/scatter4.
- Added CUDA tests for box splitting, swizzle recovery, gather/scatter lowering, and im2col fallback behavior.

## C++ style / lint notes

- This PR changes C++ implementation and public C++ headers, but the provided changes do not indicate updates to rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step is relevant because the PR adds public APIs and changes FFI-facing signatures.
- Any TLCPP003/TLCPP004 findings should remain advisory unless they identify a concrete API, FFI, or maintainability risk.
- Correctness, build, and test failures remain separate from warning-only style findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->