### PR TITLE
[Docs] Add Sunrise-AI TANG to platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ TileLang requires Python 3.10 or newer. The default `auto` target detects CUDA, 
 | MetaX MACA | `maca` | MetaX C500 and C600 | Ecosystem | Developed in [tilelang-metax](https://github.com/tile-ai/tilelang-metax); requires the MACA software stack. |
 | Moore Threads MUSA | `musa` | S5000, S4000, and M1000 | Ecosystem | Developed in [tilelang-musa](https://github.com/tile-ai/tilelang-musa) and released independently. |
 | HYGON | `hcu` | Linux; BW1000, BW1100, BW150 and K100_AI | Ecosystem | Developed in [tilelang-hygon](https://github.com/tile-ai/tilelang-hygon); requires the DTK software stack. |
+| Sunrise-AI TANG | `tang` | Sunrise S2 and S3 | Ecosystem | Developed in [tilelang-sunrise](https://github.com/tile-ai/tilelang-sunrise). The TANG software stack is required. |
 
 Prebuilt wheels are published for Linux x86-64/AArch64, Windows x86-64, and macOS arm64. Ecosystem adapters live in separate repositories, are not included in the main TileLang release wheels, and may follow different compatibility schedules. See the [target guide](https://tilelang.com/get_started/targets.html) for target syntax, architecture options, and backend-specific notes, or the corresponding adapter repository for installation and tested-device details.
 


### PR DESCRIPTION
## Summary

- Add Sunrise-AI TANG to the Platform and Backend Support table
- Document the `tang` target for Sunrise S2 and S3 with Ecosystem support
- Link the TileLang-Sunrise repository and note the required TANG software stack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added Sunrise-AI TANG to the platform and backend support table.
- Documented the `tang` target for Sunrise S2 and S3 hardware.
- Linked the external `tilelang-sunrise` repository.
- Noted the required TANG software stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->