### PR TITLE
[CUDA] Wrap ldmatrix source offsets within shared-memory regions

### DIFF
--- a/testing/python/kernel/test_tilelang_kernel_gemm_sm75.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemm_sm75.py
@@ -1,8 +1,11 @@
+import pytest
 import torch
 
 import tilelang
 import tilelang.language as T
 import tilelang.testing
+from tilelang import tvm
+from tvm.tirx.stmt_functor import post_order_visit
 
 
 def _make_gemm_kernel(M, N, K, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype):
@@ -132,6 +135,112 @@ def test_sm75_int4_gemm_uses_m8n8k32_and_matches_torch():
     ref = (a.cpu().to(torch.int32) @ b.cpu().to(torch.int32).T).to(device="cuda")
 
     tilelang.testing.torch_assert_close(c, ref, rtol=0, atol=0)
+
+
+def _make_pipelined_gemm_kernel(
+    M, N, K, block_M, block_N, block_K, num_stages, transpose_B, in_dtype=T.float16, out_dtype=T.float32, accum_dtype=T.float32
+):
+    B_shape = (N, K) if transpose_B else (K, N)
+    B_shared_shape = (block_N, block_K) if transpose_B else (block_K, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), in_dtype),
+        B: T.Tensor(B_shape, in_dtype),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), in_dtype)
+            B_shared = T.alloc_shared(B_shared_shape, in_dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            T.clear(C_local)
+            for ko in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                T.copy(A[by * block_M, ko * block_K], A_shared)
+                if transpose_B:
+                    T.copy(B[bx * block_N, ko * block_K], B_shared)
+                else:
+                    T.copy(B[ko * block_K, bx * block_N], B_shared)
+                T.gemm(A_shared, B_shared, C_local, transpose_B=transpose_B)
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(7, 5)
+@pytest.mark.parametrize("transpose_B", [True, False])
+def test_sm75_f16_gemm_pipelined_multi_stage_matches_torch(transpose_B):
+    M = N = K = 128
+    kernel = tilelang.compile(
+        _make_pipelined_gemm_kernel(M, N, K, 64, 64, 32, 2, transpose_B),
+        target="cuda",
+        out_idx=[2],
+    )
+    a = torch.randn((M, K), device="cuda", dtype=torch.float16)
+    b_shape = (N, K) if transpose_B else (K, N)
+    b = torch.randn(b_shape, device="cuda", dtype=torch.float16)
+    c = kernel(a, b)
+    ref = a.float() @ (b.float().T if transpose_B else b.float())
+
+    tilelang.testing.torch_assert_close(c, ref, rtol=1e-2, atol=1e-2, max_mismatched_ratio=0.01)
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    "in_dtype, accum_dtype, block_K, transpose_B",
+    [
+        (T.float16, T.float32, 32, True),
+        (T.float16, T.float32, 32, False),
+        (T.int8, T.int32, 64, True),
+        (T.int4, T.int32, 64, True),
+    ],
+)
+def test_sm75_ldmatrix_shared_reads_stay_in_bounds(in_dtype, accum_dtype, block_K, transpose_B):
+    # Cross-compiles for sm_75, so it guards the Turing address math on any
+    # CUDA runner. The ldmatrix lane maps step past the shared tile unless the
+    # emitter wraps them (see mma_macro_generator.py).
+    M = N = K = 128
+    kernel = tilelang.compile(
+        _make_pipelined_gemm_kernel(M, N, K, 64, 64, block_K, 0, transpose_B, in_dtype, accum_dtype, accum_dtype),
+        target={"kind": "cuda", "arch": "sm_75"},
+        out_idx=[2],
+    )
+    (func,) = kernel.artifact.device_mod.functions.values()
+
+    analyzer = tvm.arith.Analyzer()
+    buffer_sizes = {}
+    ldmatrix_calls = []
+
+    def visit(node):
+        if isinstance(node, tvm.tirx.AttrStmt) and str(node.attr_key) == "thread_extent":
+            analyzer.update(node.node.var, tvm.arith.ConstIntBound(0, int(node.value) - 1))
+        elif isinstance(node, tvm.tirx.For):
+            analyzer.update(
+                node.loop_var,
+                tvm.arith.ConstIntBound(int(node.min), int(node.min) + int(node.extent) - 1),
+            )
+        elif isinstance(node, (tvm.tirx.AllocBuffer, tvm.tirx.DeclBuffer)):
+            size = 1
+            for extent in node.buffer.shape:
+                size *= int(extent)
+            buffer_sizes[node.buffer.data] = size
+        elif isinstance(node, tvm.tirx.Call) and str(getattr(node.op, "name", "")) == "tl.ptx_ldmatrix":
+            ldmatrix_calls.append(node)
+
+    post_order_visit(func.body, visit)
+    assert ldmatrix_calls, "expected ldmatrix lowering for sm_75"
+
+    for call in ldmatrix_calls:
+        src = call.args[2]
+        assert str(src.op.name) == "tirx.tvm_access_ptr"
+        data, offset, extent = src.args[1], src.args[2], int(src.args[3])
+        assert data in buffer_sizes, f"ldmatrix source {data.name} has no visible allocation"
+        bound = analyzer.const_int_bound(offset)
+        assert bound.min_value >= 0
+        assert bound.max_value + extent <= buffer_sizes[data], (
+            f"ldmatrix reads past the shared tile: offset up to {bound.max_value} + extent {extent} exceeds {buffer_sizes[data]} elements"
+        )
 
 
 if __name__ == "__main__":

--- a/tilelang/cuda/intrinsics/macro/mma_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_macro_generator.py
@@ -348,6 +348,8 @@ class TensorCoreIntrinEmitter:
         A_base0 = A_region.region[-2].min
         A_base1 = A_region.region[-1].min
         A_other = [r.min for r in A_region.region[:-2]]
+        A_ext0 = A_region.region[-2].extent
+        A_ext1 = A_region.region[-1].extent
         A_stride_last = A_buf.shape[-1]
 
         @T.macro
@@ -367,11 +369,12 @@ class TensorCoreIntrinEmitter:
 
                 if ldmatrix_available:
                     row_off, col_off = get_ldmatrix_offset("A", tx, 0, stride, a_dtype, a_transposed)
-                    src_indices = (
-                        tuple(A_other) + (A_base0 + wk + row_off, A_base1 + wi + col_off)
-                        if a_transposed
-                        else tuple(A_other) + (A_base0 + wi + row_off, A_base1 + wk + col_off)
-                    )
+                    rel_row, rel_col = (wk + row_off, wi + col_off) if a_transposed else (wi + row_off, wk + col_off)
+                    # Some lane maps cross the region boundary on the final
+                    # micro tile. Wrap the row-major in-region offset so column
+                    # overflow carries into the row.
+                    lin = T.floormod(rel_row * A_ext1 + rel_col, A_ext0 * A_ext1)
+                    src_indices = tuple(A_other) + (A_base0 + lin // A_ext1, A_base1 + T.floormod(lin, A_ext1))
                     T.ptx_ldmatrix(
                         T.bool(trans),
                         4,
@@ -444,6 +447,8 @@ class TensorCoreIntrinEmitter:
         B_base0 = B_region.region[-2].min
         B_base1 = B_region.region[-1].min
         B_other = [r.min for r in B_region.region[:-2]]
+        B_ext0 = B_region.region[-2].extent
+        B_ext1 = B_region.region[-1].extent
         B_stride_last = B_buf.shape[-1]
         replicate_b = self.n_dim == 16
         # ldmatrix cannot be used for int8 + trans case.
@@ -484,11 +489,10 @@ class TensorCoreIntrinEmitter:
                 if ldmatrix_available:
                     num = 4 if replicate_b else 2
                     row_off, col_off = get_ldmatrix_offset("B", tx, 0, stride, b_dtype, b_transposed)
-                    src_indices = (
-                        tuple(B_other) + (B_base0 + wi + row_off, B_base1 + wk + col_off)
-                        if b_transposed
-                        else tuple(B_other) + (B_base0 + wk + row_off, B_base1 + wi + col_off)
-                    )
+                    rel_row, rel_col = (wi + row_off, wk + col_off) if b_transposed else (wk + row_off, wi + col_off)
+                    # Apply the same region-local linear wrap as ldmatrix_a.
+                    lin = T.floormod(rel_row * B_ext1 + rel_col, B_ext0 * B_ext1)
+                    src_indices = tuple(B_other) + (B_base0 + lin // B_ext1, B_base1 + T.floormod(lin, B_ext1))
                     T.ptx_ldmatrix(
                         T.bool(trans),
                         num,


### PR DESCRIPTION
## Summary

The native SM75 MMA GEMM paths for fp16, int8, uint8, and int4 have crashed at runtime since #2836:

```text
CUDA_ERROR_ILLEGAL_ADDRESS
========= Invalid __shared__ read of size 16 bytes
=========     at tl::ptx_ldmatrix_x2 ... ldsm.h:22
```

All five existing cases in `test_tilelang_kernel_gemm_sm75.py` fail on a Turing GPU. These runtime tests require compute capability 7.5, so the regression only shows up on Turing hardware.

## Cause

Some ldmatrix lane maps step beyond the final SM75 MMA micro-tile, and column overflow must carry into the next row.

Before #2836, `LowerTileOp` linearized the source indices and optional offset before converting them back to multidimensional coordinates. This normalized the addresses as a side effect.

## Fix

Wrap each complete row-major source offset within its operand region in `ldmatrix_a` and `ldmatrix_b` before rebuilding the source coordinates.

Leading dimensions, including the pipeline-stage dimension, remain untouched, so wrapping cannot cross into another buffer version. Column overflow is carried into the row before the complete region-local offset is wrapped.

When coordinates are provably in range, the simplifier removes the additional expressions. SM70 and SM80 generated sources remain byte-identical, while the SM75 addresses match the pre-#2836 mapping.

## Tests

* The five existing SM75 runtime cases pass again, and compute-sanitizer reports no errors.
* Added a two-stage pipelined SM75 fp16 GEMM in both `transpose_B` modes, verifying that wrapping remains within the current buffer version.
* Added `test_sm75_ldmatrix_shared_reads_stay_in_bounds`, which cross-compiles explicitly for `sm_75` and uses `tvm.arith` to prove that every lowered ldmatrix source access remains within its shared buffer. It runs on any CUDA runner and covers fp16 in both transpose modes, int8, and int4.

Verified locally on `sm_75` with CUDA 12.4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixes illegal shared-memory accesses in SM75 MMA GEMM paths for fp16, int8, uint8, and int4.
- Wraps row-major `ldmatrix_a` and `ldmatrix_b` offsets within each operand region.
- Carries column overflow into the next row while preserving leading dimensions and pipeline-stage boundaries.
- Adds multi-stage pipelined SM75 fp16 GEMM tests for both `transpose_B` modes.
- Adds lowered-offset bounds checks for fp16, int8, and int4 shared-memory accesses.
- Confirms SM70 and SM80 generated sources remain byte-identical.

## Testing

- Verified runtime GEMM results against PyTorch.
- Cross-compiled for `sm_75`.
- Verified lowered `tl.ptx_ldmatrix` reads remain within shared-memory tile bounds.
- Validated on CUDA 12.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->