### PR TITLE
[ROCm] Remove the Composable Kernel dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "3rdparty/tvm"]
 	path = 3rdparty/tvm
 	url = https://github.com/TileLang/tvm
-[submodule "3rdparty/composable_kernel"]
-	path = 3rdparty/composable_kernel
-	url = https://github.com/ROCm/composable_kernel

--- a/docs/deeplearning_operators/matmul.md
+++ b/docs/deeplearning_operators/matmul.md
@@ -197,7 +197,7 @@ T.gemm(A_shared, B_shared, C_local)
 ```
 
 - A single call that performs a tile-level matrix multiplication using the specified buffers.
-- Under the hood, for NVIDIA targets, it can use CUTLASS/Cute or WMMA instructions. On AMD GPUs, TileLang uses a separate HIP or composable kernel approach.
+- Under the hood, for NVIDIA targets, it can use CUTLASS/Cute or WMMA instructions. On AMD GPUs, TileLang emits HIP code built on MFMA compiler intrinsics.
 
 6. **Copying Back Results**:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,9 +132,6 @@ include = [
     # CUTLASS
     "3rdparty/cutlass/include",
     "3rdparty/cutlass/tools",
-    # Composable Kernel
-    "3rdparty/composable_kernel/include",
-    "3rdparty/composable_kernel/library",
     # Vendored HIP headers (build-time only) so source builds work on hosts
     # without a ROCm install. Not mapped into the wheel at runtime.
     "3rdparty/hip-headers/include",
@@ -164,9 +161,6 @@ tilelang = "tilelang"
 # CUTLASS
 "tilelang/3rdparty/cutlass/include" = "3rdparty/cutlass/include"
 "tilelang/3rdparty/cutlass/tools" = "3rdparty/cutlass/tools"
-# Composable Kernel
-"tilelang/3rdparty/composable_kernel/include" = "3rdparty/composable_kernel/include"
-"tilelang/3rdparty/composable_kernel/library" = "3rdparty/composable_kernel/library"
 
 
 

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "atomic.h"
-#include <ck_tile/core.hpp>
 #include <hip/amd_detail/amd_warp_functions.h>
 #include <hip/hip_bf16.h>
 #include <hip/hip_fp16.h>
@@ -183,6 +182,16 @@ __device__ __forceinline__ float16_t __habs(float16_t a) {
 }
 
 namespace tl {
+
+// Scalar max/min. The float/double overloads use the fmax/fmin builtins so
+// that NaN inputs follow IEEE semantics (and the compiler can fuse v_max3).
+template <typename T> TL_DEVICE T max(T x, T y) { return x > y ? x : y; }
+TL_DEVICE float max(float x, float y) { return __builtin_fmaxf(x, y); }
+TL_DEVICE double max(double x, double y) { return __builtin_fmax(x, y); }
+
+template <typename T> TL_DEVICE T min(T x, T y) { return x < y ? x : y; }
+TL_DEVICE float min(float x, float y) { return __builtin_fminf(x, y); }
+TL_DEVICE double min(double x, double y) { return __builtin_fmin(x, y); }
 
 // Packed x2 element-wise math helpers (HIP scalar fallbacks)
 //

--- a/src/tl_templates/hip/copy.h
+++ b/src/tl_templates/hip/copy.h
@@ -11,7 +11,26 @@ using u32 = std::uint32_t;
 
 using index_t = u32;
 
-using ck_tile::int32x4_t;
+using int32x4_t = int32_t __attribute__((ext_vector_type(4)));
+
+// Third dword of the AMD buffer resource descriptor (V#): data format /
+// config bits, which differ per architecture generation.
+#ifndef __HIP_DEVICE_COMPILE__ // host pass
+#define TL_BUFFER_RESOURCE_3RD_DWORD 0xffffffff
+#elif defined(__gfx803__) || defined(__gfx900__) || defined(__gfx906__) ||     \
+    defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx942__) ||       \
+    defined(__gfx950__) || defined(__gfx9_4_generic__)
+#define TL_BUFFER_RESOURCE_3RD_DWORD 0x00020000
+#elif defined(__gfx1030__) || defined(__gfx1031__) || defined(__gfx1032__) ||  \
+    defined(__gfx1034__) || defined(__gfx1035__) || defined(__gfx1036__) ||    \
+    defined(__gfx10_3_generic__)
+#define TL_BUFFER_RESOURCE_3RD_DWORD 0x31014000
+#elif defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) ||  \
+    defined(__gfx1103__) || defined(__gfx1150__) || defined(__gfx1151__) ||    \
+    defined(__gfx1152__) || defined(__gfx11_generic__) ||                      \
+    defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx12_generic__)
+#define TL_BUFFER_RESOURCE_3RD_DWORD 0x31004000
+#endif
 
 struct __attribute__((packed)) buffer_resource {
   const void *ptr;
@@ -19,9 +38,9 @@ struct __attribute__((packed)) buffer_resource {
   uint32_t config;
 };
 
-CK_TILE_DEVICE int32x4_t make_wave_buffer_resource(const void *ptr,
-                                                   uint32_t size = 0xffffffff) {
-  buffer_resource res{ptr, size, CK_TILE_BUFFER_RESOURCE_3RD_DWORD};
+TL_DEVICE int32x4_t make_wave_buffer_resource(const void *ptr,
+                                              uint32_t size = 0xffffffff) {
+  buffer_resource res{ptr, size, TL_BUFFER_RESOURCE_3RD_DWORD};
   int32x4_t r = __builtin_bit_cast(int32x4_t, res);
   r.x = __builtin_amdgcn_readfirstlane(r.x);
   r.y = __builtin_amdgcn_readfirstlane(r.y);
@@ -62,8 +81,8 @@ template <int N = 0> TL_DEVICE void cp_async_wait() {
 }
 
 template <bool pre_nop = false>
-CK_TILE_DEVICE void async_buffer_load_dword_v(void *smem, int32x4_t rsrc,
-                                              index_t voffset) {
+TL_DEVICE void async_buffer_load_dword_v(void *smem, int32x4_t rsrc,
+                                         index_t voffset) {
   auto const lds_ptr_sgpr =
       __builtin_amdgcn_readfirstlane((reinterpret_cast<uintptr_t>(smem)));
   asm volatile("s_mov_b32 m0, %0; \n\t"
@@ -76,8 +95,8 @@ CK_TILE_DEVICE void async_buffer_load_dword_v(void *smem, int32x4_t rsrc,
 // buffer_load_dwordx4 ... lds bypasses VGPRs entirely, giving 4x the
 // bandwidth of the 32-bit path and overlapping with MFMA computation.
 #if defined(__gfx950__)
-CK_TILE_DEVICE void async_buffer_load_dwordx4_v(void *smem, int32x4_t rsrc,
-                                                index_t voffset) {
+TL_DEVICE void async_buffer_load_dwordx4_v(void *smem, int32x4_t rsrc,
+                                           index_t voffset) {
   auto const lds_ptr_sgpr =
       __builtin_amdgcn_readfirstlane((reinterpret_cast<uintptr_t>(smem)));
   asm volatile(

--- a/src/tl_templates/hip/ldsm.h
+++ b/src/tl_templates/hip/ldsm.h
@@ -14,7 +14,7 @@ namespace tl {
 // Uses __builtin_amdgcn_ds_read_tr16_b64_v4f16 (LLVM builtin) instead of
 // inline assembly because ROCm <= 7.2 assembler does not yet recognise the
 // ds_read_tr16_b64 mnemonic even though the hardware supports it.
-CK_TILE_DEVICE uint2 ds_read_tr16_b64(const void *smem_ptr) {
+TL_DEVICE uint2 ds_read_tr16_b64(const void *smem_ptr) {
   typedef __attribute__((__vector_size__(4 * sizeof(__fp16)))) __fp16 fp16x4_t;
   // C-style cast: void* → LDS fp16x4_t* (required by the LLVM builtin
   // signature)
@@ -32,7 +32,7 @@ CK_TILE_DEVICE uint2 ds_read_tr16_b64(const void *smem_ptr) {
 //
 // Uses __builtin_amdgcn_ds_read_tr8_b64_v2i32 (LLVM builtin) for the same
 // reason as ds_read_tr16_b64 above.
-CK_TILE_DEVICE uint2 ds_read_tr8_b64(const void *smem_ptr) {
+TL_DEVICE uint2 ds_read_tr8_b64(const void *smem_ptr) {
   typedef __attribute__((__vector_size__(2 * sizeof(int)))) int i32x2_t;
   i32x2_t v = __builtin_amdgcn_ds_read_tr8_b64_v2i32(
       (__attribute__((address_space(3))) i32x2_t *)(smem_ptr));

--- a/src/tl_templates/hip/reduce.h
+++ b/src/tl_templates/hip/reduce.h
@@ -12,13 +12,13 @@ struct SumOp {
 
 struct MaxOp {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
-    return ck_tile::max(x, y);
+    return tl::max(x, y);
   }
 };
 
 struct MinOp {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
-    return ck_tile::min(x, y);
+    return tl::min(x, y);
   }
 };
 

--- a/src/tl_templates/hip/scan.h
+++ b/src/tl_templates/hip/scan.h
@@ -12,7 +12,7 @@ struct ScanSumOp {
 
 struct ScanMaxOp {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
-    return ck_tile::max(x, y);
+    return tl::max(x, y);
   }
 };
 

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -38,8 +38,6 @@ def resolve_pass_profile_threshold_ms(pass_configs: Mapping[object, object], key
 # SETUP ENVIRONMENT VARIABLES
 CUTLASS_NOT_FOUND_MESSAGE = "CUTLASS is not installed or found in the expected path"
 ", which may lead to compilation bugs when utilize tilelang backend."
-COMPOSABLE_KERNEL_NOT_FOUND_MESSAGE = "Composable Kernel is not installed or found in the expected path"
-", which may lead to compilation bugs when utilize tilelang backend."
 TL_TEMPLATE_NOT_FOUND_MESSAGE = "TileLang is not installed or found in the expected path"
 ", which may lead to compilation bugs when utilize tilelang backend."
 TVM_LIBRARY_NOT_FOUND_MESSAGE = "TVM is not installed or found in the expected path"
@@ -345,7 +343,6 @@ class Environment:
 
     # External library include paths
     CUTLASS_INCLUDE_DIR = EnvVar("TL_CUTLASS_PATH", None)
-    COMPOSABLE_KERNEL_INCLUDE_DIR = EnvVar("TL_COMPOSABLE_KERNEL_PATH", None)
 
     # TVM integration
     TVM_PYTHON_PATH = EnvVar("TVM_IMPORT_PYTHON_PATH", None)
@@ -639,14 +636,6 @@ if os.environ.get("TL_CUTLASS_PATH", None) is None:
     else:
         logger.warning(CUTLASS_NOT_FOUND_MESSAGE)
 
-# Initialize COMPOSABLE_KERNEL paths
-if os.environ.get("TL_COMPOSABLE_KERNEL_PATH", None) is None:
-    ck_inc_path = os.path.join(THIRD_PARTY_ROOT, "composable_kernel", "include")
-    if os.path.exists(ck_inc_path):
-        os.environ["TL_COMPOSABLE_KERNEL_PATH"] = env.COMPOSABLE_KERNEL_INCLUDE_DIR = ck_inc_path
-    else:
-        logger.warning(COMPOSABLE_KERNEL_NOT_FOUND_MESSAGE)
-
 # Initialize TL_TEMPLATE_PATH
 if os.environ.get("TL_TEMPLATE_PATH", None) is None:
     tl_template_path = os.path.join(THIRD_PARTY_ROOT, "..", "src")
@@ -657,6 +646,5 @@ if os.environ.get("TL_TEMPLATE_PATH", None) is None:
 
 # Export static variables after initialization.
 CUTLASS_INCLUDE_DIR = env.CUTLASS_INCLUDE_DIR
-COMPOSABLE_KERNEL_INCLUDE_DIR = env.COMPOSABLE_KERNEL_INCLUDE_DIR
 TILELANG_TEMPLATE_PATH = env.TILELANG_TEMPLATE_PATH
 TILELANG_HIP_SAVE_TEMP_FILES = env.TILELANG_HIP_SAVE_TEMP_FILES

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -121,7 +121,7 @@ class LibraryGenerator:
         elif is_hip_target(target):
             from tilelang.rocm.target import target_get_mcpu
 
-            from tilelang.env import COMPOSABLE_KERNEL_INCLUDE_DIR, TILELANG_HIP_SAVE_TEMP_FILES
+            from tilelang.env import TILELANG_HIP_SAVE_TEMP_FILES
 
             src = tempfile.NamedTemporaryFile(mode="w", suffix=".cpp", delete=False)  # noqa: SIM115
             libpath = src.name.replace(".cpp", ".so")
@@ -135,9 +135,6 @@ class LibraryGenerator:
                 "--shared",
                 src.name,
                 "-Rpass-analysis=kernel-resource-usage",
-            ]
-            command += [
-                "-I" + COMPOSABLE_KERNEL_INCLUDE_DIR,
             ]
             if TILELANG_HIP_SAVE_TEMP_FILES != "0":
                 command += ["--save-temps", "-g"]

--- a/tilelang/rocm/backend.py
+++ b/tilelang/rocm/backend.py
@@ -5,7 +5,7 @@ from tilelang.backend.host_codegen import STANDARD_HOST_CODEGENS
 from tilelang.backend.pass_pipeline import PassPipeline
 from tilelang.backend.module import BackendModule, register_backend
 from tilelang.contrib import hipcc
-from tilelang.env import COMPOSABLE_KERNEL_INCLUDE_DIR, TILELANG_TEMPLATE_PATH
+from tilelang.env import TILELANG_TEMPLATE_PATH
 from tilelang.rocm.target import target_get_mcpu
 
 from . import codegen, execution_backend, pipeline
@@ -21,7 +21,6 @@ def tilelang_callback_hip_compile(code, target):
         options=[
             "-std=c++17",
             "-I" + TILELANG_TEMPLATE_PATH,
-            "-I" + COMPOSABLE_KERNEL_INCLUDE_DIR,
         ],
         verbose=False,
     )


### PR DESCRIPTION
## Summary

TileLang's only uses of Composable Kernel were a handful of lightweight `ck_tile` utilities in the HIP runtime templates — the type `int32x4_t`, the `CK_TILE_DEVICE` macro, the `CK_TILE_BUFFER_RESOURCE_3RD_DWORD` constant, and `ck_tile::max/min`. GEMM on AMD already goes through `__builtin_amdgcn_mfma_*` intrinsics directly, so no CK device kernels were ever involved. This PR inlines local equivalents and removes the dependency entirely.

### Template changes (`src/tl_templates/hip/`)

- **copy.h**: define `int32x4_t` locally (`ext_vector_type(4)`, needed for `.x/.y/.z/.w` access) and expand CK's arch-grouping macros into an explicit per-gfx `TL_BUFFER_RESOURCE_3RD_DWORD` (`gfx9* = 0x00020000`, `gfx103* = 0x31014000`, `gfx11*/gfx12* = 0x31004000`, host pass `0xffffffff` — matching CK's `config.hpp`)
- **common.h**: drop `#include <ck_tile/core.hpp>`; add `tl::max/min` scalar helpers whose float/double overloads use `__builtin_fmaxf/fminf` to preserve the IEEE NaN semantics (and `v_max3` fusion opportunity) that `ck_tile::max/min` provided
- **ldsm.h / reduce.h / scan.h**: `CK_TILE_DEVICE` → `TL_DEVICE`, `ck_tile::max/min` → `tl::max/min`

### Build / packaging

- `tilelang/env.py`: remove the `TL_COMPOSABLE_KERNEL_PATH` plumbing
- `tilelang/rocm/backend.py`, `tilelang/jit/adapter/libgen.py`: drop the CK `-I` hipcc flags (the template include path was already added separately)
- `pyproject.toml`: stop vendoring `3rdparty/composable_kernel/{include,library}` into the sdist and wheel — a real size win
- `.gitmodules`: remove the submodule, so fresh clones no longer fetch CK

## Testing

- `import tilelang` and an end-to-end CUDA JIT kernel (compile + numerical check, cache disabled) pass; `TL_COMPOSABLE_KERNEL_PATH` no longer appears in the environment
- The replacement constructs (vector type, buffer-resource macro, async buffer loads, max/min overloads) were syntax-checked as HIP device code with clang 18 for gfx942, gfx90a, and gfx1100, confirming the buffer-resource dword resolves to the correct per-arch value
- No ROCm machine was available locally, so AMD CI should be the final gate for HIP compile + kernel correctness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed the Composable Kernel submodule and packaging support.
- Replaced `ck_tile` utilities with local HIP equivalents for vector types, buffer resources, device annotations, and `max`/`min` helpers.
- Removed Composable Kernel environment and compiler include-path handling.
- Updated AMD GEMM documentation to describe MFMA compiler intrinsics.

## Validation

- Ran CUDA import and JIT checks.
- Ran HIP syntax checks with clang 18 for gfx942, gfx90a, and gfx1100.
- AMD CI remains required for final HIP compilation and kernel-correctness validation.

## C++ style / lint notes

- The PR changes C++ headers but does not change the rules in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step applies.
- Any TLCPP003/TLCPP004 findings are advisory and do not block the PR without a clear API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->