### PR TITLE
[Lang] Reject non-positive arrive_count in alloc_barrier and alloc_cluster_barrier

### DIFF
--- a/testing/python/language/test_tilelang_language_alloc.py
+++ b/testing/python/language/test_tilelang_language_alloc.py
@@ -236,5 +236,24 @@ def test_alloc_global():
     run_alloc_global_eagerjit(1024, 128, T.float16)
 
 
+def alloc_barrier_kernel(arrive_count):
+
+    @T.prim_func
+    def main(A: T.Tensor((128,), T.float16)):
+        with T.Kernel(1, threads=128):
+            bar = T.alloc_barrier(arrive_count)  # noqa: F841
+
+    return main
+
+
+def test_alloc_barrier_rejects_non_positive_arrive_count():
+    import pytest
+
+    for bad in (0, -5, [128, 0]):
+        with pytest.raises(ValueError, match="arrive_count must be at least 1"):
+            alloc_barrier_kernel(bad)
+    alloc_barrier_kernel(128)  # valid count still traces
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/tilelang/language/allocate.py
+++ b/tilelang/language/allocate.py
@@ -178,7 +178,9 @@ def alloc_barrier(arrive_count: int | list[int]) -> Buffer:
     """Allocate a barrier buffer.
 
     Args:
-        arrive_count (int | list[int]): The number of threads that need to arrive at each barrier
+        arrive_count (int | list[int]): The number of threads that need to arrive at each barrier.
+            Every count must be at least 1: an mbarrier arrive count of 0 has no defined meaning,
+            and a negative count would be reinterpreted as a garbage unsigned value at init.
 
     Returns:
         T.Buffer: A TVM buffer object allocated as a barrier
@@ -188,6 +190,9 @@ def alloc_barrier(arrive_count: int | list[int]) -> Buffer:
     >>> mbar = alloc_barrier(128)  # allocate a barrier with arrive count 128
     >>> mbars = alloc_barrier([128] * n)  # allocate n barriers with the same arrive count 128
     """
+    counts = [arrive_count] if isinstance(arrive_count, int) else list(arrive_count)
+    if any(count <= 0 for count in counts):
+        raise ValueError(f"alloc_barrier: arrive_count must be at least 1, got {counts}")
     # Normalize to list
     if isinstance(arrive_count, int):
         arrive_count = [arrive_count]
@@ -206,11 +211,15 @@ def alloc_cluster_barrier(arrive_count: int | list[int]) -> Buffer:
     """Allocate a cluster barrier buffer.
 
     Args:
-        arrive_count (int | list[int]): The number of threads that need to arrive at each barrier
+        arrive_count (int | list[int]): The number of threads that need to arrive at each barrier.
+            Every count must be at least 1, as for `alloc_barrier`.
 
     Returns:
         T.Buffer: A TVM buffer object allocated as a cluster barrier
     """
+    counts = [arrive_count] if isinstance(arrive_count, int) else list(arrive_count)
+    if any(count <= 0 for count in counts):
+        raise ValueError(f"alloc_cluster_barrier: arrive_count must be at least 1, got {counts}")
     # Normalize to list
     if isinstance(arrive_count, int):
         arrive_count = [arrive_count]


### PR DESCRIPTION
Fixes #3030.

`alloc_barrier` and `alloc_cluster_barrier` forwarded any integer arrive count straight into the `barrier_init` attribute with no positivity check, so `T.alloc_barrier(0)` (and negatives) compiled cleanly all the way to emitted CUDA. An mbarrier arrive count of 0 has no defined meaning — it must be at least 1 — and on Hopper `bar[0].init(0)` trips the CUTLASS assert at runtime; a negative count is worse, since the assert only checks `!= 0`, so e.g. `-5` slips through as a garbage unsigned value (as documented in the issue).

Both functions now reject non-positive counts at trace time with a clear `ValueError` naming the offending value, before anything reaches a device pass or codegen. The check runs on the raw argument (int or list), so `alloc_barrier([128, 0])` is caught too.

Test: `test_alloc_barrier_rejects_non_positive_arrive_count` in `testing/python/language/test_tilelang_language_alloc.py` asserts the raise for `0`, `-5`, and `[128, 0]`, and that a valid count still traces. This part is CPU-only (frontend trace, no compile), matching the arch-independence noted in the issue.
