### PR TITLE
[BugFix][CUDA] Support non-constant int4/uint4 broadcast

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -5791,49 +5791,52 @@ void CodeGenTileLangCUDA::VisitExpr_(const BroadcastNode *op,
     return;
   }
 
+  // Note that packed 4-bit broadcast cannot trivially fallback to the
+  // generic make_<Type>(v, ...) path, as it can emit malformed make_int16_t()
+  // calls that cause nvcc compilation errors when lanes==4.
   if ((op->dtype.is_int() || op->dtype.is_uint()) && op->dtype.bits() == 4) {
-    bool fail = false;
     const int64_t *p = as_const_int(op->value);
-    ICHECK(p) << "BroadcastNode " << op << " value: " << op->value
-              << " is not a constant";
-    int64_t v = *p & 0xF;
 
-    if (lanes == 4) {
-      v = (v << 12) | (v << 8) | (v << 4) | v;
-      if (op->dtype.is_uint()) {
-        os << "(uint16_t)" << v;
-      } else {
-        os << "(int16_t)" << v;
-      }
-    } else {
-      v = (v << 28) | (v << 24) | (v << 20) | (v << 16) | (v << 12) | (v << 8) |
-          (v << 4) | v;
-      if (lanes == 8) {
-        if (op->dtype.is_uint()) {
-          os << "(uint)" << v;
-        } else {
-          os << "(int)" << v;
+    auto emit_packed_field = [&](int nibbles_per_field) {
+      if (p) {
+        int64_t v = *p & 0xF;
+        int64_t packed = 0;
+        for (int i = 0; i < nibbles_per_field; ++i) {
+          packed |= v << (i * 4);
         }
-      } else if (lanes == 16 || lanes == 32) {
-        os << "make_";
-        PrintType(op->dtype, os);
+        os << packed;
+      } else {
+        std::string v = PrintExpr(op->value);
         os << '(';
-        for (int i = 0; i < lanes / 8; ++i) {
+        for (int i = 0; i < nibbles_per_field; ++i) {
           if (i != 0)
-            os << ", ";
-          if (op->dtype.is_uint()) {
-            os << "(uint)" << v;
-          } else {
-            os << "(int)" << v;
-          }
+            os << " | ";
+          os << "((static_cast<unsigned int>(" << v << ") & 0x0fu) << "
+             << (i * 4) << ")";
         }
         os << ')';
-      } else {
-        fail = true;
       }
-    }
+    };
 
-    if (!fail) {
+    if (lanes == 4) {
+      os << (op->dtype.is_uint() ? "(uint16_t)" : "(int16_t)");
+      emit_packed_field(4);
+      return;
+    } else if (lanes == 8) {
+      os << (op->dtype.is_uint() ? "(uint)" : "(int)");
+      emit_packed_field(8);
+      return;
+    } else if (lanes == 16 || lanes == 32) {
+      os << "make_";
+      PrintType(op->dtype, os);
+      os << '(';
+      for (int i = 0; i < lanes / 8; ++i) {
+        if (i != 0)
+          os << ", ";
+        os << (op->dtype.is_uint() ? "(uint)" : "(int)");
+        emit_packed_field(8);
+      }
+      os << ')';
       return;
     }
   }

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -5797,6 +5797,12 @@ void CodeGenTileLangCUDA::VisitExpr_(const BroadcastNode *op,
   if ((op->dtype.is_int() || op->dtype.is_uint()) && op->dtype.bits() == 4) {
     const int64_t *p = as_const_int(op->value);
 
+    // Materialize for reuse to avoid side-effects.
+    std::string sval;
+    if (!p) {
+      sval = SSAGetID(PrintExpr(op->value), op->value.dtype());
+    }
+
     auto emit_packed_field = [&](int nibbles_per_field) {
       if (p) {
         int64_t v = *p & 0xF;
@@ -5806,12 +5812,11 @@ void CodeGenTileLangCUDA::VisitExpr_(const BroadcastNode *op,
         }
         os << packed;
       } else {
-        std::string v = PrintExpr(op->value);
         os << '(';
         for (int i = 0; i < nibbles_per_field; ++i) {
           if (i != 0)
             os << " | ";
-          os << "((static_cast<unsigned int>(" << v << ") & 0x0fu) << "
+          os << "((static_cast<unsigned int>(" << sval << ") & 0x0fu) << "
              << (i * 4) << ")";
         }
         os << ')';

--- a/testing/python/language/test_tilelang_language_vectorize.py
+++ b/testing/python/language/test_tilelang_language_vectorize.py
@@ -216,6 +216,64 @@ def test_vectorize_broadcast_int8(vec_num):
     vectorize_broadcast_int8.compile(vec_num=vec_num)
 
 
+def vectorize_broadcast_int4(dtype, vec_num):
+    @tilelang.jit(pass_configs={tilelang.PassConfigKey.TL_DISABLE_BUFFER_INIT_CHECK: True})
+    def kernel():
+        with T.Kernel(1, threads=128):
+            a = T.alloc_local((64,), dtype)
+            b = T.alloc_var(dtype)
+
+            for i in T.vectorized(vec_num):
+                a[i] = b
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+@pytest.mark.parametrize("vec_num", [4, 8, 16, 32])
+def test_vectorize_broadcast_int4(dtype, vec_num):
+    """Broadcasting a non-constant 4-bit value to a vectorized store must emit
+    the packed-nibble carrier rather than aborting (see issue #2997). The int4
+    branch used to ICHECK on a non-constant value; the int8 branch already
+    handled it. Every packed lane count (16/32-bit carriers and make_(u)int{N})
+    is exercised here."""
+    vectorize_broadcast_int4(dtype, vec_num).compile()
+
+
+def fill_int4_buffer(dtype, fill_value):
+    M, N = 16, 64
+
+    @T.prim_func
+    def func(B: T.Tensor((M, N), dtype)):
+        with T.Kernel(1, threads=128):
+            sh = T.alloc_shared((M, N), dtype)
+            T.fill(sh, fill_value)
+            T.copy(sh, B)
+
+    return func
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", ["int4", "uint4"])
+@pytest.mark.parametrize("fill_value", [0, 1, 7])
+def test_fill_int4_buffer(dtype, fill_value):
+    """End-to-end reproduction of issue #2997: T.fill/T.clear of an int4 buffer.
+    HoistBroadcastValues rebinds the constant fill value to a Var, so the CUDA
+    Broadcast codegen sees a non-constant value. Verify it both compiles and
+    produces the correct packed nibbles."""
+    M, N = 16, 64
+    kernel = tilelang.compile(fill_int4_buffer(dtype, fill_value))
+    # int4 buffer packs two nibbles per byte, so N columns -> N // 2 bytes.
+    out = torch.empty(M, N // 2, dtype=torch.int8, device="cuda")
+    kernel(out)
+    expected = fill_value & 0x0F
+    low = out & 0x0F
+    high = (out >> 4) & 0x0F
+    assert bool((low == expected).all()), f"low nibble mismatch for {dtype}={fill_value}"
+    assert bool((high == expected).all()), f"high nibble mismatch for {dtype}={fill_value}"
+
+
 @tilelang.jit
 def vectorize_test_call_infinity():
     A = T.empty((4,), dtype=T.float32)


### PR DESCRIPTION
The `int4` branch of `CodeGenTileLangCUDA::VisitExpr_(BroadcastNode)` unconditionally `ICHECK`ed that the broadcast value was a compile-time constant, yet `HoistBroadcastValues` rebinds a constant fill value to a `Var` before codegen, so the value can be non-constant by the time the the assert fires, even for plain `T.fill(sh, 1)`.

This patch strengthens the `int4`/`uint4` branch to handle both constant and non-constant 4-bit packing.
For constants, we fold the packed 4-bit values into a literal as before; for non-constant, we emit the packing process as a runtime expression.

Note that a trivial fallback to the generic `make_<Type>(v, ...)` path does not work: `PrintType` maps e.g. `int4x4` to `int16_t`, emitting an undefined `make_int16_t(...)` and fail nvcc compilation.
This is why we handle 4-bit packing in the dedicated branch.

Fixes #2997.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated CUDA code generation for `int4` and `uint4` broadcasts.
- Preserved packed-literal generation for constant values.
- Added runtime masking and shifting for non-constant values.
- Prevented `ICHECK` failures after `HoistBroadcastValues`.
- Added vectorization tests for widths 4, 8, 16, and 32.
- Added `T.fill` tests for `int4` and `uint4` buffers.

## C++ style / lint notes

- The change follows the TVM-style invariant-check guidance in `docs/developer_guide/cpp_style.md`.
- It does not change a public API, reflected field, namespace rule, or header interface.
- The C++ API Style Audit is warning-only.
- No correctness or build issue is indicated by the style guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->