### PR TITLE
[Ci] Register TVM feature markers to get rid of PytestUnknownMarkWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,6 +241,17 @@ filterwarnings = ["always"]
 markers = [
     "perf: benchmark and performance API tests skipped by default",
     "slow: long-running correctness sweeps",
+    # Feature markers emitted by vendored TVM's tvm.testing.utils requires_*
+    # decorators (see 3rdparty/tvm/python/tvm/testing/utils.py). TVM registers
+    # these via its own conftest, but tilelang only imports the decorators, so
+    # they must be registered here to avoid PytestUnknownMarkWarning.
+    "cpu: Mark a test as running on CPU",
+    "gpu: Mark a test as using a GPU",
+    "multi_gpu: Mark a test as using multiple GPUs",
+    "cuda: Mark a test as using CUDA",
+    "llvm: Mark a test as using LLVM",
+    "metal: Mark a test as using Metal",
+    "rocm: Mark a test as using ROCm",
 ]
 
 [tool.cibuildwheel]


### PR DESCRIPTION
Test runs emit many `PytestUnknownMarkWarning`s, most of them are `PytestUnknownMarkWarning`:

```
================== 3297 passed, 434 skipped, 19353 warnings in 375.24s (0:06:15) ===================
```

These warnings come from the `requires_cuda` / `requires_rocm` / `requires_metal` / `requires_llvm` decorators re-exported from TVM.
TVM registers these marks in its own `conftest.py`, yet tilelang only imports the decorators, without the registration.
This causes thousands of warnings during test runs.

By registering feature marks in `pyproject.toml`: `cpu`, `gpu`, `multi_gpu`, `cuda`, `llvm`, `metal`, `rocm`, this patch gets rid of warning reports without affecting test runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Registered TVM feature markers in `pyproject.toml`.
- Prevented `PytestUnknownMarkWarning` during test runs.
- Added markers for `cpu`, `gpu`, `multi_gpu`, `cuda`, `llvm`, `metal`, and `rocm`.

## Testing

- No production code or public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->