### PR TITLE
[Runtime][Cache] Export libraries after disk-cache hits

### DIFF
--- a/testing/python/cache/test_tilelang_kernel_cache.py
+++ b/testing/python/cache/test_tilelang_kernel_cache.py
@@ -201,6 +201,39 @@ def test_disk_cache_with_postproc(clean_cache_env, backend):
 
 
 @tilelang.testing.requires_cuda
+def test_tvm_ffi_export_library_after_disk_cache_hit(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "tilelang_cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(env, "TILELANG_CACHE_DIR", str(cache_dir))
+
+    cache = _dispatch_map["tvm_ffi"]
+    cache._memory_cache.clear()
+
+    @T.prim_func
+    def vector_add(
+        A: T.Tensor((128,), T.float32),
+        B: T.Tensor((128,), T.float32),
+    ):
+        with T.Kernel(128, threads=128) as i:
+            B[i] = A[i] + 1.0
+
+    kernel_func = vector_add.with_attr("global_symbol", f"export_library_{uuid.uuid4().hex[:8]}")
+    cold_kernel = tilelang.compile(kernel_func, out_idx=[1], execution_backend="tvm_ffi")
+    cold_library = tmp_path / "cold.so"
+    cold_kernel.export_library(str(cold_library))
+
+    cache._memory_cache.clear()
+    cached_kernel = tilelang.compile(kernel_func, out_idx=[1], execution_backend="tvm_ffi")
+    cached_library = tmp_path / "cached.so"
+    cached_kernel.export_library(str(cached_library))
+
+    assert cold_library.is_file()
+    assert cached_kernel.artifact is None
+    assert cached_library.read_bytes() == Path(cached_kernel.adapter.libpath).read_bytes()
+    assert tilelang.tvm.runtime.load_module(str(cached_library)) is not None
+
+
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_cache_miss_detection(clean_cache_env, backend):
     """Verify cache correctly misses when function changes.

--- a/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
+++ b/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from tilelang import tvm
+from tilelang.jit.kernel import JITKernel
 from tilelang.jit.abi import prepare_tvm_ffi_callee_allocated_outputs
 from tilelang.jit.adapter.tvm_ffi import TVMFFIKernelAdapter
 
@@ -97,6 +98,36 @@ def test_preloaded_executable_is_reused():
     assert adapter._get_executable() is preloaded_executable
     assert adapter.get_exportable_executable() is preloaded_executable
     assert created == []
+
+
+def test_disk_cached_library_can_be_exported(tmp_path):
+    cached_library = tmp_path / "cache" / "kernel_lib.so"
+    cached_library.parent.mkdir()
+    cached_library.write_bytes(b"cached-library")
+
+    kernel = JITKernel.__new__(JITKernel)
+    kernel.artifact = None
+    kernel.adapter = SimpleNamespace(libpath=str(cached_library))
+    kernel.execution_backend = "tvm_ffi"
+
+    exported_library = tmp_path / "export" / "kernel.so"
+    kernel.export_library(str(exported_library))
+
+    assert exported_library.read_bytes() == cached_library.read_bytes()
+
+
+def test_exporting_disk_cached_library_to_its_own_path_succeeds(tmp_path):
+    cached_library = tmp_path / "kernel_lib.so"
+    cached_library.write_bytes(b"cached-library")
+
+    kernel = JITKernel.__new__(JITKernel)
+    kernel.artifact = None
+    kernel.adapter = SimpleNamespace(libpath=str(cached_library))
+    kernel.execution_backend = "tvm_ffi"
+
+    kernel.export_library(str(cached_library))
+
+    assert cached_library.read_bytes() == b"cached-library"
 
 
 def test_callee_allocated_output_dispatch_uses_single_main_entry():

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -29,6 +29,7 @@ from tilelang.instrumentation import compile_pass_instrumentation, create_pass_i
 from tilelang.tools.pass_timing import create_pass_timing_tool
 import logging
 import os
+import shutil
 
 logger = logging.getLogger(__name__)
 
@@ -750,7 +751,9 @@ class JITKernel(Generic[_P, _T]):
         # rt_module: use export_library to export
         # rt_params: use cloudpickle to serialize
 
-        if self.artifact is None or self.artifact.rt_mod is None:
+        runtime_module = self.artifact.rt_mod if self.artifact is not None else None
+        cached_library = getattr(self.adapter, "libpath", None) if self.execution_backend == "tvm_ffi" else None
+        if runtime_module is None and cached_library is None:
             raise AttributeError(
                 'Runtime module is not available. Please compile the kernel with `execution_backend="tvm_ffi"` before exporting.'
             )
@@ -759,7 +762,10 @@ class JITKernel(Generic[_P, _T]):
         if dir_path:
             os.makedirs(dir_path, exist_ok=True)
 
-        self.artifact.rt_mod.export_library(kernel_file)
+        if runtime_module is not None:
+            runtime_module.export_library(kernel_file)
+        elif not (os.path.exists(kernel_file) and os.path.samefile(cached_library, kernel_file)):
+            shutil.copyfile(cached_library, kernel_file)
         logger.info(f"Kernel library exported to {os.path.abspath(kernel_file)}")
 
     def _get_ptx(self, verbose: bool | None = None) -> str:


### PR DESCRIPTION
## Summary

- export TVM FFI kernels from the cache-owned shared library after a disk-cache hit
- retain the runtime-module export path for fresh compilations
- cover cache-hit export, same-path export, and cold/cache-hit/load behavior

Closes #3062

## Validation

- `uvx --from pre-commit==4.5.1 pre-commit run --files tilelang/jit/kernel.py testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py testing/python/cache/test_tilelang_kernel_cache.py`
- `.venv/bin/python -m pytest -q testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py -k disk_cached_library` (2 passed)
- `.venv/bin/python -m pytest -q testing/python/cache/test_tilelang_kernel_cache.py -k export_library_after_disk_cache_hit` (CUDA test collected and skipped by the project marker on macOS arm64)
- editable native build with `USE_CUDA=OFF USE_METAL=ON`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fix `tvm_ffi` library export after disk-cache hits.

- Copy the cached `libpath` when no runtime module is available.
- Preserve runtime-module export for freshly compiled kernels.
- Avoid copying when the source and destination paths are identical.
- Add coverage for cold-cache export, disk-cache export, same-path export, and module loading.
- Closes `#3062`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->