### PR TITLE
[BugFix][CUDA][HIP] Handle logical not for vectorized bool

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -5554,6 +5554,31 @@ void CodeGenTileLangCUDA::VisitExpr_(const SelectNode *op, std::ostream &os) {
   os << r_var;
 }
 
+void CodeGenTileLangCUDA::VisitExpr_(const NotNode *op, std::ostream &os) {
+  if (!op->dtype.is_fixed_length_vector()) {
+    CodeGenC::VisitExpr_(op, os);
+    return;
+  }
+
+  std::string result = name_supply_->FreshName("_");
+  this->PrintIndent();
+  this->PrintType(op->dtype, stream);
+  stream << ' ' << result << ";\n";
+  int ssa_scope = BeginScope();
+  {
+    std::string value = SSAGetID(PrintExpr(op->a), op->a.dtype());
+    for (int i = 0; i < op->dtype.lanes(); ++i) {
+      std::ostringstream lane;
+      lane << "!bool(";
+      PrintVecElemLoad(value, op->a.dtype(), i, lane);
+      lane << ')';
+      PrintVecElemStore(result, op->dtype, i, lane.str());
+    }
+  }
+  EndScope(ssa_scope);
+  os << result;
+}
+
 void CodeGenTileLangCUDA::VisitExpr_(const ShuffleNode *op,
                                      std::ostream &os) { // NOLINT(*)
   // For bfloat16x2 / float16x2 construction from two scalar lanes, emit a

--- a/src/cuda/codegen/codegen_cuda.h
+++ b/src/cuda/codegen/codegen_cuda.h
@@ -58,6 +58,7 @@ public:
   void VisitExpr_(const ShuffleNode *op, std::ostream &os) final;
   void VisitExpr_(const MinNode *op, std::ostream &os) final;
   void VisitExpr_(const MaxNode *op, std::ostream &os) final;
+  void VisitExpr_(const NotNode *op, std::ostream &os) final;
   void VisitStmt_(const EvaluateNode *op) final;
   void VisitStmt_(const AllocBufferNode *op) final;
   void VisitStmt_(const AttrStmtNode *op) final;

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -806,6 +806,31 @@ void CodeGenTileLangHIP::VisitExpr_(const SelectNode *op, std::ostream &os) {
   os << result;
 }
 
+void CodeGenTileLangHIP::VisitExpr_(const NotNode *op, std::ostream &os) {
+  if (!op->dtype.is_fixed_length_vector()) {
+    CodeGenC::VisitExpr_(op, os);
+    return;
+  }
+
+  std::string result = name_supply_->FreshName("_");
+  this->PrintIndent();
+  this->PrintType(op->dtype, stream);
+  stream << ' ' << result << ";\n";
+  int ssa_scope = BeginScope();
+  {
+    std::string value = SSAGetID(PrintExpr(op->a), op->a.dtype());
+    for (int i = 0; i < op->dtype.lanes(); ++i) {
+      std::ostringstream lane;
+      lane << "!bool(";
+      PrintVecElemLoad(value, op->a.dtype(), i, lane);
+      lane << ')';
+      PrintVecElemStore(result, op->dtype, i, lane.str());
+    }
+  }
+  EndScope(ssa_scope);
+  os << result;
+}
+
 void CodeGenTileLangHIP::PrintVecElemLoad(const std::string &vec, DataType t,
                                           int i,
                                           std::ostream &os) { // NOLINT(*)

--- a/src/rocm/codegen/codegen_hip.h
+++ b/src/rocm/codegen/codegen_hip.h
@@ -50,6 +50,7 @@ public:
   void VisitExpr_(const FloatImmNode *op, std::ostream &os) final;
   void VisitExpr_(const CallNode *op, std::ostream &os) final;
   void VisitExpr_(const CastNode *op, std::ostream &os) final;
+  void VisitExpr_(const NotNode *op, std::ostream &os) final;
   void VisitExpr_(const SelectNode *op, std::ostream &os) final;
   void VisitExpr_(const ShuffleNode *op, std::ostream &os) final; // NOLINT(*)
   void VisitStmt_(const AllocBufferNode *op) final;

--- a/testing/python/amd/test_tilelang_hip_vector_not_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_vector_not_codegen.py
@@ -1,0 +1,40 @@
+import pytest
+import tilelang
+import tilelang.testing
+
+from tilelang import tvm
+from tvm import tirx
+
+
+def _make_vector_not_module(lanes):
+    value = tirx.Var("value", f"boolx{lanes}")
+    func = tirx.PrimFunc([value], tirx.Evaluate(tirx.Not(value)))
+    func = func.with_attr("global_symbol", "vector_not")
+    func = func.with_attr("calling_conv", tvm.ir.CallingConv.DEVICE_KERNEL_LAUNCH)
+    return tvm.IRModule({"vector_not": func})
+
+
+def _build_vector_not_source(lanes):
+    build = tvm.get_global_func("target.build.tilelang_hip_without_compile", allow_missing=True)
+    if build is None:
+        pytest.skip("TileLang was built without the ROCm code generator")
+    return build(_make_vector_not_module(lanes), tvm.target.Target("rocm")).inspect_source()
+
+
+@pytest.mark.parametrize("lanes", [2, 3, 4])
+def test_vector_not_is_scalarized(lanes):
+    source = _build_vector_not_source(lanes)
+
+    assignments = [line for line in source.splitlines() if "!bool(" in line]
+    assert len(assignments) == lanes
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("lanes", [2, 3, 4])
+def test_vector_not_compiles(lanes):
+    build = tvm.get_global_func("target.build.tilelang_hip")
+    build(_make_vector_not_module(lanes), tvm.target.Target("rocm"))
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/cuda/test_cuda_vector_bool_not_codegen.py
+++ b/testing/python/cuda/test_cuda_vector_bool_not_codegen.py
@@ -1,0 +1,49 @@
+import pytest
+import tilelang
+import tilelang.testing
+
+from tilelang import tvm
+from tvm import tirx
+
+
+def _make_vector_not_module(lanes):
+    value = tirx.Var("value", f"boolx{lanes}")
+    negated = tirx.Not(value)
+    func = tirx.PrimFunc([value], tirx.Evaluate(negated))
+    func = func.with_attr("global_symbol", "vector_not")
+    func = func.with_attr("calling_conv", tvm.ir.CallingConv.DEVICE_KERNEL_LAUNCH)
+    return tvm.IRModule({"vector_not": func})
+
+
+def _build_vector_not_source(lanes):
+    build = tvm.get_global_func("target.build.tilelang_cuda_without_compile", allow_missing=True)
+    if build is None:
+        pytest.skip("TileLang was built without the CUDA code generator")
+    return build(_make_vector_not_module(lanes), tvm.target.Target("cuda")).inspect_source()
+
+
+@pytest.mark.parametrize(
+    ("lanes", "carrier_type"),
+    [(2, "ushort2"), (3, "ushort3"), (4, "ushort4")],
+)
+def test_vector_not_is_scalarized(lanes, carrier_type):
+    source = _build_vector_not_source(lanes)
+
+    declarations = [line for line in source.splitlines() if line.startswith(f"  {carrier_type} __")]
+    assert len(declarations) == 1
+    assignments = [line for line in source.splitlines() if "!bool(" in line]
+    assert len(assignments) == lanes
+    assert all(f".{member}" in assignment for member, assignment in zip("xyzw", assignments))
+    # The base CodeGenC path negates the whole carrier, which is invalid.
+    assert "!__" not in source
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("lanes", [2, 3, 4])
+def test_vector_not_compiles(lanes):
+    build = tvm.get_global_func("target.build.tilelang_cuda")
+    build(_make_vector_not_module(lanes), tvm.target.Target("cuda"))
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/issue/test_tilelang_issue_3021.py
+++ b/testing/python/issue/test_tilelang_issue_3021.py
@@ -1,0 +1,51 @@
+"""Regression test for https://github.com/tile-ai/tilelang/issues/3021
+
+Logical `T.Not` on a `bool` buffer inside an auto-vectorized `T.Parallel`
+loop used to emit a scalar `!` on the whole vector carrier (e.g.
+`!ushort4`), which nvcc rejects. The NotNode visitor must scalarize the
+negation lane by lane.
+
+The negated operand must be a plain `bool` buffer load: a NotNode over a
+comparison (e.g. `T.Not(A[i] > 0)`) is rewritten by the simplifier before
+codegen and would not exercise the vectorized path.
+"""
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+N = 256
+
+
+def _make_not_kernel(threads):
+    @T.prim_func
+    def main(A: T.Tensor((N,), "bool"), C: T.Tensor((N,), "bool")):
+        with T.Kernel(1, threads=threads):
+            for i in T.Parallel(N):
+                C[i] = T.Not(A[i])
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    "threads",
+    [
+        256,  # one element per thread: scalar `!x` (control)
+        128,  # two elements per thread: boolx2
+        64,  # four elements per thread: boolx4 (the reported crash)
+    ],
+)
+def test_vectorized_bool_not(threads):
+    kernel = tilelang.compile(_make_not_kernel(threads), out_idx=[1])
+
+    a = torch.rand(N, device="cuda") > 0.5
+    c = kernel(a)
+    torch.testing.assert_close(c, ~a, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
Previously, both CUDA and HIP codegen delegate to `CodeGenC`, which cannot emit logical not for vectorized bools, causing device compilation to fail.
This PR handles vectorized `NotNode` expressions lane by lane in CUDA and HIP.

Fixes #3021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added lane-by-lane `NotNode` code generation for vectorized CUDA and HIP booleans.
- Preserved scalar handling through `CodeGenC`.
- Added CUDA and HIP codegen tests for vector widths 2, 3, and 4.
- Added a regression test for auto-vectorized `T.Parallel` loops.

## C++ style / lint notes

- The PR does not change the rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains advisory.
- No correctness or build issues are indicated by the changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->