### PR TITLE
[Bugfix][Quantize] Fix unsigned zero-point decode underflow (#2947)

### DIFF
--- a/examples/dequantize_gemm/quantize/quantization.py
+++ b/examples/dequantize_gemm/quantize/quantization.py
@@ -325,7 +325,7 @@ def _tir_packed_to_unsigned_convert_with_zeros(storage_type="uint", storage_nbit
                   dtype: str):
         assert val.dtype == storage_dtype, f"{val.dtype} != {storage_dtype}"
         mask = tvm.tirx.const((1 << nbit) - 1, storage_dtype)
-        return (((val >> (pos * nbit).astype(storage_dtype)) & mask) - zero).astype(dtype)
+        return (((val >> (pos * nbit).astype(storage_dtype)) & mask).astype(dtype) - zero.astype(dtype))
 
     return f_convert
 

--- a/testing/python/issue/test_tilelang_issue_2947.py
+++ b/testing/python/issue/test_tilelang_issue_2947.py
@@ -1,0 +1,41 @@
+import numpy as np
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from examples.dequantize_gemm.quantize.quantization import _tir_packed_to_unsigned_convert_with_zeros
+from tvm import tirx
+
+
+@tilelang.testing.requires_cuda
+def test_packed_unsigned_convert_with_zeros_uses_signed_output_domain():
+    """Zero-point subtraction must not underflow in uint32 packed storage."""
+
+    n = 16
+    zero = 8
+    convert = _tir_packed_to_unsigned_convert_with_zeros("uint", 32)
+
+    @T.prim_func
+    def dequantize(packed: T.Tensor((n,), "uint32"), decoded: T.Tensor((n,), "float16")):
+        with T.Kernel(1, threads=n):
+            thread_id = T.get_thread_binding()
+            decoded[thread_id] = convert(
+                4,
+                packed[thread_id],
+                tirx.const(0, "int32"),
+                tirx.const(zero, "uint32"),
+                "float16",
+            )
+
+    kernel = tilelang.compile(dequantize, target="cuda", execution_backend="nvrtc")
+    packed = torch.tensor(np.arange(n, dtype=np.uint32), device="cuda")
+    decoded = torch.empty(n, dtype=torch.float16, device="cuda")
+    kernel(packed, decoded)
+
+    expected = torch.arange(n, dtype=torch.float16) - zero
+    torch.testing.assert_close(decoded.cpu(), expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

I would like to thank the author of issue #2947 for the detailed analysis and the suggested fix.

I tried to reproduce the reported behavior locally. The generated CUDA code helped me understand that the zero-point subtraction was still being performed in the unsigned storage dtype.

Following the proposed solution in the issue, I applied the cast-before-subtract change and added a CUDA regression test that verifies the proposed fix for uint32 packed storage, uint32 zero-points, and float16 output.

## Changes

- Apply the suggested fix from issue #2947.
- Add CUDA regression coverage for uint32-packed 4-bit values with a non-zero
  zero-point.

## Validation

- `python -m pytest -q testing/python/issue/test_tilelang_issue_2947.py` — 1 passed
- Related uint32 signed decode regression tests — 3 passed

I may have missed some cases, so any feedback or corrections would be greatly appreciated.

Fixes #2947

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes unsigned zero-point underflow in `_tir_packed_to_unsigned_convert_with_zeros`.

- Casts the unpacked value and zero-point to the output dtype before subtraction.
- Adds CUDA regression coverage for uint32-packed 4-bit values with non-zero zero-points and float16 output.
- Verifies values below the zero-point decode to negative results.

## Validation

- Issue regression test: 1 passed.
- Related uint32 signed decode tests: 3 passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->