### PR TITLE
[BugFix] Always vectorize `T.Parallel` loops

### DIFF
--- a/src/backend/common/op/atomic_reduce.h
+++ b/src/backend/common/op/atomic_reduce.h
@@ -183,10 +183,11 @@ struct AtomicReduce {
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(
-        fused_loop, loop_layout, lower_args.thread_index, analyzer,
-        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
+    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_index,
+                             analyzer, lower_args.layout_map,
+                             par_op->GetPredicate(lower_args.thread_index),
+                             /*parallel_loop=*/true, /*should_vectorize=*/true,
+                             par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 

--- a/src/backend/common/op/atomic_reduce.h
+++ b/src/backend/common/op/atomic_reduce.h
@@ -183,11 +183,10 @@ struct AtomicReduce {
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_index,
-                             analyzer, lower_args.layout_map,
-                             par_op->GetPredicate(lower_args.thread_index),
-                             /*parallel_loop=*/true, /*should_vectorize=*/true,
-                             par_op->LoopLayoutRequiresPaddingGuard());
+    return LowerParallelLoop(
+        fused_loop, loop_layout, lower_args.thread_index, analyzer,
+        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
+        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 

--- a/src/backend/common/op/transpose.h
+++ b/src/backend/common/op/transpose.h
@@ -51,7 +51,8 @@ struct Transpose {
     return LowerParallelLoop(
         par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
         lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
+        /*parallel_loop=*/true, /*should_vectorize=*/true,
+        par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 

--- a/src/backend/common/op/transpose.h
+++ b/src/backend/common/op/transpose.h
@@ -51,8 +51,7 @@ struct Transpose {
     return LowerParallelLoop(
         par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
         lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-        /*parallel_loop=*/true, /*should_vectorize=*/true,
-        par_op->LoopLayoutRequiresPaddingGuard());
+        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 

--- a/src/cuda/op/atomic_add.cc
+++ b/src/cuda/op/atomic_add.cc
@@ -338,10 +338,11 @@ struct AtomicAdd {
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(
-        fused_loop, loop_layout, lower_args.thread_index, analyzer,
-        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
+    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_index,
+                             analyzer, lower_args.layout_map,
+                             par_op->GetPredicate(lower_args.thread_index),
+                             /*parallel_loop=*/true, /*should_vectorize=*/true,
+                             par_op->LoopLayoutRequiresPaddingGuard());
   }
 
   static LayoutMap InferLayout(const AtomicAddNode &op,

--- a/src/cuda/op/atomic_add.cc
+++ b/src/cuda/op/atomic_add.cc
@@ -338,11 +338,10 @@ struct AtomicAdd {
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_index,
-                             analyzer, lower_args.layout_map,
-                             par_op->GetPredicate(lower_args.thread_index),
-                             /*parallel_loop=*/true, /*should_vectorize=*/true,
-                             par_op->LoopLayoutRequiresPaddingGuard());
+    return LowerParallelLoop(
+        fused_loop, loop_layout, lower_args.thread_index, analyzer,
+        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
+        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
   }
 
   static LayoutMap InferLayout(const AtomicAddNode &op,

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -865,8 +865,7 @@ Stmt Copy::LowerCPAsync(const CopyNode &op, const LowerArgs &lower_args,
   Stmt lowered_loop = LowerParallelLoop(
       par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
       lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-      /*parallel_loop=*/true, /*should_vectorize=*/true,
-      par_op->LoopLayoutRequiresPaddingGuard());
+      /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
 
   auto inject_result =
       InjectPTXAsyncCopy(lowered_loop, /*async_without_async_commit_wait=*/

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -865,7 +865,8 @@ Stmt Copy::LowerCPAsync(const CopyNode &op, const LowerArgs &lower_args,
   Stmt lowered_loop = LowerParallelLoop(
       par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
       lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-      /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
+      /*parallel_loop=*/true, /*should_vectorize=*/true,
+      par_op->LoopLayoutRequiresPaddingGuard());
 
   auto inject_result =
       InjectPTXAsyncCopy(lowered_loop, /*async_without_async_commit_wait=*/

--- a/src/metal/op/transpose.cc
+++ b/src/metal/op/transpose.cc
@@ -47,7 +47,8 @@ struct Transpose {
     return LowerParallelLoop(
         par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
         lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
+        /*parallel_loop=*/true, /*should_vectorize=*/true,
+        par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 

--- a/src/metal/op/transpose.cc
+++ b/src/metal/op/transpose.cc
@@ -47,8 +47,7 @@ struct Transpose {
     return LowerParallelLoop(
         par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
         lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-        /*parallel_loop=*/true, /*should_vectorize=*/true,
-        par_op->LoopLayoutRequiresPaddingGuard());
+        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -86,8 +86,7 @@ Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &lower_args,
   return LowerParallelLoop(
       par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
       lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-      /*parallel_loop=*/true, /*should_vectorize=*/true,
-      par_op->LoopLayoutRequiresPaddingGuard());
+      /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
 }
 
 namespace {
@@ -262,8 +261,7 @@ Stmt LowerIm2ColSIMT(const Im2ColOpNode &op, const LowerArgs &lower_args,
   return LowerParallelLoop(
       par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
       lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-      /*parallel_loop=*/true, /*should_vectorize=*/true,
-      par_op->LoopLayoutRequiresPaddingGuard());
+      /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
 }
 
 bool RegisterDefaultIm2Col() {

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -86,7 +86,8 @@ Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &lower_args,
   return LowerParallelLoop(
       par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
       lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-      /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
+      /*parallel_loop=*/true, /*should_vectorize=*/true,
+      par_op->LoopLayoutRequiresPaddingGuard());
 }
 
 namespace {
@@ -261,7 +262,8 @@ Stmt LowerIm2ColSIMT(const Im2ColOpNode &op, const LowerArgs &lower_args,
   return LowerParallelLoop(
       par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
       lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-      /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
+      /*parallel_loop=*/true, /*should_vectorize=*/true,
+      par_op->LoopLayoutRequiresPaddingGuard());
 }
 
 bool RegisterDefaultIm2Col() {

--- a/src/rocm/op/atomic_add.cc
+++ b/src/rocm/op/atomic_add.cc
@@ -227,10 +227,11 @@ struct AtomicAdd {
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(
-        fused_loop, loop_layout, lower_args.thread_index, analyzer,
-        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
+    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_index,
+                             analyzer, lower_args.layout_map,
+                             par_op->GetPredicate(lower_args.thread_index),
+                             /*parallel_loop=*/true, /*should_vectorize=*/true,
+                             par_op->LoopLayoutRequiresPaddingGuard());
   }
 
   static LayoutMap InferLayout(const AtomicAddNode &op,

--- a/src/rocm/op/atomic_add.cc
+++ b/src/rocm/op/atomic_add.cc
@@ -227,11 +227,10 @@ struct AtomicAdd {
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_index,
-                             analyzer, lower_args.layout_map,
-                             par_op->GetPredicate(lower_args.thread_index),
-                             /*parallel_loop=*/true, /*should_vectorize=*/true,
-                             par_op->LoopLayoutRequiresPaddingGuard());
+    return LowerParallelLoop(
+        fused_loop, loop_layout, lower_args.thread_index, analyzer,
+        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
+        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
   }
 
   static LayoutMap InferLayout(const AtomicAddNode &op,

--- a/src/rocm/op/copy.cc
+++ b/src/rocm/op/copy.cc
@@ -131,8 +131,7 @@ private:
     Stmt lowered_loop = LowerParallelLoop(
         par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
         lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-        /*parallel_loop=*/true,
-        /*should_vectorize=*/true, par_op->LoopLayoutRequiresPaddingGuard());
+        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
 
     auto inject_result =
         InjectROCmAsyncCopy(lowered_loop, /*async_without_async_commit_wait=*/

--- a/src/rocm/op/copy.cc
+++ b/src/rocm/op/copy.cc
@@ -131,7 +131,8 @@ private:
     Stmt lowered_loop = LowerParallelLoop(
         par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
         lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
+        /*parallel_loop=*/true,
+        /*should_vectorize=*/true, par_op->LoopLayoutRequiresPaddingGuard());
 
     auto inject_result =
         InjectROCmAsyncCopy(lowered_loop, /*async_without_async_commit_wait=*/

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -317,7 +317,7 @@ Stmt LowerParallelLoop(For loop, const Fragment &loop_layout,
                        PrimExpr thread_index, arith::Analyzer *analyzer,
                        const LayoutMap &layout_map,
                        Optional<PrimExpr> predicate, bool parallel_loop,
-                       bool should_vectorize, bool require_padding_guard) {
+                       bool require_padding_guard) {
   // Save analyzer state to prevent conflicted bindings during vectorization
   auto saved_analyzer = analyzer->Clone();
 
@@ -339,10 +339,9 @@ Stmt LowerParallelLoop(For loop, const Fragment &loop_layout,
                                 loop_layout, require_padding_guard);
   }
 
-  // Step 2: Vectorize the loop (if requested)
-  if (should_vectorize) {
-    result_loop = VectorizeLoop(result_loop, saved_analyzer.get(), layout_map);
-  }
+  // Step 2: Vectorize the loop; the planner picks the size per loop
+  // (1 = scalar) from its access analysis.
+  result_loop = VectorizeLoop(result_loop, saved_analyzer.get(), layout_map);
 
   result_loop = PragmaUnrollLoop(result_loop);
 

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -317,7 +317,7 @@ Stmt LowerParallelLoop(For loop, const Fragment &loop_layout,
                        PrimExpr thread_index, arith::Analyzer *analyzer,
                        const LayoutMap &layout_map,
                        Optional<PrimExpr> predicate, bool parallel_loop,
-                       bool require_padding_guard) {
+                       bool should_vectorize, bool require_padding_guard) {
   // Save analyzer state to prevent conflicted bindings during vectorization
   auto saved_analyzer = analyzer->Clone();
 
@@ -339,9 +339,10 @@ Stmt LowerParallelLoop(For loop, const Fragment &loop_layout,
                                 loop_layout, require_padding_guard);
   }
 
-  // Step 2: Vectorize the loop; the planner picks the size per loop
-  // (1 = scalar) from its access analysis.
-  result_loop = VectorizeLoop(result_loop, saved_analyzer.get(), layout_map);
+  // Step 2: Vectorize the loop (if requested)
+  if (should_vectorize) {
+    result_loop = VectorizeLoop(result_loop, saved_analyzer.get(), layout_map);
+  }
 
   result_loop = PragmaUnrollLoop(result_loop);
 

--- a/src/transform/loop_partition.h
+++ b/src/transform/loop_partition.h
@@ -66,13 +66,17 @@ For PragmaUnrollLoop(For stmt);
  * \param parallel_loop Whether this is a true parallel loop requiring thread
  *        partitioning. False for loops that only operate on local/register
  *        buffers. (default true)
+ * \param should_vectorize Whether to vectorize the loop. False when reducer
+ *        combine stores (execution-multiplicity markers) are present or when
+ *        there are no non-local buffer accesses. (default true)
  * \return The lowered statement.
  */
 Stmt LowerParallelLoop(
     For loop, const Fragment &loop_layout, PrimExpr thread_index,
     arith::Analyzer *analyzer, const LayoutMap &layout_map = {},
     ffi::Optional<PrimExpr> predicate = ffi::Optional<PrimExpr>(),
-    bool parallel_loop = true, bool require_padding_guard = false);
+    bool parallel_loop = true, bool should_vectorize = true,
+    bool require_padding_guard = false);
 
 } // namespace tl
 } // namespace tvm

--- a/src/transform/loop_partition.h
+++ b/src/transform/loop_partition.h
@@ -66,17 +66,13 @@ For PragmaUnrollLoop(For stmt);
  * \param parallel_loop Whether this is a true parallel loop requiring thread
  *        partitioning. False for loops that only operate on local/register
  *        buffers. (default true)
- * \param should_vectorize Whether to vectorize the loop. False when reducer
- *        combine stores (execution-multiplicity markers) are present or when
- *        there are no non-local buffer accesses. (default true)
  * \return The lowered statement.
  */
 Stmt LowerParallelLoop(
     For loop, const Fragment &loop_layout, PrimExpr thread_index,
     arith::Analyzer *analyzer, const LayoutMap &layout_map = {},
     ffi::Optional<PrimExpr> predicate = ffi::Optional<PrimExpr>(),
-    bool parallel_loop = true, bool should_vectorize = true,
-    bool require_padding_guard = false);
+    bool parallel_loop = true, bool require_padding_guard = false);
 
 } // namespace tl
 } // namespace tvm

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1359,47 +1359,9 @@ private:
     // iteration has to be owned by the corresponding thread.
     bool parallel_loop = has_non_local_store || has_fragment_access;
 
-    // Check if there are non-local buffer accesses (for vectorization decision)
-    bool has_non_local = false;
-    PostOrderVisit(for_node->body, [&](const ObjectRef &obj) {
-      if (const auto *load = obj.as<BufferLoadNode>()) {
-        if (!IsLocalBuffer(load->buffer, /*allow_var*/ true) &&
-            !IsFragmentBuffer(load->buffer)) {
-          has_non_local = true;
-        }
-      } else if (const auto *store = obj.as<BufferStoreNode>()) {
-        if (!IsLocalBuffer(store->buffer, /*allow_var*/ true) &&
-            !IsFragmentBuffer(store->buffer)) {
-          has_non_local = true;
-        }
-      }
-    });
-
-    // Check if vectorizable cast operations exist
-    bool has_cast_operations = false;
-    PostOrderVisit(for_node->body, [&](const ObjectRef &obj) {
-      if (const auto *cast = obj.as<CastNode>()) {
-        DataType from_ty = cast->value.dtype();
-        DataType target_ty = cast->dtype;
-        if (IsCudaVectorizableCast(from_ty, target_ty) &&
-            TargetIsCuda(Target::Current())) {
-          has_cast_operations = true;
-        }
-      }
-    });
-
-    // Decide whether to vectorize: only if there are non-local buffers or
-    // vectorizable casts. Reducer combine stores (multiplicity markers were
-    // already lowered by PartitionLoop) need no special exclusion: the
-    // vectorizer's planner keeps stores whose indices do not advance with
-    // the vectorized loop var scalar, which is exactly the reduction-axis
-    // hazard; output-axis contiguous combine stores vectorize like any
-    // other read-modify-write.
-    bool should_vectorize = has_non_local || has_cast_operations;
-    // Lower the parallel loop using the common function
     Stmt lowered = LowerParallelLoop(
         for_node, loop_layout, CurrentThreadIndex(), analyzer_, layout_map_,
-        predicate, parallel_loop, should_vectorize, require_padding_guard);
+        predicate, parallel_loop, require_padding_guard);
 
     // Only parallel-loop lowering needs PTX cp.async injection. Thread-level
     // lowering does not require converting eligible global->shared copies to

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1359,9 +1359,47 @@ private:
     // iteration has to be owned by the corresponding thread.
     bool parallel_loop = has_non_local_store || has_fragment_access;
 
+    // Check if there are non-local buffer accesses (for vectorization decision)
+    bool has_non_local = false;
+    PostOrderVisit(for_node->body, [&](const ObjectRef &obj) {
+      if (const auto *load = obj.as<BufferLoadNode>()) {
+        if (!IsLocalBuffer(load->buffer, /*allow_var*/ true) &&
+            !IsFragmentBuffer(load->buffer)) {
+          has_non_local = true;
+        }
+      } else if (const auto *store = obj.as<BufferStoreNode>()) {
+        if (!IsLocalBuffer(store->buffer, /*allow_var*/ true) &&
+            !IsFragmentBuffer(store->buffer)) {
+          has_non_local = true;
+        }
+      }
+    });
+
+    // Check if vectorizable cast operations exist
+    bool has_cast_operations = false;
+    PostOrderVisit(for_node->body, [&](const ObjectRef &obj) {
+      if (const auto *cast = obj.as<CastNode>()) {
+        DataType from_ty = cast->value.dtype();
+        DataType target_ty = cast->dtype;
+        if (IsCudaVectorizableCast(from_ty, target_ty) &&
+            TargetIsCuda(Target::Current())) {
+          has_cast_operations = true;
+        }
+      }
+    });
+
+    // Decide whether to vectorize: only if there are non-local buffers or
+    // vectorizable casts. Reducer combine stores (multiplicity markers were
+    // already lowered by PartitionLoop) need no special exclusion: the
+    // vectorizer's planner keeps stores whose indices do not advance with
+    // the vectorized loop var scalar, which is exactly the reduction-axis
+    // hazard; output-axis contiguous combine stores vectorize like any
+    // other read-modify-write.
+    bool should_vectorize = has_non_local || has_cast_operations;
+    // Lower the parallel loop using the common function
     Stmt lowered = LowerParallelLoop(
         for_node, loop_layout, CurrentThreadIndex(), analyzer_, layout_map_,
-        predicate, parallel_loop, require_padding_guard);
+        predicate, parallel_loop, should_vectorize, require_padding_guard);
 
     // Only parallel-loop lowering needs PTX cp.async injection. Thread-level
     // lowering does not require converting eligible global->shared copies to

--- a/src/webgpu/op/transpose.cc
+++ b/src/webgpu/op/transpose.cc
@@ -46,8 +46,7 @@ struct Transpose {
     return LowerParallelLoop(
         par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
         lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-        /*parallel_loop=*/true, /*should_vectorize=*/true,
-        par_op->LoopLayoutRequiresPaddingGuard());
+        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 

--- a/src/webgpu/op/transpose.cc
+++ b/src/webgpu/op/transpose.cc
@@ -46,7 +46,8 @@ struct Transpose {
     return LowerParallelLoop(
         par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
         lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
-        /*parallel_loop=*/true, par_op->LoopLayoutRequiresPaddingGuard());
+        /*parallel_loop=*/true, /*should_vectorize=*/true,
+        par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 

--- a/testing/python/issue/test_tilelang_issue_1734.py
+++ b/testing/python/issue/test_tilelang_issue_1734.py
@@ -32,12 +32,15 @@ def test_issue_1734():
 
     mod = kernel.compile()
     source = mod.get_kernel_source()
-    # Verify that the if statement is hoisted outside the for loop
-    # After hoisting, we should see "if" before "for" pattern
+    # Verify that the if statement is hoisted outside the for loop: the
+    # guarded loop must sit inside the if block (a "for (" before the
+    # first "}" after the if). Positions relative to the whole source
+    # would be broken by the copy loops that precede the guarded region.
     if_pos = source.find("if (")
-    for_pos = source.find("for (")
-    assert if_pos != -1 and for_pos != -1
-    assert if_pos < for_pos, "Loop-invariant if should be hoisted outside the loop"
+    assert if_pos != -1, "Guard should survive lowering"
+    after_if = source[if_pos:]
+    for_pos = after_if.find("for (")
+    assert for_pos != -1 and for_pos < after_if.find("}"), "Loop-invariant if should be hoisted outside the loop"
 
 
 if __name__ == "__main__":

--- a/testing/python/issue/test_tilelang_issue_1734.py
+++ b/testing/python/issue/test_tilelang_issue_1734.py
@@ -10,20 +10,20 @@ def test_issue_1734():
     def kernel():
         @T.prim_func
         def main(
-            A: T.Tensor[(2, 512), T.float32],
-            B: T.Tensor[(2, 512), T.float32],
+            A: T.Tensor[(2, 4096), T.float32],
+            B: T.Tensor[(2, 4096), T.float32],
             C: T.Tensor[(2,), T.float32],
         ):
             with T.Kernel(1, threads=256):
-                A_local = T.alloc_fragment((2, 512), T.float32)
-                B_local = T.alloc_fragment((2, 512), T.float32)
+                A_local = T.alloc_fragment((2, 4096), T.float32)
+                B_local = T.alloc_fragment((2, 4096), T.float32)
                 C_local = T.alloc_fragment((2,), T.float32)
 
                 T.copy(A, A_local)
                 T.copy(C, C_local)
 
-                for i, j in T.Parallel(2, 512):
-                    if C_local[i] >= 0:
+                for i, j in T.Parallel(2, 4096):
+                    if C_local[0] >= 0:
                         B_local[i, j] = A_local[i, j]
 
                 T.copy(B_local, B)
@@ -36,6 +36,7 @@ def test_issue_1734():
     # After hoisting, we should see "if" before "for" pattern
     if_pos = source.find("if (")
     for_pos = source.find("for (")
+    assert if_pos != -1 and for_pos != -1
     assert if_pos < for_pos, "Loop-invariant if should be hoisted outside the loop"
 
 

--- a/testing/python/language/test_tilelang_language_parallel.py
+++ b/testing/python/language/test_tilelang_language_parallel.py
@@ -85,8 +85,9 @@ def _parallel_vectorize_local_and_var():
 
 def test_parallel_vectorize_var():
     source = _parallel_vectorize_local_and_var.get_kernel_source()
-    # do not vectorize if the loop only contains local/fragment and var buffer access
-    assert "float2" not in source
+    # register-register loops vectorize too; the var operand becomes a
+    # scalar broadcast inside the packed multiply
+    assert "float2" in source
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously `T.Parallel` loops involving only local buffers (including fragment buffers) are not allowed to be vectorized. After careful inspection we found that this does not make sense. So we lift the restriction.

This allows us to vectorize non-casting `T.Parallel` loops on registers to utilize e.g. `fp32x2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Removes the restriction on vectorizing `T.Parallel` loops that use only local or fragment buffers.
- Enables register-only loops to use vector types such as `fp32x2`.
- Simplifies `LowerParallelLoop` by removing its `should_vectorize` parameter and restoring always-vectorize behavior with access analysis selecting the vector width.
- Updates backend call sites to use the shared vectorization behavior.
- Updates tests to verify register-register vectorization and generated loop ordering.

## C++ style / lint notes

- The PR changes C++ APIs and implementation code, but it does not modify rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) may report advisory findings. These warnings are separate from correctness, build, and test results and are not merge blockers unless they indicate a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->