### PR TITLE
[Refactor] Restore LoopUnswitching test altered by #3121

### DIFF
--- a/testing/python/issue/test_tilelang_issue_1734.py
+++ b/testing/python/issue/test_tilelang_issue_1734.py
@@ -10,20 +10,26 @@ def test_issue_1734():
     def kernel():
         @T.prim_func
         def main(
-            A: T.Tensor[(2, 4096), T.float32],
-            B: T.Tensor[(2, 4096), T.float32],
+            A: T.Tensor[(2, 512), T.float32],
+            B: T.Tensor[(2, 512), T.float32],
             C: T.Tensor[(2,), T.float32],
         ):
-            with T.Kernel(1, threads=256):
-                A_local = T.alloc_fragment((2, 4096), T.float32)
-                B_local = T.alloc_fragment((2, 4096), T.float32)
+            with T.Kernel(1, threads=128):
+                A_local = T.alloc_fragment((2, 512), T.float32)
+                B_local = T.alloc_fragment((2, 512), T.float32)
                 C_local = T.alloc_fragment((2,), T.float32)
+
+                # Each thread owns 8 contiguous elements of one row, so i is
+                # constant per thread and the guard below is loop-invariant,
+                # while a residual serial loop survives vectorization.
+                row_chunks = T.Fragment((2, 512), forward_fn=lambda i, j: (i * 64 + j // 8, j % 8))
+                T.annotate_layout({A_local: row_chunks, B_local: row_chunks})
 
                 T.copy(A, A_local)
                 T.copy(C, C_local)
 
-                for i, j in T.Parallel(2, 4096):
-                    if C_local[0] >= 0:
+                for i, j in T.Parallel(2, 512):
+                    if C_local[i] >= 0:
                         B_local[i, j] = A_local[i, j]
 
                 T.copy(B_local, B)
@@ -34,8 +40,7 @@ def test_issue_1734():
     source = mod.get_kernel_source()
     # Verify that the if statement is hoisted outside the for loop: the
     # guarded loop must sit inside the if block (a "for (" before the
-    # first "}" after the if). Positions relative to the whole source
-    # would be broken by the copy loops that precede the guarded region.
+    # first "}" after the if).
     if_pos = source.find("if (")
     assert if_pos != -1, "Guard should survive lowering"
     after_if = source[if_pos:]


### PR DESCRIPTION
In `testing/python/issue/test_tilelang_issue_1734.py` the test condition `if C_local[i] >= 0:` was inadvertently changed to `if C_local[0] >= 0:` by PR #3121 , which deviates from the purpose of this test. This PR restores the original behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Restores the intended `C_local[i]` condition in `test_tilelang_issue_1734.py`.
- Pins the row-chunk layout so `C_local[i]` remains loop-invariant.
- Reduces tensor sizes and thread count for the regression test.

## Testing

- Updates the TileLang regression test for issue 1734.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->