### PR TITLE
[BugFix] Reject non-bijective sm8x sparse metadata shapes

### DIFF
--- a/testing/python/tilelibrary/test_tilelang_tilelibrary_gemm_sp.py
+++ b/testing/python/tilelibrary/test_tilelang_tilelibrary_gemm_sp.py
@@ -5,6 +5,8 @@ from tilelang.utils.tensor import torch_assert_close
 import tilelang.testing
 import torch
 import tilelang.language as T
+from tilelang import tvm
+from tilelang.layout.gemm_sp import make_cutlass_metadata_layout_sm8x
 
 
 def matmul(
@@ -755,6 +757,22 @@ def test_gemm_rr(
 )
 def test_compress_dtype_combinations(in_dtype, out_dtype, dtypeAccum, meta_dtype):
     run_gemm_ss(128, 128, 128, False, True, in_dtype, out_dtype, dtypeAccum, 128, 128, 64, 2, 128, meta_dtype=meta_dtype)
+
+
+def test_make_cutlass_metadata_layout_sm8x_rejects_bad_shapes():
+    with pytest.raises(ValueError, match="multiple of"):
+        make_cutlass_metadata_layout_sm8x(tvm.tirx.decl_buffer((48, 4), T.int16), mma_dtype=T.float16)  # 48 % 32 != 0
+
+    with pytest.raises(ValueError, match="even"):
+        make_cutlass_metadata_layout_sm8x(tvm.tirx.decl_buffer((64, 3), T.int16), mma_dtype=T.float16)  # odd K
+
+    with pytest.raises(ValueError, match="multiple of"):
+        make_cutlass_metadata_layout_sm8x(tvm.tirx.decl_buffer((40, 4), T.int32), mma_dtype=T.int8)  # 40 % 16 != 0
+
+
+def test_make_cutlass_metadata_layout_sm8x_accepts_valid_shapes():
+    make_cutlass_metadata_layout_sm8x(tvm.tirx.decl_buffer((64, 4), T.int16), mma_dtype=T.float16)
+    make_cutlass_metadata_layout_sm8x(tvm.tirx.decl_buffer((48, 4), T.int32), mma_dtype=T.int8)
 
 
 if __name__ == "__main__":

--- a/tilelang/layout/gemm_sp.py
+++ b/tilelang/layout/gemm_sp.py
@@ -135,6 +135,12 @@ def make_cutlass_metadata_layout_sm8x(buffer: tvm.tirx.Buffer, mma_dtype: str):
     group = 32 if buffer.dtype.bits == 16 else 16
     interweave = 4 if buffer.dtype.bits == 16 else 2
 
+    # ref: https://github.com/pytorch/pytorch/blob/18acb4f62d1557fb068bfeec4622967885484da6/torch/sparse/_semi_structured_conversions.py#L72-L81
+    if m % group != 0:
+        raise ValueError(f"metadata M={m} must be a multiple of {group}")
+    if k % 2 != 0:
+        raise ValueError(f"metadata K={k} must be even")
+
     def ColumnMajorInterleaved(i: int, j: int) -> int:
         i = i // group * group + (i % 8) * interweave + (i % group) // 8
         topright = (1 - (i % 2)) & (j % 2)


### PR DESCRIPTION
## Summary
- `make_cutlass_metadata_layout_sm8x`'s interleave is a bijection only when M is a multiple of the group size (32/16) and K is even; otherwise it silently collides or writes out of range.
- Reject both cases with a `ValueError`.

## Test plan
- [x] `pytest testing/python/layout/test_tilelang_layout_gemm_sp_metadata.py`

Fixes #2606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Validate SM8x sparse metadata shapes before layout construction.
- Raise `ValueError` when `M` is not a multiple of the required interleave group or when `K` is odd.
- Add tests for rejected and accepted metadata shapes and dtypes.

## Impact

This prevents non-bijective mappings, collisions, and out-of-range metadata accesses for unsupported shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->