### PR TITLE
[Example] Fix hadamard reference precision on TF32 and add pytest entry for CI

### DIFF
--- a/examples/hadamard_transform/example_hadamard.py
+++ b/examples/hadamard_transform/example_hadamard.py
@@ -5,7 +5,6 @@ from tilelang.cuda.intrinsics import make_mma_swizzle_layout
 import math
 import argparse
 import torch
-from torch.nn import functional as F
 import scipy
 
 
@@ -125,7 +124,13 @@ def ref_program(x: torch.Tensor):
     assert x.ndim == 2
     dim = x.shape[-1]
     assert is_pow_of_2(dim)
-    return F.linear(x, torch.tensor(scipy.linalg.hadamard(dim, dtype=float), dtype=x.dtype, device=x.device))
+    # Compute the reference in float64: an fp32 matmul may run in reduced
+    # precision depending on the environment (e.g. TF32 is enabled by default
+    # in NGC torch builds). For dim=32768 such a reference deviates from the
+    # exact result by ~1e-1, which exceeds the 1e-2 tolerance below and makes
+    # a correct kernel "fail".
+    H = torch.tensor(scipy.linalg.hadamard(dim, dtype=float), dtype=torch.float64, device=x.device)
+    return (x.double() @ H.T).to(x.dtype)
 
 
 def main():

--- a/examples/hadamard_transform/example_hadamard.py
+++ b/examples/hadamard_transform/example_hadamard.py
@@ -133,11 +133,11 @@ def ref_program(x: torch.Tensor):
     return (x.double() @ H.T).to(x.dtype)
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("--batch", type=int, default=64, help="Batch size")
     parser.add_argument("--dim", type=int, default=32768, help="Dimension")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     B, D = args.batch, args.dim
     x = torch.randn((B, D), device="cuda")

--- a/examples/hadamard_transform/test_example_hadamard.py
+++ b/examples/hadamard_transform/test_example_hadamard.py
@@ -1,0 +1,18 @@
+import tilelang.testing
+
+import example_hadamard
+
+
+# Cover the distinct kernel code paths:
+#   dim=256   -> thread-local + warp shuffle only (no shared-memory exchange)
+#   dim=1024  -> single shared-memory exchange across warps
+#   dim=8192  -> single exchange with full 32KB shared memory
+#   dim=32768 -> multiple shared-memory exchange rounds
+@tilelang.testing.requires_cuda
+def test_example_hadamard():
+    for batch, dim in [(8, 256), (8, 1024), (8, 8192), (8, 32768)]:
+        example_hadamard.main(["--batch", str(batch), "--dim", str(dim)])
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Description

This PR fixes a spurious precision failure in the hadamard example and makes
the example actually run in CI.

### Problem

Running `examples/hadamard_transform/example_hadamard.py` (default
`batch=64, dim=32768, fp32`) fails `torch.testing.assert_close` with
`atol=rtol=1e-2`:

```text
Mismatched elements: 19509 / 2097152 (0.9%)
Greatest absolute difference: 0.18517494201660156 at index (26, 15653) (up to 0.01 allowed)
Greatest relative difference: 1311.22216796875 at index (45, 409) (up to 0.01 allowed)
```

### Root Cause

The kernel is correct — the **reference** is the low-precision side.
`ref_program` used `F.linear` in fp32, which silently runs in TF32 on NGC
torch builds (`allow_tf32=True` / `fp32_precision=tf32` by default, unlike
community torch builds).

Evidence (measured on H200, NGC image, torch 2.11 + CUDA 13.2):

| Check | Result |
|:---|:---|
| Two runs on the same input | bit-identical (`max_abs = 0`, no race) |
| Kernel vs fp64 reference (all dims 256–32768) | `max_abs ≤ 1.2e-4`, 0 mismatches |
| TF32 `F.linear` reference vs fp64 reference | `max_abs = 1.9e-1`, 12.6% mismatches (@1e-3) |

TF32 truncates inputs to a 10-bit mantissa before the multiply; over a
32768-length dot product this accumulates to ~0.1 absolute error — far
beyond the 1e-2 tolerance, so a perfectly correct kernel "fails".

### Changes

- **`example_hadamard.py`**: compute the reference in float64 and cast back
  to the kernel dtype, making it an environment-independent oracle.
- **`example_hadamard.py`**: `main()` now accepts an optional `argv` list
  (same pattern as the convolution example) so it can be driven from pytest
  without argument conflicts.
- **`test_example_hadamard.py`** (new): pytest entry covering the distinct
  kernel code paths:
  - `dim=256` — thread-local + warp shuffle only (no smem exchange)
  - `dim=1024` — single shared-memory exchange across warps
  - `dim=8192` — single exchange filling the full 32KB smem
  - `dim=32768` — multiple shared-memory exchange rounds

  Note the example had never been executed by CI before: the examples suite
  is collected with pytest's default `test_*.py` pattern, so the earlier
  "[CI] Add hadamard example to CI" (#549) never actually took effect.

### Verification

- `python examples/hadamard_transform/example_hadamard.py` on H200 (NGC
  torch, TF32 on): `All tests passed. Tile-lang: 0.04 ms`
- `pytest examples/hadamard_transform/test_example_hadamard.py` on H200:
  `1 passed in 21.40s` (with examples `conftest.py`)
- `ruff check` / `ruff format --check` clean on both files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Use a float64 Hadamard reference computation to avoid TF32 precision errors.
- Cast the reference result back to the input dtype.
- Allow `main(argv=None)` for test invocation.
- Add CUDA-gated pytest coverage for dimensions 256, 1024, 8192, and 32768.
- Cover thread-local, warp-shuffle, and shared-memory kernel paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->