### PR TITLE
[BugFix] Coalesce sub-32-bit elements in parallel loop partition   

### DIFF
--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -10,6 +10,7 @@
 #include <tvm/runtime/logging.h>
 
 #include <algorithm>
+#include <limits>
 #include <tvm/tirx/analysis.h>
 #include <tvm/tirx/op.h>
 #include <unordered_set>
@@ -120,7 +121,85 @@ int SelectMinPaddingVectorSize(int max_vector_size, PrimExpr loop_total_size,
   return best_vector_size;
 }
 
+/**
+ * @brief Whether the statement contains a call with non-pure effects.
+ *
+ * Atomics and stateful intrinsics rule out treating the loop as a pure copy.
+ * Pure calls (e.g. shift/logical builtins inside index arithmetic) do not
+ * block copy coalescing.
+ */
+bool ContainsImpureCall(const Stmt &stmt) {
+  bool impure = false;
+  PostOrderVisit(stmt, [&](const ObjectRef &node) {
+    if (impure) {
+      return;
+    }
+    if (const auto *call = node.as<CallNode>()) {
+      impure = SideEffect(GetRef<PrimExpr>(call)) > CallEffectKind::kPure;
+    }
+  });
+  return impure;
+}
+
+/**
+ * @brief Whether every buffer store is a raw global->shared copy.
+ *
+ * A raw copy is a shared-memory store whose value is a load from a global
+ * buffer with a matching dtype — the only shape that the cp.async injector
+ * can rewrite. cp.async only applies to global->shared transfers, so loops
+ * with other side effects (global stores, mixed compute) must keep their
+ * original partition: re-coalescing them changes their codegen (or even
+ * their semantics, e.g. vectorized atomics) without enabling cp.async.
+ */
+bool IsPureGlobalToSharedCopyLoop(const Stmt &stmt) {
+  bool pure = true;
+  bool saw_store = false;
+  PostOrderVisit(stmt, [&](const ObjectRef &node) {
+    const auto *store = node.as<BufferStoreNode>();
+    if (store == nullptr || !pure) {
+      return;
+    }
+    saw_store = true;
+    const auto *load = store->value.as<BufferLoadNode>();
+    if (load == nullptr || !IsGlobalBuffer(load->buffer) ||
+        !IsSharedBuffer(store->buffer) ||
+        load->buffer->dtype != store->buffer->dtype) {
+      pure = false;
+    }
+  });
+  return saw_store && pure;
+}
+
+/**
+ * @brief Smallest element bit-width among the loop's global->shared copies.
+ *
+ * Measures the full element width (dtype bits times lanes) so vector-typed
+ * buffers are not underreported and over-widened. Callers must only use this
+ * after IsPureGlobalToSharedCopyLoop() accepted the loop.
+ */
+int MinGlobalToSharedCopyElementBits(const Stmt &stmt) {
+  int min_bits = std::numeric_limits<int>::max();
+  PostOrderVisit(stmt, [&](const ObjectRef &node) {
+    if (const auto *store = node.as<BufferStoreNode>()) {
+      if (const auto *load = store->value.as<BufferLoadNode>()) {
+        int bits = load->buffer->dtype.bits() * load->buffer->dtype.lanes();
+        min_bits = std::min(min_bits, bits);
+      }
+    }
+  });
+  return min_bits;
+}
+
 } // anonymous namespace
+
+std::optional<int>
+ParallelOpNode::GlobalToSharedCopyMinElementBits(const For &root) const {
+  if (ContainsImpureCall(root->body) ||
+      !IsPureGlobalToSharedCopyLoop(root->body)) {
+    return std::nullopt;
+  }
+  return MinGlobalToSharedCopyElementBits(root->body);
+}
 
 /**
  * @brief Handle a parallel For node during traversal, collecting loop metadata.
@@ -996,6 +1075,16 @@ Fragment ParallelOpNode::ComputeLoopLayoutFromBuffer(
   return result;
 }
 
+/**
+ * @brief Compute the plan-based loop layout candidate.
+ *
+ * Determines a vectorized loop layout candidate from the maximum legal
+ * vectorize size, then adjusts it to the smallest-padding width for
+ * non-fragment loops. Pure global->shared copies with sub-32-bit dtypes are
+ * additionally coalesced to keep each active thread's chunk at or above
+ * 4 bytes, so the copy stays compatible with the cp.async minimum transfer
+ * width instead of silently falling back to a synchronous load.
+ */
 Fragment
 ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &layout_args) const {
   // Vectorize Size must be aware of the buffer_remap
@@ -1024,9 +1113,27 @@ ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &layout_args) const {
       vector_size /= 2;
     }
   } else if (!root_->annotations.count(attr::kCoalescedWidth)) {
+    int max_vector_size = vector_size;
     vector_size = SelectMinPaddingVectorSize(vector_size, loop_total_size,
                                              layout_args.thread_bounds->extent,
                                              &analyzer_);
+    // Coalesce sub-width elements before distributing them to threads: for
+    // global->shared copies, keep each active thread's chunk at or above the
+    // cp.async minimum transfer width. Smaller per-thread chunks are
+    // memory-inefficient and fall below that width (4/8/16 bytes), which
+    // would silently force the synchronous copy fallback. Threads left idle
+    // by the wider chunk are covered by the partition predicate (and by
+    // predicated cp.async after the rewrite pass).
+    if (auto min_bits =
+            GlobalToSharedCopyMinElementBits(maybe_remapped_root_)) {
+      if (*min_bits < kCPAsyncMinTransferBits &&
+          kCPAsyncMinTransferBits % *min_bits == 0) {
+        int min_lanes = kCPAsyncMinTransferBits / *min_bits;
+        if (vector_size < min_lanes && max_vector_size >= min_lanes) {
+          vector_size = min_lanes;
+        }
+      }
+    }
   }
   DLOG(INFO) << "[PlanLoopPartition] after adjust: vector_size = "
              << vector_size << '\n';

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -10,6 +10,7 @@
 #include <tvm/target/target.h>
 #include <tvm/tirx/stmt_functor.h>
 
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -224,6 +225,11 @@ private:
   // Compute plan-based loop layout candidate using vectorization and thread
   // bounds.
   Fragment ComputePlanCandidate(const LayoutInferArgs &layout_args) const;
+  // If `root`'s body is a pure global->shared copy, return the minimum
+  // element bit-width (dtype bits times lanes) of the copied dtypes;
+  // otherwise return std::nullopt. Drives the cp.async-oriented partition
+  // coalescing in ComputePlanCandidate.
+  std::optional<int> GlobalToSharedCopyMinElementBits(const For &root) const;
   // Propose the partial layout of a reducer this nest updates, from the
   // solved loop layout: the induced projection when every narrow-plan proof
   // passes, participant-wide replication otherwise.

--- a/src/op/utils.h
+++ b/src/op/utils.h
@@ -102,6 +102,13 @@ inline bool IsGlobalBuffer(const Buffer &buffer) {
   return buffer.defined() && buffer.scope() == "global";
 }
 
+// Minimum transfer width of a single cp.async transaction, and its value in
+// bits. PTX cp.async supports 4/8/16-byte transactions; the SIMT partition
+// coalescing in op/parallel.cc references this instead of a bare 32 so the
+// two cannot silently drift apart.
+inline constexpr int kCPAsyncMinTransferBytes = 4;
+inline constexpr int kCPAsyncMinTransferBits = kCPAsyncMinTransferBytes * 8;
+
 inline bool IsValidCPAsyncTransferBytes(int bytes) {
   return bytes == 4 || bytes == 8 || bytes == 16;
 }

--- a/testing/python/language/test_tilelang_language_copy.py
+++ b/testing/python/language/test_tilelang_language_copy.py
@@ -1,9 +1,11 @@
 import tilelang
 import tilelang.language as T
+import pytest
 import torch
 import tilelang.testing
 from tilelang import tvm
 from tilelang.layout import make_gemm_fragment_8x8_transposed
+from tilelang.tools.compile_only import compile_kernel_source, cuda_codegen_available
 
 print(torch.__version__)
 
@@ -451,6 +453,83 @@ def test_tilelang_copy_uses_stmatrix_m16n8_for_sm100_int8_shared_store():
         artifact = tilelang.lower(main, target=target)
 
     assert "tl::ptx_stmatrix_m16n8_x1_trans" in artifact.kernel_source
+
+
+def _sub32bit_g2s_copy_kernel(dtype, n=128, threads=128):
+    """128 threads copy 128 sub-32-bit elements global -> shared.
+
+    Each thread naturally gets a sub-4-byte chunk, which used to fall below
+    the cp.async minimum transfer width and silently lower to a synchronous
+    scalar load. The partitioner now coalesces the chunk to >= 4 bytes.
+    """
+
+    @T.prim_func
+    def kernel(A: T.Tensor((n,), dtype), B: T.Tensor((n,), dtype)):
+        with T.Kernel(1, threads=threads):
+            a_sh = T.alloc_shared((n,), dtype)
+            T.copy(A, a_sh, prefer_instruction="cp_async")
+            T.copy(a_sh, B)
+
+    return kernel
+
+
+@pytest.mark.skipif(
+    not cuda_codegen_available(),
+    reason="CUDA codegen FFI missing (e.g. ROCm or macOS Metal builds)",
+)
+def test_sub32bit_g2s_copy_coalesced_to_cp_async():
+    src = compile_kernel_source(_sub32bit_g2s_copy_kernel(T.float8_e4m3fn), "cuda -arch=sm_80")
+    # 4 fp8 elements per active thread -> cp.async; the 96 threads left idle
+    # by the wider chunk are predicated off.
+    assert "tl::cp_async" in src
+    assert "((int)threadIdx.x) < 32" in src
+
+
+def _atomic_add_kernel(dtype=T.bfloat16, n=128, threads=128):
+    @T.prim_func
+    def kernel(A: T.Tensor((n,), dtype), Out: T.Tensor((1,), dtype)):
+        with T.Kernel(1, threads=threads):
+            for i in T.Parallel(n):
+                T.atomic_add(Out[0], A[i])
+
+    return kernel
+
+
+@pytest.mark.skipif(
+    not cuda_codegen_available(),
+    reason="CUDA codegen FFI missing (e.g. ROCm or macOS Metal builds)",
+)
+def test_sub32bit_atomic_loop_not_coalesced():
+    # Negative case: a loop containing an atomic (impure) call is not a pure
+    # global->shared copy, so the partition keeps the original one
+    # element/thread distribution (vectorizing the loop once corrupted the
+    # atomic into a half-width update).
+    src = compile_kernel_source(_atomic_add_kernel(), "cuda -arch=sm_80")
+    assert "AtomicAdd" in src
+    assert "((int)threadIdx.x) < 64" not in src
+    assert "A[((int)threadIdx.x)]" in src
+
+
+def _global_compute_store_kernel(dtype=T.float16, n=128, threads=128):
+    @T.prim_func
+    def kernel(A: T.Tensor((n,), dtype), B: T.Tensor((n,), dtype)):
+        with T.Kernel(1, threads=threads):
+            for i in T.Parallel(n):
+                B[i] = A[i] + A[i % 32]
+
+    return kernel
+
+
+@pytest.mark.skipif(
+    not cuda_codegen_available(),
+    reason="CUDA codegen FFI missing (e.g. ROCm or macOS Metal builds)",
+)
+def test_sub32bit_non_copy_store_not_coalesced():
+    # Negative case: a global load feeding a non-copy global store (mixed
+    # compute) is not eligible for coalescing either; one element/thread and
+    # no thread-idling predicate.
+    src = compile_kernel_source(_global_compute_store_kernel(), "cuda -arch=sm_80")
+    assert "((int)threadIdx.x) < 64" not in src
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
                                                                                                                                                
   ### Problem                                                                                                                                                   
                                                                                                                                                                 
   When a non-fragment `T.Parallel` loop touches global memory with a sub-32-bit                                                                                 
   dtype (fp8/int8/uint16/fp16), the loop partitioner may assign each thread fewer                                                                               
   than 4 bytes. For example, copying 128 fp8 elements with 128 threads gives                                                                                    
   1 byte per thread.                                                                                                                                            
                                                                                                                                                                 
   cp.async requires a transfer width of 4/8/16 bytes, so with a sub-4B per-thread                                                                               
   chunk `InjectPTXAsyncCopy` finds no eligible vectorized global→shared store and                                                                               
   the copy **silently falls back to a synchronous scalar global load** — even when                                                                              
   `prefer_instruction="cp_async"` is given explicitly. These sub-4B per-thread                                                                                  
   global accesses are also memory-inefficient in general.                                                                                                       
                                                                                                                                                                 
   ### Reproducer                                                                                                                                                
                                                                                                                                                                 
   ```python                                                                                                                                                     
   import tilelang                                                                                                                                               
   import tilelang.language as T                                                                                                                                 
   from tilelang.tools.compile_only import compile_kernel_source                                                                                                 
                                                                                                                                                                 
   N, THREADS = 128, 128                                                                                                                                         
                                                                                                                                                                 
                                                                                                                                                                 
   @T.prim_func                                                                                                                                                  
   def kernel(                                                                                                                                                   
       A: T.Tensor((N,), T.float8_e4m3fn),                                                                                                                       
       B: T.Tensor((N,), T.float8_e4m3fn),                                                                                                                       
   ):                                                                                                                                                            
       with T.Kernel(1, threads=THREADS) as bx:                                                                                                                  
           a_sh = T.alloc_shared((N,), T.float8_e4m3fn)                                                                                                          
           T.copy(A, a_sh, prefer_instruction="cp_async")                                                                                                        
           T.copy(a_sh, B)                                                                                                                                       
                                                                                                                                                                 
                                                                                                                                                                 
   src = compile_kernel_source(kernel, "cuda -arch=sm_80")                                                                                                       
   print(src)                                                                                                                                                    
   assert "tl::cp_async" in src          # used to silently fall back to a sync load                                                                             
   assert "threadIdx.x) < 32" in src     # idled threads are predicated off                                                                                      
   ```                                                                                                                                                           
                                                                                                                                                                 
   ### Generated code (kernel body)                                                                                                                              
                                                                                                                                                                 
   **Before** — 1 byte per thread, cp.async rewrite misses, silent sync fallback:                                                                                
                                                                                                                                                                 
   ```cuda                                                                                                                                                       
   extern "C" __global__ void __launch_bounds__(128, 1) kernel_kernel(const fp8_e4_t* __restrict__ A, fp8_e4_t* __restrict__ B) {                                
     extern __shared__ __align__(1024) fp8_e4_t a_sh[];                                                                                                          
     a_sh[((int)threadIdx.x)] = A[((int)threadIdx.x)];                                                                                                           
     B[((int)threadIdx.x)] = a_sh[((int)threadIdx.x)];                                                                                                           
   }                                                                                                                                                             
   ```                                                                                                                                                           
                                                                                                                                                                 
   **After** — per-thread chunk coalesced to 4 bytes, lowered to cp.async, idle                                                                                  
   threads covered by the partition predicate:                                                                                                                   
                                                                                                                                                                 
   ```cuda                                                                                                                                                       
   extern "C" __global__ void __launch_bounds__(128, 1) kernel_kernel(const fp8_e4_t* __restrict__ A, fp8_e4_t* __restrict__ B) {                                
     extern __shared__ __align__(1024) fp8_e4_t a_sh[];                                                                                                          
     if (((int)threadIdx.x) < 32) {                                                                                                                              
       tl::cp_async_gs<4>((&(a_sh[(((int)threadIdx.x) * 4)])), (&(A[(((int)threadIdx.x) * 4)])));                                                                
     }                                                                                                                                                           
     tl::cp_async_commit();                                                                                                                                      
     tl::cp_async_wait<0>();                                                                                                                                     
     __syncthreads();                                                                                                                                            
     if (((int)threadIdx.x) < 32) {                                                                                                                              
       *(fp8_e4_4_t*)(B + (((int)threadIdx.x) * 4)) = *(fp8_e4_4_t*)(a_sh + (((int)threadIdx.x) * 4));                                                           
     }                                                                                                                                                           
   }                                                                                                                                                             
   ```                                                                                                                                                           
                                                                                                                                                                 
   ### Fix                                                                                                                                                       
                                                                                                                                                                 
   In `ParallelOpNode::ComputePlanCandidate`, after `SelectMinPaddingVectorSize`                                                                                 
   picks the smallest-padding vector width, scan the loop body for the smallest                                                                                  
   dtype bit-width among the accessed global-memory buffers                                                                                                      
   (`MinGlobalAccessDtypeBits`). If it is below 32 bits (and divides 32), scale the                                                                              
   per-thread chunk up to `32 / dtype_bits` elements — but only when the original                                                                                
   (maximum legal) vector width allows it, so we never exceed what vectorization                                                                                 
   would have used anyway.                                                                                                                                       
                                                                                                                                                                 
   Threads left idle by the wider chunk are covered by the partition predicate                                                                                   
   (and by predicated cp.async after the rewrite pass), so there is no                                                                                           
   out-of-bounds access, as shown by the `threadIdx.x < 32` guard in the generated                                                                               
   code above. Loops that do not touch global memory and loops with explicit                                                                                     
   `coalesced_width` annotations are unaffected.                                                                                                                 
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes partitioning for non-fragment `T.Parallel` loops that access global memory with sub-32-bit dtypes.
- Coalesces each thread’s work to at least 32 bits when the legal vector width allows it.
- Enables supported-width `cp.async` transfers instead of scalar synchronous loads.
- Guards threads that become inactive after chunk widening.
- Leaves loops without global-memory accesses and loops with explicit `coalesced_width` unchanged.

## C++ style / lint notes

- The PR changes C++ code in `src/op/parallel.cc`.
- It does not change the rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step remains advisory.
- No correctness, build, or test issue is identified from the described changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->