### PR TITLE
[BugFix][Transform] Keep shared FP32 atomics scalar on SM90

### DIFF
--- a/src/transform/vectorize_loop.cc
+++ b/src/transform/vectorize_loop.cc
@@ -149,14 +149,16 @@ inline Op GetVectorizedAtomicOp(int vector_size) {
 }
 
 /*!
- * \brief Get the max vector size supported by the given dtype for atomic ops.
+ * \brief Get the max vector size supported by the destination for atomic ops.
  */
-inline int GetMaxAtomicVectorSize(DataType dtype, Target target) {
+inline int GetMaxAtomicVectorSize(const Buffer &destination, Target target) {
+  DataType dtype = destination->dtype;
   if (dtype.is_float16() || dtype.is_bfloat16()) {
     return 2;
   }
   if (dtype.is_float() && dtype.bits() == 32 &&
-      TargetHasSMVersionGE(target, 90)) {
+      TargetHasSMVersionGE(target, 90) && IsGlobalBuffer(destination)) {
+    // CUDA's float2/float4 atomicAdd overloads support global memory only.
     return 4;
   }
   return 1;
@@ -635,9 +637,10 @@ public:
     auto dst_buffer_load = ExtractBufferLoadForAtomic(dst);
     Target target = Target::Current(false);
     int max_vec_size =
-        GetMaxAtomicVectorSize(dst_buffer_load.value()->buffer->dtype, target);
+        GetMaxAtomicVectorSize(dst_buffer_load.value()->buffer, target);
     if (vector_size > max_vec_size) {
-      // Vector size not supported for this dtype, cannot vectorize
+      // Keep the loop binder when this atomic requires scalar lanes.
+      need_scalarize_ = true;
       return GetRef<PrimExpr>(op);
     }
 

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -1342,6 +1342,40 @@ def test_atomic_add_contended_bf16():
     run_atomic_add_contended(128, 128, T.bfloat16)
 
 
+@tilelang.jit
+def atomic_add_fp32_shared_sm90_program(N, threads):
+    @T.prim_func
+    def atomic_add_fp32_shared_sm90(A: T.Tensor((N,), T.float32), Out: T.Tensor((N,), T.float32)):
+        with T.Kernel(1, threads=threads):
+            shared = T.alloc_shared((N,), T.float32)
+            for i in T.Parallel(N):
+                shared[i] = T.float32(0)
+            for i in T.Parallel(N):
+                T.atomic_add(shared[i], A[i])
+            for i in T.Parallel(N):
+                Out[i] = shared[i]
+
+    return atomic_add_fp32_shared_sm90
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_atomic_add_fp32_shared_stays_scalar_on_sm90():
+    n = 256
+    kernel = atomic_add_fp32_shared_sm90_program(n, 128)
+    source = kernel.get_kernel_source()
+
+    assert "AtomicAdd(" in source
+    assert "AtomicAddx2(" not in source
+    assert "AtomicAddx4(" not in source
+
+    a = torch.arange(n, dtype=torch.float32, device="cuda")
+    out = torch.empty_like(a)
+    kernel(a, out)
+
+    torch.testing.assert_close(out, a, atol=0, rtol=0)
+
+
 @tilelang.jit(target={"kind": "cuda", "arch": "sm_75"})
 def atomic_add_bf16_sm75_program(N):
     @T.prim_func

--- a/testing/python/transform/test_tilelang_transform_loop_vectorize.py
+++ b/testing/python/transform/test_tilelang_transform_loop_vectorize.py
@@ -7,6 +7,8 @@ from tvm.tirx.stmt_functor import post_order_visit
 
 
 _TARGET = tvm.target.Target({"kind": "cuda", "arch": "sm_80"})
+_SM89_TARGET = tvm.target.Target({"kind": "cuda", "arch": "sm_89"})
+_SM90_TARGET = tvm.target.Target({"kind": "cuda", "arch": "sm_90"})
 
 
 def _run_layout_inference(func):
@@ -21,6 +23,91 @@ def _run_vectorized_loop_legalizer(func):
     mod = tvm.IRModule({"main": func})
     with _TARGET:
         return tl.transform.LegalizeVectorizedLoop()(mod)
+
+
+def _run_vectorize_loop(func, target=_SM90_TARGET):
+    mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
+    with target:
+        mod = tvm.tirx.transform.BindTarget(target)(mod)
+        mod = tl.transform.FlattenBuffer()(mod)
+        return tl.transform.VectorizeLoop()(mod)
+
+
+def _atomic_op_names(func):
+    names = []
+
+    def collect(node):
+        if isinstance(node, tvm.tirx.Call) and hasattr(node.op, "name") and node.op.name.startswith("tl.atomic_add"):
+            names.append(node.op.name)
+
+    post_order_visit(func.body, collect)
+    return names
+
+
+def _loop_kinds(func):
+    kinds = []
+
+    def collect(node):
+        if isinstance(node, tvm.tirx.For):
+            kinds.append(node.kind)
+
+    post_order_visit(func.body, collect)
+    return kinds
+
+
+def _undefined_local_vars(func):
+    defined_vars = [*func.params, *(buffer.data for buffer in func.buffer_map.values())]
+    return tvm.tirx.analysis.undefined_vars(func.body, defined_vars)
+
+
+def test_fp32_shared_atomic_stays_scalar_on_sm90():
+    @T.prim_func
+    def main(A: T.Tensor((4,), T.float32)):
+        shared = T.alloc_buffer((4,), "float32", scope="shared")
+        for i in T.vectorized(4):
+            T.atomic_add(shared[i], A[i])
+
+    transformed = _run_vectorize_loop(main)
+
+    assert _atomic_op_names(transformed["main"]) == ["tl.atomic_add_elem_op"]
+    assert tvm.tirx.ForKind.SERIAL in _loop_kinds(transformed["main"])
+    assert not _undefined_local_vars(transformed["main"])
+
+
+def test_fp32_atomic_stays_scalar_on_sm89():
+    @T.prim_func
+    def main(A: T.Tensor((4,), T.float32), output: T.Tensor((4,), T.float32)):
+        for i in T.vectorized(4):
+            T.atomic_add(output[i], A[i])
+
+    transformed = _run_vectorize_loop(main, _SM89_TARGET)
+
+    assert _atomic_op_names(transformed["main"]) == ["tl.atomic_add_elem_op"]
+    assert tvm.tirx.ForKind.SERIAL in _loop_kinds(transformed["main"])
+    assert not _undefined_local_vars(transformed["main"])
+
+
+def test_fp32_global_atomic_keeps_x4_vectorization_on_sm90():
+    @T.prim_func
+    def main(A: T.Tensor((4,), T.float32), output: T.Tensor((4,), T.float32)):
+        for i in T.vectorized(4):
+            T.atomic_add(output[i], A[i])
+
+    transformed = _run_vectorize_loop(main)
+
+    assert _atomic_op_names(transformed["main"]) == ["tl.atomic_addx4_elem_op"]
+
+
+def test_fp16_shared_atomic_keeps_x2_vectorization_on_sm90():
+    @T.prim_func
+    def main(A: T.Tensor((2,), T.float16)):
+        shared = T.alloc_buffer((2,), "float16", scope="shared")
+        for i in T.vectorized(2):
+            T.atomic_add(shared[i], A[i])
+
+    transformed = _run_vectorize_loop(main)
+
+    assert _atomic_op_names(transformed["main"]) == ["tl.atomic_addx2_elem_op"]
 
 
 def _vectorized_extents(func):

--- a/testing/python/transform/test_tilelang_transform_loop_vectorize.py
+++ b/testing/python/transform/test_tilelang_transform_loop_vectorize.py
@@ -29,6 +29,7 @@ def _run_vectorize_loop(func, target=_SM90_TARGET):
     mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
     with target:
         mod = tvm.tirx.transform.BindTarget(target)(mod)
+        mod = tl.transform.LowerAccessPtr()(mod)
         mod = tl.transform.FlattenBuffer()(mod)
         return tl.transform.VectorizeLoop()(mod)
 

--- a/testing/python/transform/test_tilelang_transform_loop_vectorize.py
+++ b/testing/python/transform/test_tilelang_transform_loop_vectorize.py
@@ -70,7 +70,7 @@ def test_fp32_shared_atomic_stays_scalar_on_sm90():
     transformed = _run_vectorize_loop(main)
 
     assert _atomic_op_names(transformed["main"]) == ["tl.atomic_add_elem_op"]
-    assert tvm.tirx.ForKind.SERIAL in _loop_kinds(transformed["main"])
+    assert _loop_kinds(transformed["main"]) == [tvm.tirx.ForKind.SERIAL]
     assert not _undefined_local_vars(transformed["main"])
 
 
@@ -83,7 +83,7 @@ def test_fp32_atomic_stays_scalar_on_sm89():
     transformed = _run_vectorize_loop(main, _SM89_TARGET)
 
     assert _atomic_op_names(transformed["main"]) == ["tl.atomic_add_elem_op"]
-    assert tvm.tirx.ForKind.SERIAL in _loop_kinds(transformed["main"])
+    assert _loop_kinds(transformed["main"]) == [tvm.tirx.ForKind.SERIAL]
     assert not _undefined_local_vars(transformed["main"])
 
 


### PR DESCRIPTION
## Summary

SM90 auto-vectorization selected `AtomicAddx4` for shared-memory FP32 destinations. CUDA's `float2` and `float4` `atomicAdd` overloads support global memory, so the generated shared-memory call failed at launch with `CUDA_ERROR_INVALID_VALUE` on H100.

This change includes the destination memory scope in the atomic width decision. Shared FP32 atomics use scalar lanes, global FP32 atomics retain x4 vectorization on SM90+, and FP16/BF16 atomics retain x2 vectorization.

The scalar fallback now scalarizes the enclosing loop. This preserves the loop binder and produces valid TIR whenever the selected vector width exceeds the destination's supported atomic width.

## Tests

- Added host transform coverage for SM90 shared FP32 scalarization, SM89 FP32 scalarization, SM90 global FP32 x4, and SM90 shared FP16 x2.
- Added a CUDA runtime regression that checks generated atomic helpers and exact output on compute capability 9.0+ using the native device target.
- `python -m pytest testing/python/transform/test_tilelang_transform_loop_vectorize.py -q` (`16 passed`)
- `cmake --build build` with `USE_CUDA=OFF`
- `uvx pre-commit run --files src/transform/vectorize_loop.cc testing/python/transform/test_tilelang_transform_loop_vectorize.py testing/python/language/test_tilelang_language_atomic.py`

Closes tile-ai/tilelang#3038


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Select atomic vector width based on destination memory scope.
- Keep shared-memory FP32 atomics scalar.
- Preserve x4 vectorization for global FP32 atomics.
- Preserve x2 vectorization for FP16 and BF16 atomics.
- Scalarize the enclosing loop while preserving its binder.
- Add transform tests for shared and global FP32 and shared FP16 atomics.
- Add an SM90 CUDA regression test for generated atomic helpers and output correctness.

## C++ style / lint notes

- The PR changes C++ code in `src/transform/vectorize_loop.cc`.
- The change does not touch rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) CI step is relevant.
- Review warnings introduced by this change separately from correctness, build, and test failures.
- Warning-only TLCPP003/TLCPP004 findings are advisory and are not merge blockers unless they indicate an API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->