### PR TITLE
[Lang] Add T.auto_alloc with automatic memory-scope inference

### DIFF
--- a/src/op/utils.cc
+++ b/src/op/utils.cc
@@ -9,6 +9,7 @@
 #include <tvm/ir/cast.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/tirx/expr.h>
+#include <tvm/tirx/stmt_functor.h>
 
 #include <tvm/tirx/builtin.h>
 
@@ -126,6 +127,27 @@ AccessRegion NormalizeToAccessRegion(const PrimExpr &arg,
     }
   }
   return {NormalizeToBufferRegion(arg), default_access_mask};
+}
+
+void CheckNoAutoScopeBuffers(const PrimFunc &func, const char *pass_name) {
+  struct Visitor : StmtExprVisitor {
+    const char *pass_name;
+    void VisitStmt_(const SBlockNode *op) final {
+      for (const Buffer &buffer : op->alloc_buffers) {
+        ICHECK(buffer.scope() != "auto")
+            << pass_name << ": buffer '" << buffer->name
+            << "' still has the virtual scope \"auto\" (T.auto_alloc). The "
+               "tl.transform.InferMemoryScope pass must run before this pass "
+               "to resolve it; it is currently registered for the "
+               "cuda/rocm/cpu pipelines only. Use an explicit T.alloc_* "
+               "scope for this backend.";
+      }
+      StmtExprVisitor::VisitStmt_(op);
+    }
+  };
+  Visitor visitor;
+  visitor.pass_name = pass_name;
+  visitor(func->body);
 }
 
 PrimExpr MakeAccessPtrFromRegion(const BufferRegion &region, int rw_mask,

--- a/src/op/utils.h
+++ b/src/op/utils.h
@@ -11,6 +11,7 @@
 #include "support/check.h"
 #include "tvm/runtime/base.h"
 #include <tvm/tirx/buffer.h>
+#include <tvm/tirx/function.h>
 #include <tvm/tirx/op.h>
 
 namespace tvm {
@@ -112,6 +113,9 @@ inline bool IsLocalBuffer(const Buffer &buffer, bool allow_var = false) {
 inline bool IsLocalVarBuffer(const Buffer &buffer) {
   return buffer.defined() && buffer.scope() == "local.var";
 }
+
+TVM_DLL void CheckNoAutoScopeBuffers(const tirx::PrimFunc &func,
+                                     const char *pass_name);
 
 // True when global packed FP4 is copied into f8f6f4/mxf8f6f4 unpacked FP4 SMEM.
 inline bool IsFP4PackedToUnpackedStorageCopy(DataType global_dtype,

--- a/src/transform/infer_memory_scope.cc
+++ b/src/transform/infer_memory_scope.cc
@@ -1,0 +1,707 @@
+/*!
+ * \file infer_memory_scope.cc
+ *
+ * Infer concrete memory scopes for buffers allocated with the virtual scope
+ * "auto" (T.auto_alloc, issue #277).
+ *
+ * The pass runs early: after VerifyBufferInit and before warp specialization,
+ * pipeline planning and layout inference, so that downstream passes that
+ * branch on IsSharedBuffer (multi-versioning, cp.async/TMA staging, layout
+ * inference) already see the final scope.
+ *
+ * Decision rules (conservative, correctness first):
+ *   R1  tl.gemm accumulator (C)            -> local.fragment (hard)
+ *   R2  tl.gemm A/B operands               -> shared.dyn     (hard)
+ *   R3  T.copy(global -> X) dst inside a pipelined (num_stages) loop
+ *                                          -> shared.dyn     (hard)
+ *   R4  tl.cumsum / tl.cummax src or dst   -> shared.dyn     (hard)
+ *   R5  tl.copy / tl.fill / tl.atomic_add  -> no constraint
+ *   R6  all accesses are plain loads/stores inside T.Parallel nests, with a
+ *       consistent (up to loop-var renaming) bijective index mapping
+ *                                          -> local.fragment
+ *   R7  all accesses are plain loads/stores outside parallel loops
+ *                                          -> local
+ *       (but accesses whose indices reference a per-thread threadIdx binding
+ *       var, or which sit under a per-thread condition, are never R6/R7:
+ *       a per-thread scope would give every thread a private copy with only
+ *       its own slots written, silently breaking cross-thread reads)
+ *   R8  anything else                      -> shared.dyn
+ *   R9  R1 conflicting with R2/R3/R4       -> compile error with per-use
+ *                                             diagnostics
+ *   R10 dead buffer (no accesses)          -> local
+ *   R11 bool dtype decided as shared       -> shared (MergeSharedMemory-
+ *                                             Allocations cannot merge bool)
+ *
+ * On CPU targets every shared choice degrades to "local": the CPU backend has
+ * no shared-memory hierarchy and its op lowerings reject shared scopes.
+ *
+ * The rewrite follows the CanonicalizeLegacyReducer precedent: for each auto
+ * buffer a new data Var (with the new PointerType storage scope) and a new
+ * Buffer are created, the owning sblock's alloc_buffers entry is replaced, and
+ * all references in the body are rewritten.
+ */
+
+#include "../layout/layout.h"
+#include "../op/builtin.h"
+#include "../op/copy.h"
+#include "../op/gemm.h"
+#include "../op/gemm_sp.h"
+#include "../op/operator.h"
+#include "../op/scan.h"
+#include "../op/utils.h"
+#include "backend/common/target_utils.h"
+#include "common/pipeline_utils.h"
+
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <tvm/arith/analyzer.h>
+#include <tvm/arith/iter_affine_map.h>
+#include <tvm/runtime/logging.h>
+#include <tvm/tirx/analysis.h>
+#include <tvm/tirx/expr.h>
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt.h>
+#include <tvm/tirx/stmt_functor.h>
+#include <tvm/tirx/transform.h>
+
+namespace tvm::tl {
+
+using namespace tirx;
+using namespace ffi;
+
+namespace {
+
+constexpr const char *kAutoScope = "auto";
+
+/*! \brief Whether this call is a tile op (or a region bridge), however
+ *  well-formed its arguments are. */
+bool IsTileOpCall(const CallNode *op) {
+  if (op->op.same_as(tl::region())) {
+    return true;
+  }
+  auto opt_op = op->op.as<Op>();
+  if (!opt_op.has_value()) {
+    return false;
+  }
+  const std::string &name = opt_op.value()->name;
+  return name.rfind("tl.tileop.", 0) == 0;
+}
+
+/*! \brief Parse a call as a tile op, or return null if it cannot be parsed.
+ *
+ * The call is not always in its final form at this point in the pipeline; a
+ * builder that cannot interpret its arguments throws. Builders raise
+ * tvm::ffi::Error, which derives from std::exception; catching the base covers
+ * the rest by the same rule (same approach as VerifyBufferInit).
+ */
+TileOperator TryParseOperator(const Call &call) {
+  try {
+    return ParseOperator(call);
+  } catch (const std::exception &) {
+    return TileOperator();
+  }
+}
+
+/*! \brief Accumulated facts about one auto-scope buffer. */
+struct BufferScopeAnalysis {
+  /*! \brief The buffer is read or written at least once. */
+  bool has_access = false;
+  /*! \brief Uses that require local.fragment, as human-readable reasons. */
+  std::vector<std::string> fragment_reasons;
+  /*! \brief Uses that require shared memory, as human-readable reasons. */
+  std::vector<std::string> shared_reasons;
+  /*! \brief Every access is a plain BufferLoad/BufferStore (no tile op). */
+  bool all_plain = true;
+  /*! \brief Every access sits inside an all-parallel loop nest. */
+  bool all_parallel_nest = true;
+  /*! \brief Every access sits outside parallel loops entirely. */
+  bool all_sequential = true;
+  /*! \brief Every parallel-nest access has a bijective index mapping. */
+  bool bijective = true;
+  /*! \brief Every parallel-nest access has the same index mapping (up to
+   *  loop-var renaming) and the same loop extents. */
+  bool mapping_consistent = true;
+  /*! \brief Whether canonical_indices/canonical_extents hold a value. */
+  bool has_canonical = false;
+  /*! \brief Normalized indices of the first parallel-nest access. */
+  Array<PrimExpr> canonical_indices;
+  /*! \brief Parallel loop extents of the first parallel-nest access. */
+  Array<PrimExpr> canonical_extents;
+};
+
+/*!
+ * \brief Collect the auto-scope buffers of a function and how each is used.
+ *
+ * The whole function body is scanned once; buffers are keyed by their data
+ * Var, so the allocating sblock's nesting does not matter.
+ */
+class AutoScopeCollector : public StmtExprVisitor {
+public:
+  std::unordered_map<Var, Buffer, ObjectPtrHash, ObjectPtrEqual> auto_buffers_;
+  std::unordered_map<Var, BufferScopeAnalysis, ObjectPtrHash, ObjectPtrEqual>
+      analyses_;
+
+  void VisitStmt_(const SBlockNode *op) final {
+    for (const Buffer &buffer : op->alloc_buffers) {
+      if (buffer.scope() == kAutoScope) {
+        auto_buffers_.emplace(buffer->data, buffer);
+        analyses_.emplace(buffer->data, BufferScopeAnalysis{});
+      }
+    }
+    StmtExprVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const ForNode *op) final {
+    // Pre-launch-binding IR (e.g. pass-level use) carries thread bindings as
+    // kThreadBinding For loops.
+    const bool is_per_thread_axis =
+        op->kind == ForKind::kThreadBinding && op->thread_binding.defined() &&
+        IsPerThreadTag(op->thread_binding.value()->thread_tag);
+    if (is_per_thread_axis) {
+      thread_vars_.push_back(op->loop_var.get());
+    }
+    loop_stack_.push_back(op);
+    StmtExprVisitor::VisitStmt_(op);
+    loop_stack_.pop_back();
+    if (is_per_thread_axis) {
+      thread_vars_.pop_back();
+    }
+  }
+
+  void VisitStmt_(const AttrStmtNode *op) final {
+    // After MaterializeKernelLaunch, thread bindings are thread_extent
+    // AttrStmts instead of For loops.
+    bool pushed = false;
+    if (op->attr_key == tirx::attr::thread_extent) {
+      if (const auto *iv = op->node.as<IterVarNode>();
+          iv != nullptr && IsPerThreadTag(iv->thread_tag)) {
+        thread_vars_.push_back(iv->var.get());
+        pushed = true;
+      }
+    }
+    StmtExprVisitor::VisitStmt_(op);
+    if (pushed) {
+      thread_vars_.pop_back();
+    }
+  }
+
+  void VisitStmt_(const IfThenElseNode *op) final {
+    // A write guarded by a per-thread condition (e.g. `if tx == 0`) only lands
+    // in some threads' private copies under a per-thread scope.
+    const bool thread_conditional = UsesAnyThreadVar(op->condition);
+    if (thread_conditional) {
+      ++thread_condition_depth_;
+    }
+    StmtExprVisitor::VisitStmt_(op);
+    if (thread_conditional) {
+      --thread_condition_depth_;
+    }
+  }
+
+  void VisitStmt_(const BufferStoreNode *op) final {
+    RecordPlainAccess(op->buffer, op->indices);
+    StmtExprVisitor::VisitStmt_(op);
+  }
+
+  void VisitExpr_(const BufferLoadNode *op) final {
+    RecordPlainAccess(op->buffer, op->indices);
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  void VisitExpr_(const CallNode *op) final {
+    if (IsTileOpCall(op)) {
+      if (TileOperator tile_op = TryParseOperator(GetRef<Call>(op));
+          tile_op.defined()) {
+        VisitTileOp(tile_op);
+      } else {
+        RecordOpaqueTileOp(op);
+      }
+      // Do not recurse: a tl.region argument wraps a BufferLoad that marks the
+      // region, not an element access, and a parsed op's access regions already
+      // cover its arguments.
+      return;
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+private:
+  /*! \brief The For nodes enclosing the node currently being visited. */
+  std::vector<const ForNode *> loop_stack_;
+  /*! \brief Per-thread (threadIdx.*) binding vars currently in scope. */
+  std::vector<const VarNode *> thread_vars_;
+  /*! \brief Enclosing if-conditions that reference a per-thread var. */
+  int thread_condition_depth_ = 0;
+  arith::Analyzer analyzer_;
+  /*! \brief Canonical loop-var placeholders, one per (position, dtype). */
+  std::unordered_map<std::string, Var> placeholders_;
+
+  /*! \brief threadIdx.* axes are per-thread; blockIdx.* are block-uniform and
+   *  do not by themselves make a local scope unsafe. */
+  static bool IsPerThreadTag(const String &tag) {
+    const std::string &s = tag;
+    return s.rfind("threadIdx", 0) == 0;
+  }
+
+  /*! \brief Whether the expression references an in-scope per-thread var. */
+  bool UsesAnyThreadVar(const PrimExpr &expr) const {
+    if (thread_vars_.empty()) {
+      return false;
+    }
+    return UsesVar(expr, [this](const VarNode *var) {
+      return std::find(thread_vars_.begin(), thread_vars_.end(), var) !=
+             thread_vars_.end();
+    });
+  }
+
+  Var PlaceholderVar(size_t position, DataType dtype) {
+    std::string key = std::to_string(position) + "_" +
+                      std::to_string(dtype.code()) + "_" +
+                      std::to_string(dtype.bits());
+    auto it = placeholders_.find(key);
+    if (it != placeholders_.end()) {
+      return it->second;
+    }
+    Var var("pv" + std::to_string(position), dtype);
+    placeholders_.emplace(key, var);
+    return var;
+  }
+
+  BufferScopeAnalysis *Lookup(const Buffer &buffer) {
+    auto it = analyses_.find(buffer->data);
+    return it == analyses_.end() ? nullptr : &it->second;
+  }
+
+  /*! \brief Whether any enclosing loop is pipelined (carries num_stages). */
+  bool InPipelinedLoop() const {
+    for (const ForNode *loop : loop_stack_) {
+      if (GetPipelineNumStages(loop).defined()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void RequireFragment(const Buffer &buffer, std::string reason) {
+    if (BufferScopeAnalysis *a = Lookup(buffer)) {
+      a->fragment_reasons.push_back(std::move(reason));
+    }
+  }
+
+  void RequireShared(const Buffer &buffer, std::string reason) {
+    if (BufferScopeAnalysis *a = Lookup(buffer)) {
+      a->shared_reasons.push_back(std::move(reason));
+    }
+  }
+
+  /*! \brief A tile op touches this buffer: it is accessed, but not through a
+   *  plain per-element load/store. */
+  void RecordTileOpAccess(const Buffer &buffer) {
+    if (BufferScopeAnalysis *a = Lookup(buffer)) {
+      a->has_access = true;
+      a->all_plain = false;
+      a->all_parallel_nest = false;
+      a->all_sequential = false;
+    }
+  }
+
+  /*! \brief A tile op call that could not be parsed: mark every buffer it
+   *  references as opaquely accessed. */
+  void RecordOpaqueTileOp(const CallNode *op) {
+    for (const PrimExpr &arg : op->args) {
+      if (const auto *load = arg.as<BufferLoadNode>()) {
+        RecordTileOpAccess(load->buffer);
+      } else if (const auto *var = arg.as<VarNode>()) {
+        if (var->dtype.is_handle()) {
+          auto it = analyses_.find(GetRef<Var>(var));
+          if (it != analyses_.end()) {
+            it->second.has_access = true;
+            it->second.all_plain = false;
+            it->second.all_parallel_nest = false;
+            it->second.all_sequential = false;
+          }
+        }
+      } else if (const auto *call = arg.as<CallNode>()) {
+        RecordOpaqueTileOp(call);
+      }
+    }
+  }
+
+  void VisitTileOp(const TileOperator &tile_op) {
+    // Role-specific hard constraints first.
+    if (const auto *gemm = tile_op.as<GemmNode>()) {
+      RequireFragment(gemm->cRegion_->buffer,
+                      "used as T.gemm accumulator (requires local.fragment)");
+      RequireShared(gemm->aRegion_->buffer,
+                    "used as T.gemm A operand (requires shared.dyn)");
+      RequireShared(gemm->bRegion_->buffer,
+                    "used as T.gemm B operand (requires shared.dyn)");
+    } else if (const auto *gemm_sp = tile_op.as<GemmSPNode>()) {
+      RequireFragment(
+          gemm_sp->cRegion_->buffer,
+          "used as T.gemm_sp accumulator (requires local.fragment)");
+      RequireShared(gemm_sp->aRegion_->buffer,
+                    "used as T.gemm_sp A operand (requires shared.dyn)");
+      RequireShared(gemm_sp->bRegion_->buffer,
+                    "used as T.gemm_sp B operand (requires shared.dyn)");
+    } else if (const auto *copy = tile_op.as<CopyNode>()) {
+      if (InPipelinedLoop() && IsGlobalBuffer(copy->src)) {
+        RequireShared(copy->dst,
+                      "used as T.copy destination fed from global memory "
+                      "inside a pipelined loop (requires shared.dyn)");
+      }
+    } else if (const auto *cumsum = tile_op.as<CumSumOpNode>()) {
+      RequireShared(cumsum->src,
+                    "used as T.cumsum operand (requires shared.dyn)");
+      RequireShared(cumsum->dst,
+                    "used as T.cumsum operand (requires shared.dyn)");
+    } else if (const auto *cummax = tile_op.as<CumMaxOpNode>()) {
+      RequireShared(cummax->src,
+                    "used as T.cummax operand (requires shared.dyn)");
+      RequireShared(cummax->dst,
+                    "used as T.cummax operand (requires shared.dyn)");
+    }
+    // Generic: every region this op touches is a non-plain access.
+    AccessRegions regions = tile_op->GetAccessRegions();
+    for (const BufferRegion &region : regions.reads) {
+      RecordTileOpAccess(region->buffer);
+    }
+    for (const BufferRegion &region : regions.writes) {
+      RecordTileOpAccess(region->buffer);
+    }
+  }
+
+  /*! \brief Record a plain element access and classify its loop nest. */
+  void RecordPlainAccess(const Buffer &buffer, const Array<PrimExpr> &indices) {
+    BufferScopeAnalysis *a = Lookup(buffer);
+    if (a == nullptr) {
+      return;
+    }
+    a->has_access = true;
+
+    // An access whose indices reference a per-thread (threadIdx) binding var,
+    // or one guarded by a per-thread condition, is not a scope-safe sequential
+    // or parallel-nest pattern: under a per-thread scope every thread owns a
+    // private copy with only its own slots written, so cross-thread reads (or
+    // reads by threads the condition excluded) silently see garbage. Force the
+    // shared fallback. (Values referencing thread vars are fine: each thread's
+    // private copy stays self-consistent.)
+    bool uses_thread_var = thread_condition_depth_ > 0;
+    for (const PrimExpr &index : indices) {
+      uses_thread_var = uses_thread_var || UsesAnyThreadVar(index);
+    }
+    if (uses_thread_var) {
+      a->all_sequential = false;
+      a->all_parallel_nest = false;
+      return;
+    }
+
+    // Thread-binding loops are launch geometry, not compute loops; ignore them
+    // when classifying the nest.
+    std::vector<const ForNode *> compute_loops;
+    for (const ForNode *loop : loop_stack_) {
+      if (loop->kind != ForKind::kThreadBinding) {
+        compute_loops.push_back(loop);
+      }
+    }
+    Array<Var> parallel_vars;
+    Array<PrimExpr> parallel_extents;
+    bool all_parallel = !compute_loops.empty();
+    for (const ForNode *loop : compute_loops) {
+      if (loop->kind == ForKind::kParallel && is_zero(loop->min)) {
+        parallel_vars.push_back(loop->loop_var);
+        parallel_extents.push_back(loop->extent);
+      } else {
+        all_parallel = false;
+      }
+    }
+
+    if (parallel_vars.empty()) {
+      a->all_parallel_nest = false;
+      return;
+    }
+    a->all_sequential = false;
+    if (!all_parallel) {
+      a->all_parallel_nest = false;
+      return;
+    }
+    CheckParallelMapping(a, indices, parallel_vars, parallel_extents);
+  }
+
+  /*! \brief Check one parallel-nest access for bijectivity (DetectIterMap) and
+   *  for mapping consistency with the accesses seen so far. */
+  void CheckParallelMapping(BufferScopeAnalysis *a,
+                            const Array<PrimExpr> &indices,
+                            const Array<Var> &parallel_vars,
+                            const Array<PrimExpr> &parallel_extents) {
+    Map<Var, Range> input_iters;
+    for (size_t i = 0; i < parallel_vars.size(); ++i) {
+      input_iters.Set(parallel_vars[i],
+                      Range::FromMinExtent(0, parallel_extents[i]));
+    }
+    auto result = arith::DetectIterMap(
+        indices, input_iters, 1, arith::IterMapLevel::Bijective, &analyzer_);
+    if (!result->errors.empty()) {
+      a->bijective = false;
+      return;
+    }
+    // Normalize loop vars to positional placeholders so mappings from
+    // different nests can be compared structurally. The placeholder Vars are
+    // created once per (position, dtype) and reused: ExprDeepEqual compares
+    // free Vars by identity, so fresh objects would never compare equal.
+    std::unordered_map<const VarNode *, PrimExpr> subst;
+    for (size_t i = 0; i < parallel_vars.size(); ++i) {
+      subst.emplace(parallel_vars[i].get(),
+                    PlaceholderVar(i, parallel_vars[i].dtype()));
+    }
+    auto remap = [&subst](const Var &var) -> Optional<PrimExpr> {
+      auto it = subst.find(var.get());
+      if (it != subst.end()) {
+        return it->second;
+      }
+      return std::nullopt;
+    };
+    Array<PrimExpr> normalized;
+    normalized.reserve(indices.size());
+    for (const PrimExpr &index : indices) {
+      normalized.push_back(Substitute(index, remap));
+    }
+    if (!a->has_canonical) {
+      a->has_canonical = true;
+      a->canonical_indices = normalized;
+      a->canonical_extents = parallel_extents;
+      return;
+    }
+    if (!ArrayDeepEqual(a->canonical_indices, normalized) ||
+        !ArrayDeepEqual(a->canonical_extents, parallel_extents)) {
+      a->mapping_consistent = false;
+    }
+  }
+
+  static bool ArrayDeepEqual(const Array<PrimExpr> &lhs,
+                             const Array<PrimExpr> &rhs) {
+    if (lhs.size() != rhs.size()) {
+      return false;
+    }
+    ExprDeepEqual equal;
+    for (size_t i = 0; i < lhs.size(); ++i) {
+      if (!equal(lhs[i], rhs[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+/*! \brief Decide the concrete scope of one auto buffer from its analysis. */
+String DecideScope(const Buffer &buffer, const BufferScopeAnalysis &a,
+                   bool is_cpu_target) {
+  // CPU targets have no shared-memory hierarchy and their op lowerings reject
+  // shared scopes (e.g. src/cpu/op/fill.cc); every would-be-shared decision
+  // degrades to thread-local storage there.
+  const bool is_bool = buffer->dtype.is_bool();
+  const char *shared_choice =
+      is_cpu_target ? "local" : (is_bool ? "shared" : "shared.dyn");
+  if (!a.fragment_reasons.empty() && !a.shared_reasons.empty()) {
+    std::ostringstream os;
+    os << "Error: cannot infer memory scope for buffer '" << buffer->name
+       << "'\n";
+    for (const std::string &reason : a.fragment_reasons) {
+      os << "  - " << reason << "\n";
+    }
+    for (const std::string &reason : a.shared_reasons) {
+      os << "  - " << reason << "\n";
+    }
+    os << "Hint: use T.alloc_shared / T.alloc_fragment explicitly.";
+    LOG(FATAL) << os.str();
+  }
+  if (!a.fragment_reasons.empty()) {
+    return "local.fragment";
+  }
+  if (!a.shared_reasons.empty()) {
+    return shared_choice;
+  }
+  if (!a.has_access) {
+    return "local";
+  }
+  if (a.all_plain && a.all_parallel_nest && a.bijective &&
+      a.mapping_consistent) {
+    return "local.fragment";
+  }
+  if (a.all_plain && a.all_sequential) {
+    return "local";
+  }
+  return shared_choice;
+}
+
+/*!
+ * \brief Rewrite buffer references after the scope decisions.
+ *
+ * Follows the CanonicalizeLegacyReducer precedent: the owning sblock's
+ * alloc_buffers entry is swapped for a buffer whose data Var carries the new
+ * PointerType storage scope, and BufferLoad/BufferStore/bare-Var references in
+ * the body are rewritten. Tile op arguments go through tl.region bridge calls
+ * whose region marker is a BufferLoad, so they are covered by the BufferLoad
+ * hook. sblock reads/writes regions are remapped as well for completeness.
+ */
+class AutoScopeRewriter : public StmtExprMutator {
+public:
+  AutoScopeRewriter(Map<Var, Var> var_remap, Map<Buffer, Buffer> buffer_remap)
+      : var_remap_(std::move(var_remap)),
+        buffer_remap_(std::move(buffer_remap)) {}
+
+  Stmt VisitStmt_(const SBlockNode *op) final {
+    SBlock block = Downcast<SBlock>(StmtExprMutator::VisitStmt_(op));
+    auto *p_block = block.CopyOnWrite();
+    p_block->alloc_buffers = RemapBuffers(op->alloc_buffers);
+    p_block->reads = RemapRegions(op->reads);
+    p_block->writes = RemapRegions(op->writes);
+    // Annotations keyed by a buffer's data Var must follow the rewritten
+    // buffer: T.annotate_layout (layout_map) and T.annotate_safe_value
+    // (safe_value_map) can both reference an auto-scope buffer.
+    RemapVarKeyedAnnotation<Layout>(p_block, attr::kLayoutMap);
+    RemapVarKeyedAnnotation<PrimExpr>(p_block, attr::kSafeValueMap);
+    // barrier_init is intentionally not remapped: barrier buffers carry their
+    // own dedicated scope (T.alloc_barrier) and can never be auto.
+    return block;
+  }
+
+  Stmt VisitStmt_(const BufferStoreNode *op) final {
+    BufferStore store = Downcast<BufferStore>(StmtExprMutator::VisitStmt_(op));
+    auto it = buffer_remap_.find(store->buffer);
+    if (it == buffer_remap_.end()) {
+      return store;
+    }
+    return BufferStore((*it).second, store->value, store->indices);
+  }
+
+  PrimExpr VisitExpr_(const BufferLoadNode *op) final {
+    BufferLoad load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
+    auto it = buffer_remap_.find(load->buffer);
+    if (it == buffer_remap_.end()) {
+      return load;
+    }
+    return BufferLoad((*it).second, load->indices);
+  }
+
+  PrimExpr VisitExpr_(const VarNode *op) final {
+    auto it = var_remap_.find(GetRef<Var>(op));
+    if (it != var_remap_.end()) {
+      return (*it).second;
+    }
+    return StmtExprMutator::VisitExpr_(op);
+  }
+
+private:
+  /*! \brief Rewrite the keys of a Var-keyed map annotation (e.g. layout_map).
+   *
+   * Uses the exact static value type so that unrelated Map-typed annotations
+   * with non-Var keys are left untouched.
+   */
+  template <typename V>
+  void RemapVarKeyedAnnotation(SBlockNode *p_block, const char *key) const {
+    auto ref = p_block->annotations.Get(key);
+    if (!ref.has_value()) {
+      return;
+    }
+    auto map = ref.value().as<Map<Var, V>>();
+    if (!map.has_value()) {
+      return;
+    }
+    Map<Var, V> updated;
+    bool changed = false;
+    for (const auto &[var, value] : map.value()) {
+      auto it = var_remap_.find(var);
+      if (it != var_remap_.end()) {
+        updated.Set((*it).second, value);
+        changed = true;
+      } else {
+        updated.Set(var, value);
+      }
+    }
+    if (changed) {
+      p_block->annotations.Set(key, updated);
+    }
+  }
+
+  Array<Buffer> RemapBuffers(const Array<Buffer> &buffers) const {
+    Array<Buffer> result;
+    result.reserve(buffers.size());
+    bool changed = false;
+    for (const Buffer &buffer : buffers) {
+      auto it = buffer_remap_.find(buffer);
+      if (it != buffer_remap_.end()) {
+        result.push_back((*it).second);
+        changed = true;
+      } else {
+        result.push_back(buffer);
+      }
+    }
+    return changed ? result : buffers;
+  }
+
+  Array<BufferRegion> RemapRegions(const Array<BufferRegion> &regions) const {
+    Array<BufferRegion> result;
+    result.reserve(regions.size());
+    bool changed = false;
+    for (const BufferRegion &region : regions) {
+      auto it = buffer_remap_.find(region->buffer);
+      if (it != buffer_remap_.end()) {
+        result.push_back(BufferRegion((*it).second, region->region));
+        changed = true;
+      } else {
+        result.push_back(region);
+      }
+    }
+    return changed ? result : regions;
+  }
+
+  Map<Var, Var> var_remap_;
+  Map<Buffer, Buffer> buffer_remap_;
+};
+
+using namespace tirx::transform;
+
+tvm::transform::Pass InferMemoryScope() {
+  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    AutoScopeCollector collector;
+    collector(f->body);
+    if (collector.auto_buffers_.empty()) {
+      return f;
+    }
+    auto target = f->GetAttr<Target>(tvm::attr::kTarget);
+    const bool is_cpu_target = target.defined() && TargetIsCPU(target.value());
+    Map<Var, Var> var_remap;
+    Map<Buffer, Buffer> buffer_remap;
+    for (const auto &[var, buffer] : collector.auto_buffers_) {
+      String new_scope =
+          DecideScope(buffer, collector.analyses_.at(var), is_cpu_target);
+      // Preserve the span so later diagnostics still point at the user's
+      // T.auto_alloc line.
+      Var new_var(buffer->data->name_hint,
+                  PointerType(PrimType(buffer->dtype), new_scope),
+                  buffer->data->span);
+      Buffer new_buffer(new_var, buffer->dtype, buffer->shape, buffer->strides,
+                        buffer->elem_offset, buffer->name,
+                        buffer->data_alignment, buffer->offset_factor,
+                        buffer->buffer_type);
+      var_remap.Set(buffer->data, new_var);
+      buffer_remap.Set(buffer, new_buffer);
+    }
+    AutoScopeRewriter rewriter(var_remap, buffer_remap);
+    f.CopyOnWrite()->body = rewriter(f->body);
+    return f;
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.InferMemoryScope", {});
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = reflection;
+  refl::GlobalDef().def("tl.transform.InferMemoryScope", InferMemoryScope);
+}
+
+} // namespace
+
+} // namespace tvm::tl

--- a/src/transform/infer_memory_scope.cc
+++ b/src/transform/infer_memory_scope.cc
@@ -4,7 +4,7 @@
  * Infer concrete memory scopes for buffers allocated with the virtual scope
  * "auto" (T.auto_alloc, issue #277).
  *
- * The pass runs early: after VerifyBufferInit and before warp specialization,
+ * The pass runs early: before VerifyBufferInit, warp specialization,
  * pipeline planning and layout inference, so that downstream passes that
  * branch on IsSharedBuffer (multi-versioning, cp.async/TMA staging, layout
  * inference) already see the final scope.

--- a/src/transform/verify_buffer_init.cc
+++ b/src/transform/verify_buffer_init.cc
@@ -19,6 +19,7 @@
 #include "../op/gemm.h"
 #include "../op/gemm_sp.h"
 #include "../op/operator.h"
+#include "../op/utils.h"
 #include "span_utils.h"
 #include <exception>
 #include <sstream>
@@ -399,6 +400,13 @@ using namespace tirx::transform;
 
 tvm::transform::Pass VerifyBufferInit() {
   auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    // The virtual "auto" scope (T.auto_alloc) must have been resolved by
+    // InferMemoryScope already, which runs right before this pass on the
+    // cuda/rocm/cpu pipelines. Any residual auto buffer is a hard error here:
+    // on pipelines without InferMemoryScope (metal/webgpu) it is unsupported,
+    // otherwise it indicates an internal bug. This is the single gate; later
+    // passes do not re-check. Not gated by the warning opt-out below.
+    CheckNoAutoScopeBuffers(f, "VerifyBufferInit");
     // Enabled by default. The analysis reports buffers that nothing writes at
     // all, plus order-sensitive cases in per-thread storage where the only
     // write comes after the read, which keeps false positives rare enough to

--- a/testing/python/transform/test_tilelang_transform_infer_memory_scope.py
+++ b/testing/python/transform/test_tilelang_transform_infer_memory_scope.py
@@ -1,0 +1,505 @@
+"""Tests for tl.transform.InferMemoryScope (T.auto_alloc, issue #277).
+
+All tests are GPU-free: pass-level tests apply InferMemoryScope manually and
+inspect the TIR; pipeline-level tests use tilelang.lower() which only emits
+source code; the numeric check runs on the CPU ("c") target.
+"""
+
+import re
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+from tvm.target import Target
+
+PASS_NAME = "tl.transform.InferMemoryScope"
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _alloc_scopes(func) -> dict:
+    """Map each sblock-allocated buffer name to its scope string."""
+    scopes = {}
+
+    def _visit(node):
+        if isinstance(node, tvm.tirx.SBlock):
+            for buf in node.alloc_buffers:
+                scopes[buf.name] = buf.scope()
+
+    tvm.tirx.stmt_functor.post_order_visit(func.body, _visit)
+    return scopes
+
+
+def _infer(func) -> dict:
+    """Apply InferMemoryScope to the parsed func and return buffer scopes."""
+    mod = tvm.IRModule.from_expr(func)
+    mod = tilelang.transform.InferMemoryScope()(mod)
+    for _, f in mod.functions.items():
+        return _alloc_scopes(f)
+    raise AssertionError("empty module")
+
+
+# ---------------------------------------------------------------------------
+# kernels under test
+# ---------------------------------------------------------------------------
+
+M, N, K = 1024, 1024, 1024
+BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 64
+
+
+def _gemm_auto():
+    """The issue #277 example, written with T.auto_alloc."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), "float16"),
+        B: T.Tensor((N, K), "float16"),
+        C: T.Tensor((M, N), "float16"),
+    ):
+        with T.Kernel(N // BLOCK_N, M // BLOCK_M, threads=128) as (bx, by):
+            A_buf = T.auto_alloc((BLOCK_M, BLOCK_K), "float16")
+            B_buf = T.auto_alloc((BLOCK_N, BLOCK_K), "float16")
+            C_buf = T.auto_alloc((BLOCK_M, BLOCK_N), "float16")
+            T.clear(C_buf)
+            for k in T.Pipelined(K // BLOCK_K, num_stages=3):
+                T.copy(A[by * BLOCK_M, k * BLOCK_K], A_buf)
+                T.copy(B[bx * BLOCK_N, k * BLOCK_K], B_buf)
+                T.gemm(A_buf, B_buf, C_buf, transpose_B=True)
+            T.copy(C_buf, C[by * BLOCK_M, bx * BLOCK_N])
+
+    return main
+
+
+def _gemm_explicit():
+    """The same kernel with hand-written scopes."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), "float16"),
+        B: T.Tensor((N, K), "float16"),
+        C: T.Tensor((M, N), "float16"),
+    ):
+        with T.Kernel(N // BLOCK_N, M // BLOCK_M, threads=128) as (bx, by):
+            A_buf = T.alloc_shared((BLOCK_M, BLOCK_K), "float16")
+            B_buf = T.alloc_shared((BLOCK_N, BLOCK_K), "float16")
+            C_buf = T.alloc_fragment((BLOCK_M, BLOCK_N), "float16")
+            T.clear(C_buf)
+            for k in T.Pipelined(K // BLOCK_K, num_stages=3):
+                T.copy(A[by * BLOCK_M, k * BLOCK_K], A_buf)
+                T.copy(B[bx * BLOCK_N, k * BLOCK_K], B_buf)
+                T.gemm(A_buf, B_buf, C_buf, transpose_B=True)
+            T.copy(C_buf, C[by * BLOCK_M, bx * BLOCK_N])
+
+    return main
+
+
+# ---------------------------------------------------------------------------
+# pass-level rule tests
+# ---------------------------------------------------------------------------
+
+
+def test_gemm_scopes():
+    """R1/R2 (+R3): gemm C -> local.fragment, A/B -> shared.dyn."""
+    scopes = _infer(_gemm_auto())
+    assert scopes["A_buf"] == "shared.dyn"
+    assert scopes["B_buf"] == "shared.dyn"
+    assert scopes["C_buf"] == "local.fragment"
+
+
+def test_pipelined_copy_dst_is_shared():
+    """R3: copy(global -> X) dst inside a num_stages loop -> shared.dyn."""
+
+    @T.prim_func
+    def main(A: T.Tensor((M, K), "float16"), C: T.Tensor((M, K), "float16")):
+        with T.Kernel(M // BLOCK_M, threads=128) as bx:
+            stage = T.auto_alloc((BLOCK_M, BLOCK_K), "float16")
+            for k in T.Pipelined(K // BLOCK_K, num_stages=2):
+                T.copy(A[bx * BLOCK_M, k * BLOCK_K], stage)
+            T.copy(stage, C[bx * BLOCK_M, 0])
+
+    assert _infer(main)["stage"] == "shared.dyn"
+
+
+def test_cumsum_operand_is_shared():
+    """R4: cumsum src/dst -> shared.dyn (frontend silently routes non-fragment
+    buffers to the shared-memory tl.cumsum lowering)."""
+
+    @T.prim_func
+    def main(A: T.Tensor((128, 128), "float32"), B: T.Tensor((128, 128), "float32")):
+        with T.Kernel(1, threads=128):
+            src = T.auto_alloc((128, 128), "float32")
+            dst = T.auto_alloc((128, 128), "float32")
+            T.copy(A, src)
+            T.cumsum(src, dst)
+            T.copy(dst, B)
+
+    scopes = _infer(main)
+    assert scopes["src"] == "shared.dyn"
+    assert scopes["dst"] == "shared.dyn"
+
+
+def test_elementwise_parallel_is_fragment():
+    """R6: plain accesses in T.Parallel nests with a consistent bijective
+    mapping -> local.fragment."""
+
+    @T.prim_func
+    def main(A: T.Tensor((128, 128), "float32"), B: T.Tensor((128, 128), "float32")):
+        with T.Kernel(1, threads=128):
+            tmp = T.auto_alloc((128, 128), "float32")
+            for i, j in T.Parallel(128, 128):
+                tmp[i, j] = A[i, j] + 1.0
+            for i, j in T.Parallel(128, 128):
+                B[i, j] = tmp[i, j]
+
+    assert _infer(main)["tmp"] == "local.fragment"
+
+
+def test_transpose_access_is_shared():
+    """R8: inconsistent index mappings across parallel nests -> shared.dyn."""
+
+    @T.prim_func
+    def main(A: T.Tensor((128, 128), "float32"), B: T.Tensor((128, 128), "float32")):
+        with T.Kernel(1, threads=128):
+            tmp = T.auto_alloc((128, 128), "float32")
+            for i, j in T.Parallel(128, 128):
+                tmp[i, j] = A[i, j]
+            for i, j in T.Parallel(128, 128):
+                B[j, i] = tmp[j, i]  # transposed read: mapping [j, i] != [i, j]
+
+    assert _infer(main)["tmp"] == "shared.dyn"
+
+
+def test_broadcast_write_is_shared():
+    """R8: an access whose mapping is not bijective (loop var unused) must not
+    become a fragment."""
+
+    @T.prim_func
+    def main(A: T.Tensor((128,), "float32"), B: T.Tensor((128, 128), "float32")):
+        with T.Kernel(1, threads=128):
+            tmp = T.auto_alloc((128,), "float32")
+            for i in T.Parallel(128):
+                tmp[i] = A[i]
+            for i, j in T.Parallel(128, 128):
+                B[i, j] = tmp[i]  # j does not index tmp: replicated read
+
+    assert _infer(main)["tmp"] == "shared.dyn"
+
+
+def test_sequential_only_is_local():
+    """R7: plain accesses outside parallel loops -> local."""
+
+    @T.prim_func
+    def main(A: T.Tensor((128,), "float32"), B: T.Tensor((128,), "float32")):
+        with T.Kernel(1, threads=128):
+            tmp = T.auto_alloc((128,), "float32")
+            for i in T.serial(128):
+                tmp[i] = A[i] * 2.0
+            for i in T.serial(128):
+                B[i] = tmp[i]
+
+    assert _infer(main)["tmp"] == "local"
+
+
+def test_thread_indexed_access_is_not_local():
+    """Soundness (review P1): per-thread-indexed writes in sequential code must
+    not become local — each thread's private copy would have only its own slot
+    initialized and cross-thread reads would silently see garbage."""
+
+    @T.prim_func
+    def main(A: T.Tensor((16,), "float32"), B: T.Tensor((16,), "float32")):
+        with T.Kernel(1, threads=16):
+            tmp = T.auto_alloc((16,), "float32")
+            tx = T.get_thread_binding()
+            tmp[tx] = A[tx]
+            for i in T.serial(16):
+                B[i] = tmp[i]
+
+    assert _infer(main)["tmp"] == "shared.dyn"
+
+
+def test_thread_conditional_write_is_not_local():
+    """Same soundness class as the thread-indexed case: a write guarded by a
+    per-thread condition only lands in some threads' private copies."""
+
+    @T.prim_func
+    def main(A: T.Tensor((16,), "float32"), B: T.Tensor((16,), "float32")):
+        with T.Kernel(1, threads=16):
+            tmp = T.auto_alloc((16,), "float32")
+            tx = T.get_thread_binding()
+            if tx == 0:
+                for i in T.serial(16):
+                    tmp[i] = A[i]
+            for i in T.serial(16):
+                B[i] = tmp[i]
+
+    assert _infer(main)["tmp"] == "shared.dyn"
+
+
+def test_dead_buffer_is_local():
+    """R10: a buffer with no accesses -> local."""
+
+    @T.prim_func
+    def main(A: T.Tensor((128,), "float32")):
+        with T.Kernel(1, threads=128):
+            _tmp = T.auto_alloc((128,), "float32")
+            for i in T.Parallel(128):
+                A[i] = A[i] + 1.0
+
+    assert _infer(main)["_tmp"] == "local"
+
+
+def test_bool_shared_decision_uses_static_shared():
+    """R11: bool buffers decided as shared use "shared", not "shared.dyn"
+    (MergeSharedMemoryAllocations cannot merge bool)."""
+
+    @T.prim_func
+    def main(A: T.Tensor((128, 128), "bool"), B: T.Tensor((128, 128), "bool")):
+        with T.Kernel(1, threads=128):
+            tmp = T.auto_alloc((128, 128), "bool")
+            for i, j in T.Parallel(128, 128):
+                tmp[i, j] = A[i, j]
+            for i, j in T.Parallel(128, 128):
+                B[j, i] = tmp[j, i]  # transposed read -> shared fallback
+
+    assert _infer(main)["tmp"] == "shared"
+
+
+def test_conflicting_gemm_roles_error():
+    """R9: one buffer as both gemm accumulator and A operand -> error listing
+    both conflicting uses."""
+
+    @T.prim_func
+    def main(
+        A2: T.Tensor((128, 32), "float16"),
+        B1: T.Tensor((128, 64), "float16"),
+        B2: T.Tensor((64, 32), "float16"),
+        C: T.Tensor((128, 128), "float16"),
+    ):
+        with T.Kernel(1, threads=128):
+            # M=128, K=64 for gemm1; M=128, N=64 for gemm2, so a (128, 64)
+            # buffer can serve as gemm1's A operand and gemm2's accumulator.
+            both = T.auto_alloc((128, 64), "float16")
+            c_acc = T.auto_alloc((128, 128), "float16")
+            b1 = T.alloc_shared((128, 64), "float16")
+            a2 = T.alloc_shared((128, 32), "float16")
+            b2 = T.alloc_shared((64, 32), "float16")
+            T.copy(B1, b1)
+            T.copy(A2, a2)
+            T.copy(B2, b2)
+            T.clear(c_acc)
+            T.clear(both)
+            # 'both' is the A operand here ...
+            T.gemm(both, b1, c_acc, transpose_B=True)
+            # ... and the accumulator here: conflicting scope requirements.
+            T.gemm(a2, b2, both, transpose_B=True)
+            T.copy(c_acc, C)
+
+    mod = tvm.IRModule.from_expr(main)
+    with pytest.raises(Exception, match="cannot infer memory scope for buffer 'both'"):
+        tilelang.transform.InferMemoryScope()(mod)
+
+
+def _residual_auto_func():
+    @T.prim_func
+    def main(A: T.Tensor((128,), "float32"), B: T.Tensor((128,), "float32")):
+        with T.Kernel(1, threads=128):
+            tmp = T.auto_alloc((128,), "float32")
+            for i in T.Parallel(128):
+                tmp[i] = A[i]
+            for i in T.Parallel(128):
+                B[i] = tmp[i]
+
+    return tvm.IRModule.from_expr(main)
+
+
+def test_verify_buffer_init_rejects_residual_auto():
+    """VerifyBufferInit is the single gate for unresolved auto scopes: on
+    pipelines with InferMemoryScope they cannot occur, on pipelines without it
+    (metal/webgpu) they must fail loudly here."""
+    with pytest.raises(Exception, match="InferMemoryScope"):
+        tilelang.transform.VerifyBufferInit()(_residual_auto_func())
+
+
+def test_auto_check_not_gated_by_init_check_optout():
+    """The auto-scope gate is a hard correctness check, not a warning: it must
+    fire even when the buffer-init warning is disabled by pass config."""
+    mod = _residual_auto_func()
+    config = {tilelang.PassConfigKey.TL_DISABLE_BUFFER_INIT_CHECK.value: True}
+    with tvm.transform.PassContext(config=config), pytest.raises(Exception, match="InferMemoryScope"):
+        tilelang.transform.VerifyBufferInit()(mod)
+
+
+def test_reduce_rejects_auto_scope():
+    """A 类禁区: reduce macros dispatch on scope at trace time; auto buffers
+    must get an actionable error instead of a generic scope failure."""
+
+    def build():
+        @T.prim_func
+        def main(A: T.Tensor((128, 64), "float32"), B: T.Tensor((128,), "float32")):
+            with T.Kernel(1, threads=128):
+                src = T.auto_alloc((128, 64), "float32")
+                dst = T.alloc_fragment((128,), "float32")
+                T.copy(A, src)
+                T.reduce_sum(src, dst, dim=1)
+                T.copy(dst, B)
+
+        return tvm.IRModule.from_expr(main)
+
+    with pytest.raises(ValueError, match="auto"):
+        build()
+
+
+def test_print_rejects_auto_scope():
+    """A 类禁区: T.print dispatches on scope at trace time."""
+
+    def build():
+        @T.prim_func
+        def main(A: T.Tensor((128,), "float32")):
+            with T.Kernel(1, threads=128):
+                tmp = T.auto_alloc((128,), "float32")
+                for i in T.Parallel(128):
+                    tmp[i] = A[i]
+                T.print(tmp)
+
+        return tvm.IRModule.from_expr(main)
+
+    with pytest.raises(ValueError, match="auto"):
+        build()
+
+
+def test_verify_buffer_init_checks_inferred_buffer(capfd):
+    """Pipeline order: InferMemoryScope runs before VerifyBufferInit, so the
+    init check applies to buffers under their inferred scopes."""
+
+    @T.prim_func
+    def main(A: T.Tensor((128,), "float32"), B: T.Tensor((128,), "float32")):
+        with T.Kernel(1, threads=128):
+            tmp = T.auto_alloc((128,), "float32")
+            for i in T.Parallel(128):
+                B[i] = tmp[i]  # read before anything writes tmp
+            for i in T.Parallel(128):
+                tmp[i] = A[i]
+
+    mod = tvm.IRModule.from_expr(main)
+    mod = tilelang.transform.InferMemoryScope()(mod)
+    tilelang.transform.VerifyBufferInit()(mod)
+    assert "Buffer read before initialization" in capfd.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# pipeline-level equivalence and codegen tests (GPU-free)
+# ---------------------------------------------------------------------------
+
+_PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER.value: True,
+    tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED.value: True,
+    tilelang.PassConfigKey.TL_DISABLE_DATA_RACE_CHECK.value: True,
+}
+
+
+def _lower_source(func, target: str) -> str:
+    with tvm.transform.PassContext(config=_PASS_CONFIGS), Target(target):
+        artifact = tilelang.lower(func, target=target)
+    return artifact.kernel_source
+
+
+def test_auto_gemm_matches_explicit_gemm_cuda():
+    """The auto-scope kernel must lower to the same CUDA source as the
+    hand-written alloc_shared/alloc_fragment version."""
+    auto_src = _lower_source(_gemm_auto(), "cuda")
+    explicit_src = _lower_source(_gemm_explicit(), "cuda")
+    assert auto_src == explicit_src
+
+
+def test_auto_gemm_codegen_form():
+    """A/B land in dynamic shared memory; C is a plain local array."""
+    src = _lower_source(_gemm_auto(), "cuda")
+    # A/B are carved out of the dynamic shared-memory arena.
+    assert "extern __shared__" in src
+    assert re.search(r"A_buf\s*=\s*\(\(void\*\)\(\(char\*\)buf_dyn_shmem", src), src
+    assert re.search(r"B_buf\s*=\s*\(\(void\*\)\(\(char\*\)buf_dyn_shmem", src), src
+    # The accumulator is a thread-local array, not shared.
+    assert re.search(r"half_t\s+C_buf\[\d+\];", src), src
+
+
+def test_elementwise_fragment_full_pipeline():
+    """R6's local.fragment decision must survive LayoutInference and lower to a
+    per-thread local array (vectorized), not shared memory."""
+
+    @T.prim_func
+    def main(A: T.Tensor((128, 128), "float32"), B: T.Tensor((128, 128), "float32")):
+        with T.Kernel(1, threads=128):
+            tmp = T.auto_alloc((128, 128), "float32")
+            for i, j in T.Parallel(128, 128):
+                tmp[i, j] = A[i, j] + 1.0
+            for i, j in T.Parallel(128, 128):
+                B[i, j] = tmp[i, j]
+
+    src = _lower_source(main, "cuda")
+    assert re.search(r"float\s+tmp\[\d+\];", src), src
+    assert "tmp = ((void*)((char*)buf_dyn_shmem" not in src
+
+
+# ---------------------------------------------------------------------------
+# CPU end-to-end numeric validation
+# ---------------------------------------------------------------------------
+
+
+def test_cpu_elementwise_numeric():
+    """R7 local on CPU: serial-only auto buffer kernel matches torch."""
+
+    @T.prim_func
+    def main(A: T.Tensor((256,), "float32"), B: T.Tensor((256,), "float32")):
+        with T.Kernel(1):
+            tmp = T.auto_alloc((256,), "float32")
+            for i in T.serial(256):
+                tmp[i] = A[i] * 2.0
+            for i in T.serial(256):
+                B[i] = tmp[i] + 1.0
+
+    compiled = tilelang.compile(main, target="c", out_idx=-1, execution_backend="cython")
+    a = torch.randn(256)
+    b = compiled(a)
+    torch.testing.assert_close(b, a * 2.0 + 1.0)
+
+
+def test_cpu_gemm_numeric():
+    """Auto buffers in a small tiled gemm (copy staging + scalar compute)
+    match torch on the CPU target."""
+    m = n = k = 128
+    bm, bn, bk = 32, 32, 32
+
+    @T.prim_func
+    def matmul(
+        A: T.Tensor((m, k), "float32"),
+        B: T.Tensor((k, n), "float32"),
+        C: T.Tensor((m, n), "float32"),
+    ):
+        with T.Kernel(n // bn, m // bm) as (bx, by):
+            A_local = T.auto_alloc((bm, bk), "float32")
+            B_local = T.auto_alloc((bk, bn), "float32")
+            C_local = T.auto_alloc((bm, bn), "float32")
+            T.clear(C_local)
+            for ko in T.serial(k // bk):
+                T.copy(A[by * bm, ko * bk], A_local)
+                T.copy(B[ko * bk, bx * bn], B_local)
+                for i, j, kk in T.grid(bm, bn, bk):
+                    C_local[i, j] += A_local[i, kk] * B_local[kk, j]
+            T.copy(C_local, C[by * bm, bx * bn])
+
+    compiled = tilelang.compile(matmul, target="c", out_idx=-1, execution_backend="cython")
+    a = torch.randn(m, k)
+    b = torch.randn(k, n)
+    c = compiled(a, b)
+    torch.testing.assert_close(c, a @ b, rtol=1e-5, atol=1e-5)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_infer_memory_scope.py
+++ b/testing/python/transform/test_tilelang_transform_infer_memory_scope.py
@@ -337,8 +337,6 @@ def test_auto_check_not_gated_by_init_check_optout():
 
 
 def test_reduce_rejects_auto_scope():
-    """A 类禁区: reduce macros dispatch on scope at trace time; auto buffers
-    must get an actionable error instead of a generic scope failure."""
 
     def build():
         @T.prim_func
@@ -357,7 +355,6 @@ def test_reduce_rejects_auto_scope():
 
 
 def test_print_rejects_auto_scope():
-    """A 类禁区: T.print dispatches on scope at trace time."""
 
     def build():
         @T.prim_func
@@ -394,7 +391,7 @@ def test_verify_buffer_init_checks_inferred_buffer(capfd):
 
 
 # ---------------------------------------------------------------------------
-# pipeline-level equivalence and codegen tests (GPU-free)
+# pipeline-level equivalence and codegen tests
 # ---------------------------------------------------------------------------
 
 _PASS_CONFIGS = {
@@ -410,6 +407,7 @@ def _lower_source(func, target: str) -> str:
     return artifact.kernel_source
 
 
+@tilelang.testing.requires_cuda
 def test_auto_gemm_matches_explicit_gemm_cuda():
     """The auto-scope kernel must lower to the same CUDA source as the
     hand-written alloc_shared/alloc_fragment version."""
@@ -418,6 +416,7 @@ def test_auto_gemm_matches_explicit_gemm_cuda():
     assert auto_src == explicit_src
 
 
+@tilelang.testing.requires_cuda
 def test_auto_gemm_codegen_form():
     """A/B land in dynamic shared memory; C is a plain local array."""
     src = _lower_source(_gemm_auto(), "cuda")
@@ -429,6 +428,7 @@ def test_auto_gemm_codegen_form():
     assert re.search(r"half_t\s+C_buf\[\d+\];", src), src
 
 
+@tilelang.testing.requires_cuda
 def test_elementwise_fragment_full_pipeline():
     """R6's local.fragment decision must survive LayoutInference and lower to a
     per-thread local array (vectorized), not shared memory."""

--- a/tilelang/cpu/pipeline.py
+++ b/tilelang/cpu/pipeline.py
@@ -27,6 +27,7 @@ def CPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.Simplify()(mod)
     mod = tilelang.transform.CanonicalizeLegacyReducer()(mod)
     mod = tilelang.transform.VerifyReducerEpoch()(mod)
+    mod = tilelang.transform.InferMemoryScope()(mod)
     # Warn on buffers that are read before anything writes them.
     # Runs after the reducer passes above, so legacy reducers have been
     # canonicalized, and before PipelinePlanning and LowerTileOp, while

--- a/tilelang/cuda/language/print.py
+++ b/tilelang/cuda/language/print.py
@@ -191,6 +191,11 @@ def print(obj: Any = None, msg: str = "", warp_group_id: int = 0, warp_id: int =
             condition = True
             print_global_buffer_with_condition(condition, buffer, elems, msg)
         else:
+            if buffer.scope() == "auto":
+                raise ValueError(
+                    'T.print does not support buffers with the virtual scope "auto"; '
+                    "use explicit T.alloc_shared / T.alloc_fragment instead of T.auto_alloc"
+                )
             raise ValueError(f"Unsupported buffer scope: {buffer.scope()}")
 
     elif isinstance(obj, tirx.PrimExpr):

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -90,6 +90,7 @@ def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     # diagnostics point at user-written code)
     mod = tilelang.transform.CanonicalizeLegacyReducer()(mod)
     mod = tilelang.transform.VerifyReducerEpoch()(mod)
+    mod = tilelang.transform.InferMemoryScope()(mod)
     # Warn on buffers that are read before anything writes them.
     # Runs after the reducer passes above, so legacy reducers have been
     # canonicalized, and before PipelinePlanning and LowerTileOp, while

--- a/tilelang/language/allocate.py
+++ b/tilelang/language/allocate.py
@@ -92,6 +92,46 @@ def alloc_fragment(shape: ShapeType, dtype: DType, scope="local.fragment") -> Bu
     return _with_span(T.sblock_alloc_buffer(shape, dtype, scope=scope))
 
 
+def auto_alloc(shape: ShapeType, dtype: DType) -> Buffer:
+    """Allocate a buffer whose memory scope is inferred by the compiler.
+
+    The buffer is created with the virtual scope "auto"; the
+    ``tl.transform.InferMemoryScope`` pass rewrites it to a concrete scope
+    (``shared.dyn`` / ``local.fragment`` / ``local``) before LayoutInference,
+    based on how the buffer is accessed:
+
+    - a ``T.gemm`` accumulator (C) becomes ``local.fragment``;
+    - ``T.gemm`` A/B operands, ``T.copy`` destinations fed from global memory
+      inside a pipelined (``num_stages``) loop, and ``T.cumsum``/``T.cummax``
+      operands become ``shared.dyn``;
+    - a buffer whose accesses are all plain loads/stores inside ``T.Parallel``
+      nests with a consistent bijective index mapping becomes
+      ``local.fragment``;
+    - a buffer accessed only outside parallel loops becomes ``local`` — unless
+      an access index references a per-thread (``threadIdx``) binding variable
+      or sits under a per-thread condition, which forces ``shared.dyn`` (a
+      per-thread scope would silently break cross-thread reads);
+    - anything ambiguous falls back to ``shared.dyn`` (``shared`` for bool).
+
+    On CPU targets every shared choice degrades to ``local`` (the CPU backend
+    has no shared-memory hierarchy and its op lowerings reject shared scopes).
+
+    Not supported with scope-dispatching frontend macros (``T.reduce_*``,
+    ``T.print``, ``T.tma_gather4``/``T.tma_scatter4``, barrier ops) — use the
+    explicit ``T.alloc_*`` variants there. Conflicting requirements (e.g. one
+    buffer used as both a gemm accumulator and a gemm A/B operand) are a
+    compile-time error.
+
+    Args:
+        shape (tuple): The shape of the buffer to allocate
+        dtype (str): The data type of the buffer (e.g., 'float32', 'int32')
+
+    Returns:
+        T.Buffer: A TVM buffer object whose scope is chosen by the compiler
+    """
+    return _with_span(T.sblock_alloc_buffer(shape, dtype, scope="auto"))
+
+
 @overload
 def alloc_var(dtype: DType, init: PrimExpr | int | float, scope: str = "local.var") -> Buffer: ...
 

--- a/tilelang/language/common.py
+++ b/tilelang/language/common.py
@@ -51,6 +51,7 @@ from .allocate import (
     alloc_global,  # noqa: F401
     alloc_barrier,  # noqa: F401
     alloc_reducer,  # noqa: F401
+    auto_alloc,  # noqa: F401
     empty,  # noqa: F401
 )
 from tvm.tirx.script.builder.ir import alloc_buffer as allocate  # noqa: F401
@@ -241,6 +242,7 @@ _LOCAL_EXPORTS = (
     "atomic_min",
     "atomic_or",
     "atomic_store",
+    "auto_alloc",
     "ballot",
     "ballot_sync",
     "barrier_arrive",

--- a/tilelang/language/reduce_op.py
+++ b/tilelang/language/reduce_op.py
@@ -161,6 +161,12 @@ def reduce(
                 annotations=annotations,
             )
         else:
+            if buffer.scope() == "auto" or out.scope() == "auto":
+                raise ValueError(
+                    f'T.reduce_* does not support buffers with the virtual scope "auto" '
+                    f"(got {buffer.scope()} and {out.scope()}); use explicit T.alloc_shared / "
+                    f"T.alloc_fragment instead of T.auto_alloc"
+                )
             raise ValueError(f"Invalid buffer scopes: {buffer.scope()} and {out.scope()}")
 
     reduce_macro(buffer, out, reduce_type, dim, clear)

--- a/tilelang/rocm/pipeline.py
+++ b/tilelang/rocm/pipeline.py
@@ -29,6 +29,7 @@ def ROCMPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.Simplify()(mod)
     mod = tilelang.transform.CanonicalizeLegacyReducer()(mod)
     mod = tilelang.transform.VerifyReducerEpoch()(mod)
+    mod = tilelang.transform.InferMemoryScope()(mod)
     # Warn on buffers that are read before anything writes them.
     # Runs after the reducer passes above, so legacy reducers have been
     # canonicalized, and before PipelinePlanning and LowerTileOp, while

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -105,6 +105,22 @@ def VerifyBufferInit():
     return _ffi_api.VerifyBufferInit()  # type: ignore
 
 
+def InferMemoryScope():
+    """Infer concrete memory scopes for buffers allocated with T.auto_alloc.
+
+    Buffers allocated via ``T.auto_alloc`` carry the virtual scope ``"auto"``;
+    this pass rewrites them to ``shared.dyn`` / ``local.fragment`` / ``local``
+    based on their access patterns. It must run before warp specialization,
+    pipeline planning and layout inference, which branch on the scope.
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.InferMemoryScope()  # type: ignore
+
+
 def ThreadSync(storage_scope: str):
     """Insert sync between parallel read/write of shared buffers.
 


### PR DESCRIPTION
#277 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds `T.auto_alloc` for automatic memory-scope inference.
- Adds `tl.transform.InferMemoryScope`, which infers concrete scopes from buffer usage.
- Integrates inference into CUDA, ROCm, and CPU pipelines.
- Rejects unresolved `auto` scopes before buffer verification.
- Adds clear errors for unsupported `auto` usage in `T.reduce_*` and `T.print`.
- Exports `auto_alloc` through the common language API.
- Adds pass-level, pipeline, code-generation, error-path, and CPU numerical tests.

## C++ style / lint notes

- The PR changes C++ files but does not change `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) CI step may report advisory findings for the new exported utility and pass registration.
- These findings are warning-only and do not indicate correctness or build failures.
- No blocking TLCPP003/TLCPP004 issue is identified from the provided changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->