### PR TITLE
[CUDA] Complete 16-bit bridges for CUDA-lowered unary math

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -213,15 +213,63 @@ TL_PATCH TL_DEVICE bfloat16_t __hfma(const bfloat16_t x, const bfloat16_t y,
 #endif
 }
 
-// CUDA has no half-precision tangent intrinsic, but tangent lowering uses the
-// half-style `htan` name for 16-bit inputs. Evaluate in float32 and convert the
-// result back to the source type.
+// 16-bit lowering emits these h* names, but CUDA has no overload of them
+// that accepts the CUTLASS wrapper types. Evaluate in float32 and convert
+// the result back to the source type.
 TL_PATCH TL_DEVICE half_t htan(const half_t x) {
   return half_t(tanf(float(x)));
 }
 
 TL_PATCH TL_DEVICE bfloat16_t htan(const bfloat16_t x) {
   return bfloat16_t(tanf(float(x)));
+}
+
+TL_PATCH TL_DEVICE half_t hsinh(const half_t x) {
+  return half_t(sinhf(float(x)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hsinh(const bfloat16_t x) {
+  return bfloat16_t(sinhf(float(x)));
+}
+
+TL_PATCH TL_DEVICE half_t hcosh(const half_t x) {
+  return half_t(coshf(float(x)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hcosh(const bfloat16_t x) {
+  return bfloat16_t(coshf(float(x)));
+}
+
+TL_PATCH TL_DEVICE half_t htanh(const half_t x) {
+  return half_t(tanhf(float(x)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t htanh(const bfloat16_t x) {
+  return bfloat16_t(tanhf(float(x)));
+}
+
+TL_PATCH TL_DEVICE half_t hatan(const half_t x) {
+  return half_t(atanf(float(x)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hatan(const bfloat16_t x) {
+  return bfloat16_t(atanf(float(x)));
+}
+
+TL_PATCH TL_DEVICE half_t herf(const half_t x) {
+  return half_t(erff(float(x)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t herf(const bfloat16_t x) {
+  return bfloat16_t(erff(float(x)));
+}
+
+TL_PATCH TL_DEVICE half_t hnearbyint(const half_t x) {
+  return half_t(nearbyintf(float(x)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hnearbyint(const bfloat16_t x) {
+  return bfloat16_t(nearbyintf(float(x)));
 }
 
 // TVM lowers 16-bit math ops to CUDA's half-style names (hexp, hlog, ...).

--- a/testing/python/language/test_tilelang_language_intrinsics_codegen.py
+++ b/testing/python/language/test_tilelang_language_intrinsics_codegen.py
@@ -67,6 +67,12 @@ HALF_MATH_OPS = (
     ("ceil", "hceil", torch.ceil, 1),
     ("round", "hrint", torch.round, 1),
     ("trunc", "htrunc", torch.trunc, 1),
+    ("sinh", "hsinh", torch.sinh, 1),
+    ("cosh", "hcosh", torch.cosh, 1),
+    ("tanh", "htanh", torch.tanh, 1),
+    ("atan", "hatan", torch.atan, 1),
+    ("erf", "herf", torch.erf, 1),
+    ("nearbyint", "hnearbyint", torch.round, 1),
 )
 
 
@@ -92,6 +98,12 @@ def half_math_kernel(dtype, N):
             ceil_value = T.ceil(C[i])
             round_value = T.round(C[i])
             trunc_value = T.trunc(C[i])
+            sinh_value = T.sinh(C[i])
+            cosh_value = T.cosh(C[i])
+            tanh_value = T.tanh(C[i])
+            atan_value = T.atan(C[i])
+            erf_value = T.erf(C[i])
+            nearbyint_value = T.nearbyint(C[i])
             B[0, i] = exp_value
             B[1, i] = exp2_value
             B[2, i] = exp10_value
@@ -104,6 +116,12 @@ def half_math_kernel(dtype, N):
             B[9, i] = ceil_value
             B[10, i] = round_value
             B[11, i] = trunc_value
+            B[12, i] = sinh_value
+            B[13, i] = cosh_value
+            B[14, i] = tanh_value
+            B[15, i] = atan_value
+            B[16, i] = erf_value
+            B[17, i] = nearbyint_value
 
     return main
 


### PR DESCRIPTION
## Summary

`T.sinh`, `T.cosh`, `T.tanh`, `T.atan`, `T.erf`, and `T.nearbyint` fail to compile on `float16` and `bfloat16`.

CUDA lowering emits half-style names for these operations, but no CUDA overload of those names accepts the `cutlass::half_t` and `cutlass::bfloat16_t` values TileLang emits. Most toolkits do not declare the names at all, and the overloads that do exist take native `__half` or `__nv_bfloat16`, which the CUTLASS wrappers have no implicit conversion to. These operations therefore fail on every toolkit:

```text
error: identifier "hsinh" is undefined
```
## Fix

Add `half_t` and `bfloat16_t` overloads for the six names, each evaluating in float32 and converting back — the same approach as the existing `htan` bridge (#2894).

This completes the set: every unary floating-point op that CUDA lowering already handles now has a 16-bit bridge. Verified by compiling all 22 of them in both `float16` and `bfloat16`: 44/44 emit the expected `h*` name and compile.

## Tests

Extended the existing 16-bit intrinsics kernel with the six ops.

Verified locally on sm_75 / CUDA 12.4:

* Touched file: 5 passed.
* Negative control (bridges reverted): fails only with the six undefined identifiers.
* Fast-math and sm_75 GEMM suites alongside the touched file: 141 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added CUDA 16-bit bridges for `sinh`, `cosh`, `tanh`, `atan`, `erf`, and `nearbyint`.
- Added `half_t` and `bfloat16_t` overloads for the corresponding `h*` CUDA names.
- Evaluated each operation in `float32`, then converted the result back to the source type.
- Expanded the CUDA intrinsic test kernel to cover all six operations.
- Validation compiled 22 unary floating-point operations for both 16-bit types. All 44 cases passed.
- Additional CUDA 12.4 `sm_75` test suites passed.

## C++ style / lint notes

- The PR changes C++ code in `src/tl_templates/cuda/common.h`.
- It does not modify rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step is relevant to the changed helper overloads.
- Any TLCPP003/TLCPP004 findings are advisory unless they indicate a clear API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->