### PR TITLE
[CI] Fix slow Windows wheel builds by making ccache effective

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -141,10 +141,35 @@ jobs:
           fetch-depth: 1
           submodules: recursive
 
+      - name: Setup Python and uv with caching
+        id: setup-uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.target.python_version }}
+          activate-environment: true
+
+      # CMakeLists.txt only plugs cmake/ccache_strip_pep517.py (normalizes the
+      # random PEP 517 build-env paths before ccache hashes the preprocessed
+      # output) in front of the preprocessor when a stable interpreter exists
+      # at .venv/Scripts/python.exe. Without it ccache misses on ~99% of
+      # lookups and the Windows wheel build recompiles all of TVM + TileLang
+      # from scratch (~40 min).
+      - name: Create stable .venv for ccache wrapper (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          if (-not (Test-Path ".venv\Scripts\python.exe")) {
+            uv venv .venv
+          }
+          & ".venv\Scripts\python.exe" --version
+
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          max-size: "200MB"
+          # One full Windows build writes >200MB of compressed objects; a
+          # smaller cap makes ccache evict entries mid-build (522 cleanups
+          # observed at 200MB) so the cache never converges.
+          max-size: "2GB"
           create-symlink: ${{ runner.os != 'Windows' }}
           evict-old-files: "7d"
           append-timestamp: false
@@ -210,13 +235,6 @@ jobs:
           package-dir: .
           output-dir: wheelhouse
           config-file: "{package}/pyproject.toml"
-
-      - name: Setup Python and uv with caching
-        id: setup-uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          python-version: ${{ matrix.target.python_version }}
-          activate-environment: true
 
       - name: Test built wheels
         if: runner.os != 'Windows'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,19 @@ if(MSVC)
       $<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-command-line-argument>
       $<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unknown-attributes>
       $<$<COMPILE_LANGUAGE:CXX>:-fdelayed-template-parsing>)
+
+    # Recent clang (VS 2026 bundles 22.x) warns on every C++20 TU that
+    # -fdelayed-template-parsing is deprecated; the flag still takes effect,
+    # and the warning floods CI logs. Feature-check the suppression so older
+    # LLVM without this diagnostic group doesn't emit
+    # -Wunknown-warning-option noise instead.
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("-Wno-delayed-template-parsing-in-cxx20"
+                            TILELANG_HAS_WNO_DELAYED_TEMPLATE_PARSING_IN_CXX20)
+    if(TILELANG_HAS_WNO_DELAYED_TEMPLATE_PARSING_IN_CXX20)
+      add_compile_options(
+        $<$<COMPILE_LANGUAGE:CXX>:-Wno-delayed-template-parsing-in-cxx20>)
+    endif()
   endif()
 endif()
 

--- a/cmake/ccache_strip_pep517.py
+++ b/cmake/ccache_strip_pep517.py
@@ -1,10 +1,13 @@
 """ccache prefix_command_cpp wrapper for PEP 517 build-isolation tempdir names.
 
-uv (and pip) materialize each PEP 517 build into a freshly-named tempdir like
-``<UV_CACHE_DIR>/builds-v0/.tmpXXXXXXXX``. That ``.tmpXXX`` segment shows up in
-``-I`` flags (NVIDIA cu13, z3, ...) and is preserved inside cl.exe's
-preprocessor output as ``#line N "...\\.tmpXXX\\..."`` directives. ccache hashes
-the preprocessed text to derive its result key, so the random tempdir name
+PEP 517 frontends materialize each build into a freshly-named tempdir:
+uv uses ``<UV_CACHE_DIR>/builds-v0/.tmpXXXXXXXX``, pypa/build (cibuildwheel's
+default frontend) uses ``%TEMP%\\build-env-XXXXXXXX``, pip uses
+``pip-build-env-XXXXXXXX``, and cibuildwheel itself nests everything under
+``cibw-run-XXXXXXXX``. Those random segments show up in include flags
+(NVIDIA cu13, z3, ...) and are preserved inside cl.exe's preprocessor output
+as ``#line N "...\\build-env-XXX\\..."`` directives. ccache hashes the
+preprocessed text to derive its result key, so the random tempdir name
 defeats cache hits across rebuilds.
 
 This wrapper is plugged into ccache via ``prefix_command_cpp``. ccache invokes
@@ -13,9 +16,11 @@ it as::
     python ccache_strip_pep517.py <cl.exe path> <cl.exe args including /Fi...>
 
 We forward the call to cl.exe unchanged, then post-process the file cl.exe
-wrote to (the path given via ``/Fi`` or ``-Fi``) by replacing every
-``.tmpXXXXXXXX`` token with a stable ``_pep517`` placeholder. ccache then sees
-identical preprocessed bytes across rebuilds and the result-key lookup hits.
+wrote to (the path given via ``/Fi`` or ``-Fi``) by replacing every random
+tempdir token (``.tmpXXXXXXXX`` / ``build-env-XXXXXXXX`` / ``cibw-run-XXXXXXXX``)
+with a stable ``_pep517`` placeholder. ccache then sees identical preprocessed
+bytes across rebuilds and the result-key lookup hits. The rewritten text is
+only ever hashed, never compiled, so the substitution cannot miscompile.
 
 Note this only stabilizes ccache's *result key* (preprocessor mode). The
 *manifest key* still embeds the raw command line, so direct-mode lookup keeps
@@ -31,7 +36,8 @@ import re
 import subprocess
 import sys
 
-_TMP_PATTERN = re.compile(rb"\.tmp[A-Za-z0-9]+")
+# tempfile's random suffix alphabet includes "_" (e.g. build-env-gna_6ikk).
+_TMP_PATTERN = re.compile(rb"(?:\.tmp|build-env-|cibw-run-)[A-Za-z0-9_]+")
 _STABLE_TOKEN = b"_pep517"
 
 


### PR DESCRIPTION
## Summary

The `Dist` workflow's Windows wheel job takes ~48 min while Linux takes ~9 min (see e.g. [run 33572214431](https://github.com/tile-ai/tilelang/actions/runs/33572214431)). Almost all of it is cibuildwheel recompiling all ~700 TVM + TileLang TUs with clang-cl on every run: the ccache hit rate was **8/698 (1.15%)** on Windows vs **678/714 (95%)** on Linux.

## Root causes

1. **PEP 517 build-isolation tempdir names leak into ccache's hash.** cibuildwheel's `build` frontend materializes each build into a randomly-named `Temp\build-env-XXXXXXXX` dir, which hosts the pip-provided CUDA cu13 / z3 headers. That path is preserved in the preprocessor output as `#line` directives, so ccache's preprocessed-mode result key changes on every run. The repo already ships the fix — `cmake/ccache_strip_pep517.py`, plugged in via ccache `prefix_command_cpp` — but:
   - CMakeLists.txt only activates it when a stable interpreter exists at `.venv/Scripts/python.exe`, and CI never created one (the configure log shows `ccache: no stable .venv python found`);
   - the wrapper's regex only matched uv's `.tmpXXX` naming, not the `build-env-XXX` naming pypa/build actually uses (nor random suffixes containing `_`, e.g. `build-env-gna_6ikk`).
2. **`max-size: 200MB` is smaller than one full build's output.** ccache evicted entries mid-build (522 cleanups, cache 99.96% full), so the cache could never converge to a full set of objects.

The command-line side is already safe: ccache 4.9 natively treats `-imsvc` / `-external:I` as preprocessor path options excluded from the cpp-mode hash, so the `#line` text was the only leak.

## Changes

- `cmake/ccache_strip_pep517.py`: widen normalization to `(?:\.tmp|build-env-|cibw-run-)[A-Za-z0-9_]+`. The rewritten text is only hashed, never compiled, so this cannot miscompile.
- `.github/workflows/dist.yml`: move `setup-uv` before the build step and create a repo-root `.venv` on Windows so the wrapper activates; raise ccache `max-size` to 2GB for the wheel jobs.
- `CMakeLists.txt`: suppress clang-cl's `-Wdelayed-template-parsing-in-cxx20` deprecation warning (feature-checked so older LLVM doesn't emit unknown-warning-option noise instead); it fired on every C++20 TU and flooded the logs.

## Expected effect / how to verify

The first Windows run after this lands still compiles cold (~45 min) and populates the cache. Subsequent runs should hit ~95% and drop "Build wheels" from ~44 min to well under 10 min. Check the `Post Setup ccache` stats and the `ccache: stripping PEP 517 .tmpXXX paths via ...` configure line (instead of `no stable .venv python found`).

Since this PR touches `dist.yml` / `CMakeLists.txt`, the Dist workflow runs on the PR itself — the second datapoint needs a re-run or a follow-up push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Improved Windows wheel build caching by normalizing more PEP 517 temporary-directory patterns.
- Created a stable repository-root `.venv` before the Windows cibuildwheel step.
- Increased the wheel-job ccache limit from 200 MB to 2 GB.
- Added conditional suppression for the clang-cl C++20 delayed-template-parsing deprecation warning.
- Expected subsequent Windows builds to reach about 95% cache hits and complete in under 10 minutes.

## C++ style / lint notes

- The PR changes a C++ compiler warning in `CMakeLists.txt`.
- It does not modify rules documented in `docs/developer_guide/cpp_style.md`.
- The change does not affect the “C++ API Style Audit (warning only)” CI step.
- The clang-cl warning suppression is conditional and avoids unknown-warning-option noise on unsupported toolchains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->