### PR TITLE
[CI] Cap torch<2.14 for CUDA tests until flash-attn supports torch 2.14

### DIFF
--- a/requirements-test-cuda.txt
+++ b/requirements-test-cuda.txt
@@ -6,6 +6,12 @@
 
 # CUDA specific requirements
 flash-attn==2.5.8
+# torch 2.14 headers require C++20, but every flash-attn release so far
+# (<=2.8.3.post1, and upstream main as of 2026-09) still compiles its CUDA
+# extension with -std=c++17 and ships no prebuilt torch-2.14 wheels, so the
+# source build fails (e.g. in c10/core/SymBool.h). Remove this cap once a
+# flash-attn release supports torch 2.14.
+torch<2.14
 cuda-python==13.0.3
 # Use the cu13 extra so CuTeDSL installs the CUDA 13 runtime package.
 nvidia-cutlass-dsl[cu13]==4.7.0


### PR DESCRIPTION
## Why

The self-hosted CUDA job started failing in `Setup venv` (e.g. [this run](https://github.com/tile-ai/tilelang/actions/runs/33594121983/job/100134195979)):

1. `torch==2.14.0+cu130` was published on the cu130 index (the last green main run on 8/30 still resolved `2.13.0+cu130`), and its headers now require **C++20**.
2. The pinned `flash-attn==2.5.8` has no prebuilt wheel for torch 2.14 (its `setup.py` wheel-URL guess gets HTTP 404), so it falls back to a source build.
3. The source build compiles with `-std=c++17` and dies with ~100 errors in `c10/core/SymBool.h` (`#error C++20 or later compatible compiler is required`, `std::strong_ordering`, `requires`, ...).
4. The post-failure cleanup then wipes the runner's uv cache, so every retry rebuilds from a cold cache and hits the same wall.

Upgrading flash-attn does not help today: every release up to `2.8.3.post1` — and even upstream `main` — still compiles the **CUDA** extension with `-std=c++17` (only the ROCm/CK path was bumped to C++20), and the newest cu13 prebuilt wheels only cover `torch2.9`. There is no upstream issue/PR for torch 2.14 yet.

## What

Cap `torch<2.14` in `requirements-test-cuda.txt`, next to the flash-attn pin, with a comment stating the removal condition. The current CI matrix has no `Nightly-*` toolkit entries, and ROCm/Metal jobs (both green on torch 2.14) are unaffected.

Note: in the CUDA job, the earlier `uv pip install -r requirements-test.txt` still resolves torch 2.14 before the CUDA requirements downgrade it to 2.13, costing one extra cached torch install (~1-2 min warm). Scoping the cap to the CUDA file was chosen over holding all platforms back; feel free to hoist it into `requirements-test.txt` if you'd rather avoid the double install.

## Revert condition

Remove the cap once a flash-attn release builds its CUDA extension with `-std=c++20` (or ships torch-2.14 wheels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Cap CUDA test dependencies at `torch<2.14`.
- Document the incompatibility between Torch 2.14 headers and the C++17 build used by `flash-attn==2.5.8`.
- Limit the change to CUDA tests. ROCm and Metal jobs remain unaffected.
- Remove the cap when `flash-attn` supports C++20 CUDA builds or provides Torch 2.14 wheels.

## C++ style / lint notes

- This change does not modify C++ code or documented C++ style rules.
- The C++ API Style Audit is not relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->