### PR TITLE
[BugFix] Allow async copies in conditionally executed pipeline stages 

### DIFF
--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -494,9 +494,12 @@ public:
   }
 
   bool IsAsyncProducerCandidate(const PipelineStageInfo &pinfo) const {
-    if (pinfo.conditional_execution) {
-      return false;
-    }
+    // Conditionally executed copies are still eligible for cp.async: commit is
+    // emitted outside the user branch (a skipped iteration commits an empty
+    // group, which completes immediately), so group counting stays consistent.
+    // Conditional TMA remains excluded (tma_copy is never set for conditional
+    // stages): mbarrier arrive/wait must pair up, and a skipped arrive with a
+    // non-skipped wait deadlocks (see #2002, blocksparse_gemm launch failures).
     if (pinfo.IsTmaCopy()) {
       return false;
     }
@@ -602,6 +605,10 @@ public:
   void ClassifyCopyLikeStage(const Stmt &stmt, PipelineStageInfo *pinfo) const {
     ICHECK(pinfo != nullptr);
     if (pinfo->conditional_execution) {
+      // Intentional exclusion (safe, not policy): conditional plain copies
+      // are already classified by the pure-copy path in MakePipelineStageInfo,
+      // so this fallback only gates conditional im2col, whose pipeline-managed
+      // cp.async path has no test coverage yet.
       return;
     }
 
@@ -942,6 +949,10 @@ public:
       ClassifyCopyLikeStage(pipeline_stmts[i], &pinfo);
       pinfo.order = static_cast<int>(order_array[i]->value);
       pinfo.stage = static_cast<int>(stage_array[i]->value);
+      // The conditional check here is an intentional conservative exclusion:
+      // this legacy heuristic promotes non-pure (mixed compute+copy)
+      // statements to copy stages, and extending that guess to conditionally
+      // executed statements is not covered by any use case.
       if (!pinfo.IsCopyStage() && !pinfo.conditional_execution &&
           pinfo.stage == 0) {
         bool reads_global = false;

--- a/testing/python/transform/test_tilelang_transform_pipeline_planning.py
+++ b/testing/python/transform/test_tilelang_transform_pipeline_planning.py
@@ -1,7 +1,10 @@
 from tilelang import tvm as tvm
+import pytest
 import tilelang as tl
+import tilelang.testing
 from tilelang.backend.target import determine_target
 import tilelang.language as T
+from tilelang.tools.compile_only import compile_kernel_source, cuda_codegen_available
 from tvm.tirx.stmt_functor import post_order_visit
 
 auto_target = tvm.target.Target(determine_target("auto"))
@@ -838,3 +841,121 @@ def test_pipeline_planning_keeps_bind_that_reads_atomic_target():
     assert stages == [0, 0, 1, 1]
     assert orders == [0, 1, 2, 3]
     assert "software_pipeline_replayable_scalar_binds" not in anno
+
+
+def _conditional_copy_gemm_kernel(num_stages):
+    """Pipelined GEMM whose copy+gemm body is guarded by a runtime condition.
+
+    Before the fix, PipelineStageAnalyzer rejected conditionally executed copy
+    stages from async, so the copies stayed synchronous. The copies should be
+    eligible for cp.async: commit is emitted outside the user branch, so group
+    counting stays consistent for skipped iterations.
+    """
+    M = N = K = 256
+    BM, BN, BK = 64, 64, 32
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((M, K), T.float16),
+        B: T.Tensor((K, N), T.float16),
+        C: T.Tensor((M, N), T.float16),
+        limit: T.int32,
+    ):
+        with T.Kernel(T.ceildiv(N, BN), T.ceildiv(M, BM), threads=128) as (bx, by):
+            a_sh = T.alloc_shared((BM, BK), T.float16)
+            b_sh = T.alloc_shared((BK, BN), T.float16)
+            c_loc = T.alloc_fragment((BM, BN), T.float32)
+            T.clear(c_loc)
+            for k in T.Pipelined(T.ceildiv(K, BK), num_stages=num_stages):
+                if k < limit:
+                    T.copy(A[by * BM : (by + 1) * BM, k * BK : (k + 1) * BK], a_sh)
+                    T.copy(B[k * BK : (k + 1) * BK, bx * BN : (bx + 1) * BN], b_sh)
+                    T.gemm(a_sh, b_sh, c_loc)
+            T.copy(c_loc, C[by * BM : (by + 1) * BM, bx * BN : (bx + 1) * BN])
+
+    return kernel
+
+
+def _line_after_matching_brace(src, needle):
+    """Return the first statement line after the closing brace of the if block
+    that starts with `needle`."""
+    start = src.index(needle)
+    depth = 0
+    i = src.index("{", start)
+    while True:
+        ch = src[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        i += 1
+    for line in src[i + 1 :].splitlines():
+        line = line.strip()
+        if line and not line.startswith("#line"):
+            return line
+    raise AssertionError("no statement found after " + needle)
+
+
+@pytest.mark.skipif(
+    not cuda_codegen_available(),
+    reason="CUDA codegen FFI missing (e.g. ROCm or macOS Metal builds)",
+)
+@pytest.mark.parametrize("num_stages", [2, 3])
+def test_pipeline_planning_conditional_copy_emits_cp_async(num_stages):
+    kernel = _conditional_copy_gemm_kernel(num_stages)
+    src = compile_kernel_source(kernel, {"kind": "cuda", "arch": "sm_80"})
+
+    # The conditional copy stage must lower to cp.async instead of falling
+    # back to a synchronous vector copy.
+    assert "tl::cp_async" in src
+    assert "tl::cp_async_commit();" in src
+    # Steady-state wait depth and the final drain.
+    assert f"tl::cp_async_wait<{num_stages - 1}>();" in src
+    assert "tl::cp_async_wait<0>();" in src
+
+    # Commit must be emitted outside the producer branch: the statement right
+    # after the steady-state `if ((k + n) < limit) { ... }` block is the
+    # commit, so every iteration commits exactly one (possibly empty) group
+    # and wait<N> group counting stays consistent for skipped iterations.
+    producer_if = f"if ((k + {num_stages - 1}) < limit)"
+    next_stmt = _line_after_matching_brace(src, producer_if)
+    assert next_stmt == "tl::cp_async_commit();", next_stmt
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(8, 0)
+def test_pipeline_planning_conditional_copy_cp_async_numerics():
+    """Device-side numerics for the conditional async pipeline.
+
+    Sweeps the runtime limit so skipped iterations exercise the empty-commit
+    path, on the cp.async pipeline (warp specialization disabled so Hopper
+    does not reroute the copies through WS/TMA, which is classified
+    independently of this change).
+    """
+    import torch
+
+    M = N = K = 256
+    BK = 32
+    num_iters = K // BK
+
+    kernel = tilelang.compile(
+        _conditional_copy_gemm_kernel(num_stages=2),
+        out_idx=[2],
+        pass_configs={tl.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )
+
+    a = torch.randn(M, K, device="cuda", dtype=torch.float16)
+    b = torch.randn(K, N, device="cuda", dtype=torch.float16)
+
+    for limit in (0, 1, 3, num_iters, num_iters + 2):
+        c = kernel(a, b, limit)
+        ref = torch.zeros(M, N, device="cuda", dtype=torch.float32)
+        for k in range(min(limit, num_iters)):
+            ref += a[:, k * BK : (k + 1) * BK].float() @ b[k * BK : (k + 1) * BK, :].float()
+        torch.testing.assert_close(c.float(), ref, rtol=1e-2, atol=1e-2)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
PipelineStageAnalyzer rejected any copy stage whose statement may be conditionally executed, so a pipelined global->shared copy guarded by a runtime condition (e.g. 'if (cond) { T.copy; T.gemm }') silently stayed a synchronous load and the whole pipeline fell back to __syncthreads.

The rejection is unnecessary: the injected cp.async carries the branch predicate, and the pipeline lowering already places commit_group outside the branch and the wait before the conditional consumer, with the gemm re-guarded by the original predicate, so skipped iterations stay correct. Drop the conditional_execution check from IsAsyncProducerCandidate and let conditional copy stages use cp.async.

### Problem                                                                                                                           
                                                                                                                                           
   When a pipelined loop's copy is guarded by a runtime condition:                                                                       
                                                                                                                                         
   ```python                                                                                                                             
   for k in T.Pipelined(T.ceildiv(K, BK), num_stages=2):                                                                                 
       if k < limit:                          # dynamic condition                                                                        
           T.copy(A[k * BK : (k + 1) * BK], a_sh)   # global -> shared                                                                   
           T.gemm(a_sh, b_sh, c_loc)                                                                                                     
   ```                                                                                                                                   
                                                                                                                                         
   `PipelineStageAnalyzer::IsAsyncProducerCandidate` rejects any copy stage whose                                                        
   statement `MayBeConditionallyExecuted`, so the copy silently stays a                                                                  
   synchronous global load and the whole pipeline degenerates to                                                                         
   `__syncthreads`-based staging. The condition is legitimate for bounds-style                                                           
   tiling, and the ideal lowering is well-defined:                                                                                       
   `if (cond) { cp.async } commit; if (cond) { wait, gemm }`.                                                                            
                                                                                                                                         
   ### Reproducer (compile-only, no GPU needed)                                                                                          
                                                                                                                                         
   ```python                                                                                                                             
   import tilelang                                                                                                                       
   import tilelang.language as T                                                                                                         
   from tilelang.tools.compile_only import compile_kernel_source                                                                         
                                                                                                                                         
   M = N = K = 256                                                                                                                       
   BM, BN, BK = 64, 64, 32                                                                                                               
                                                                                                                                         
                                                                                                                                         
   @T.prim_func                                                                                                                          
   def kernel(                                                                                                                           
       A: T.Tensor((M, K), T.float16),                                                                                                   
       B: T.Tensor((K, N), T.float16),                                                                                                   
       C: T.Tensor((M, N), T.float16),                                                                                                   
       limit: T.int32,                                                                                                                   
   ):                                                                                                                                    
       with T.Kernel(T.ceildiv(N, BN), T.ceildiv(M, BM), threads=128) as (bx, by):                                                       
           a_sh = T.alloc_shared((BM, BK), T.float16)                                                                                    
           b_sh = T.alloc_shared((BK, BN), T.float16)                                                                                    
           c_loc = T.alloc_fragment((BM, BN), T.float32)                                                                                 
           T.clear(c_loc)                                                                                                                
           for k in T.Pipelined(T.ceildiv(K, BK), num_stages=2):                                                                         
               if k < limit:                                                                                                             
                   T.copy(A[by * BM:(by + 1) * BM, k * BK:(k + 1) * BK], a_sh)                                                           
                   T.copy(B[k * BK:(k + 1) * BK, bx * BN:(bx + 1) * BN], b_sh)                                                           
                   T.gemm(a_sh, b_sh, c_loc)                                                                                             
           T.copy(c_loc, C[by * BM:(by + 1) * BM, bx * BN:(bx + 1) * BN])                                                                
                                                                                                                                         
                                                                                                                                         
   src = compile_kernel_source(kernel, "cuda -arch=sm_80")                                                                               
   assert "tl::cp_async" in src  # used to silently stay a synchronous copy                                                              
   ```                                                                                                                                   
                                                                                                                                         
   ### Generated code, steady-state loop (index arithmetic abridged)                                                                     
                                                                                                                                         
   **Before** — conditional stage excluded from async, everything synchronous:                                                           
                                                                                                                                         
   ```cuda                                                                                                                               
   for (int k = 0; k < 7; ++k) {                                                                                                         
     __syncthreads();                                                                                                                    
     if ((k + 1) < limit) {                                                                                                              
       *(uint4*)(a_sh_smem + ... ) = *(uint4*)(A + ...);   // sync vector copy                                                           
       *(uint4*)(b_sh_smem + ... ) = *(uint4*)(B + ...);                                                                                 
     }                                                                                                                                   
     __syncthreads();                                                                                                                    
     if (k < limit) { /* ldmatrix + mma */ }                                                                                             
   }                                                                                                                                     
   ```                                                                                                                                   
                                                                                                                                         
   **After** — cp.async keeps the branch predicate, commit hoisted out of the                                                            
   branch, wait before the conditional consumer:                                                                                         
                                                                                                                                         
   ```cuda                                                                                                                               
   if (0 < limit) { tl::cp_async_gs<16>(...); }  // prologue                                                                             
   tl::cp_async_commit();                                                                                                                
   for (int k = 0; k < 7; ++k) {                                                                                                         
     __syncthreads();                                                                                                                    
     if ((k + 1) < limit) {                                                                                                              
       tl::cp_async_gs<16>((&a_sh[...]), (&A[...]));                                                                                     
       tl::cp_async_gs<16>((&b_sh[...]), (&B[...]));                                                                                     
     }                                                                                                                                   
     tl::cp_async_commit();                       // outside the if: always runs                                                         
     tl::cp_async_wait<1>();                                                                                                             
     __syncthreads();                                                                                                                    
     if (k < limit) { /* ldmatrix + mma */ }                                                                                             
   }                                                                                                                                     
   tl::cp_async_wait<0>();                        // drain                                                                               
   __syncthreads();                                                                                                                      
   if (7 < limit) { /* epilogue gemm */ }                                                                                                
   ```                                                                                                                                   
                                                                                                                                         
   ### Fix                                                                                                                               
                                                                                                                                         
   Drop the `conditional_execution` early-return in                                                                                      
   `IsAsyncProducerCandidate` (`src/transform/pipeline_planning.cc`). No new pass                                                        
   is needed: the injected cp.async carries the branch predicate, and the                                                                
   existing pipeline lowering already places `commit_group` *outside* the branch                                                         
   (so skipped iterations still commit a consistent, possibly empty group) and                                                           
   the wait before the consumer guarded by the original predicate. TMA copies                                                            
   and non-copy stages remain excluded.                                                                                                  
                                                                                                                                         
   ### Validation                                                                                                                        
                                                                                                                                         
   - Reproducer above emits `tl::cp_async_gs<16>` with correct commit/wait                                                               
     placement; checked for `num_stages=2` and `num_stages=3`                                                                            
     (prologue fills stages, steady state `wait<2>`, drain `wait<1>`/`wait<0>`).                                                         
   - Transform-level pipeline suites:                                                                                                    
     `test_tilelang_transform_Inject_software_pipeline.py`,                                                                              
     `test_tilelang_transform_pipeline_planning.py`,                                                                                     
     `test_tilelang_transform_pipeline_barrier_ownership.py`                                                                             
     — 34 passed, 3 skipped.                                                                                                             
   - `pre-commit run --all-files` is clean.                                                                                              
   - Note: device-run numerics should be validated by CI on an SM80+ GPU;                                                                
     the verification here is at the codegen/TIR level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Allow conditionally executed global-to-shared copy stages to use `cp.async`.
- Keep conditional TMA copies and non-copy stages excluded.
- Emit commit groups outside conditional branches.
- Wait before conditional consumers while preserving consumer predicates.
- Avoid unnecessary `__syncthreads` fallback for runtime-guarded copies.

## Validation

- Compile-only checks passed for two-stage and three-stage pipeline reproducers.
- 34 pipeline tests passed.
- 3 pipeline tests were skipped.
- Pre-commit checks passed.
- GPU numerical validation remains deferred to CI on SM80+ hardware.

## C++ style / lint notes

- The change touches C++ implementation code but does not alter rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains relevant to CI.
- This change introduces no public API changes or known warning-only style issues.
- Advisory TLCPP003/TLCPP004 findings do not indicate correctness or build issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->