### PR TITLE
[BugFix] Split divergent branches around required syncs

### DIFF
--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -578,10 +578,13 @@ using VarPropertyMap = std::unordered_map<Var, ConditionThreadProperty,
                                           ObjectPtrHash, ObjectPtrEqual>;
 
 /*!
- * \brief 分析条件是否依赖运行时数据，以及 block 内线程是否得到相同结果。
+ * \brief Analyze whether a condition depends on runtime data and whether all
+ *        threads in a block produce the same result.
  *
- * 运行时且非 block-uniform 的条件需要拆分分支。仅依赖线程编号的条件若要
- * 保留分支内 partial barrier，还必须证明参与线程按完整 warp 对齐。
+ * Runtime conditions that are not block-uniform require branch splitting.
+ * Conditions that depend only on thread indices may retain an in-branch
+ * partial barrier only when participating threads form complete, warp-aligned
+ * groups.
  */
 class ConditionThreadPropertyChecker : public IRMutatorWithAnalyzer {
 public:
@@ -592,7 +595,7 @@ public:
         let_var_properties_(let_var_properties), warp_size_(warp_size) {}
 
   /*!
-   * \brief 分析与分支同步变换有关的条件属性。
+   * \brief Analyze condition properties relevant to branch synchronization.
    */
   ConditionThreadProperty AnalyzeExpr(const PrimExpr &expr) {
     current_ = ConditionThreadProperty();
@@ -1128,7 +1131,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     let_var_properties_.erase(loop_var_it);
   }
 
-  /*! \brief 汇总 if 两侧的访存，并为不安全的分支内 barrier 制定拆分计划。 */
+  /*! \brief Summarize both branches and plan splits for unsafe barriers. */
   void VisitStmt_(const IfThenElseNode *op) final {
     StmtEntry s;
     bool condition_is_block_uniform = IsBlockUniformCondition(op->condition);

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -210,6 +210,7 @@ private:
 };
 
 using StmtIdentitySet = std::unordered_set<Stmt, ObjectPtrHash, ObjectPtrEqual>;
+using VarIdentitySet = std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual>;
 
 struct DivergentBranchSyncPlan {
   StmtIdentitySet then_syncs;
@@ -289,11 +290,11 @@ private:
              "write and read phases.";
     }
 
-    std::unordered_set<const VarNode *> prior_phase_bindings;
+    VarIdentitySet prior_phase_bindings;
     for (const Array<Stmt> &phase : phases) {
       for (const Stmt &statement : phase) {
         if (UsesVar(statement, [&](const VarNode *var) {
-              return prior_phase_bindings.count(var) != 0;
+              return prior_phase_bindings.count(GetRef<Var>(var)) != 0;
             })) {
           LOG(FATAL) << "[ThreadSync] Cannot split a divergent branch because "
                         "a scalar binding crosses the required shared-memory "
@@ -302,7 +303,7 @@ private:
       }
       for (const Stmt &statement : phase) {
         if (const auto *bind = statement.as<BindNode>()) {
-          prior_phase_bindings.insert(bind->var.get());
+          prior_phase_bindings.insert(bind->var);
         }
       }
     }
@@ -573,6 +574,9 @@ struct ConditionThreadProperty {
   }
 };
 
+using VarPropertyMap = std::unordered_map<Var, ConditionThreadProperty,
+                                          ObjectPtrHash, ObjectPtrEqual>;
+
 /*!
  * \brief 分析条件是否依赖运行时数据，以及 block 内线程是否得到相同结果。
  *
@@ -583,9 +587,7 @@ class ConditionThreadPropertyChecker : public IRMutatorWithAnalyzer {
 public:
   explicit ConditionThreadPropertyChecker(
       arith::Analyzer *analyzer, const Array<IterVar> &env_threads,
-      const std::unordered_map<const VarNode *, ConditionThreadProperty>
-          &let_var_properties,
-      int warp_size = 32)
+      const VarPropertyMap &let_var_properties, int warp_size = 32)
       : IRMutatorWithAnalyzer(analyzer), env_threads_(env_threads),
         let_var_properties_(let_var_properties), warp_size_(warp_size) {}
 
@@ -661,7 +663,7 @@ private:
       current_.is_block_uniform = false;
       return GetRef<Var>(op);
     }
-    auto it = let_var_properties_.find(op);
+    auto it = let_var_properties_.find(GetRef<Var>(op));
     if (it != let_var_properties_.end()) {
       current_.Merge(it->second);
     } else {
@@ -710,8 +712,7 @@ private:
 private:
   ConditionThreadProperty current_;
   const Array<IterVar> &env_threads_;
-  const std::unordered_map<const VarNode *, ConditionThreadProperty>
-      &let_var_properties_;
+  const VarPropertyMap &let_var_properties_;
   int warp_size_;
 };
 
@@ -846,6 +847,44 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     LOG(FATAL) << "Thread variable " << tag << " not found";
     return IterVar();
   }
+
+  void AddThreadVaryingSubstitutions(Map<Var, PrimExpr> &sub1,
+                                     Map<Var, PrimExpr> &sub2) const {
+    auto add_var = [&](const Var &var) {
+      if (!sub1.count(var)) {
+        sub1.Set(var, Var(var->name_hint + "<T1>", var.dtype()));
+        sub2.Set(var, Var(var->name_hint + "<T2>", var.dtype()));
+      }
+    };
+    for (const IterVar &iv : env_threads_) {
+      if (runtime::ThreadScope::Create(iv->thread_tag).rank == 1) {
+        add_var(iv->var);
+      }
+    }
+    for (const auto &[var, property] : let_var_properties_) {
+      if (!property.is_block_uniform) {
+        add_var(var);
+      }
+    }
+  }
+
+  bool IsBlockUniformValue(const PrimExpr &value) {
+    Map<Var, PrimExpr> sub1, sub2;
+    AddThreadVaryingSubstitutions(sub1, sub2);
+    if (sub1.empty()) {
+      return true;
+    }
+    ConstrSet cset = GetConstrSet();
+    ConstrSet c1 =
+        cset.RenameFrom("<T1>", sub1, std::nullopt, /*rename_ranges=*/false);
+    ConstrSet c2 =
+        cset.RenameFrom("<T2>", sub2, std::nullopt, /*rename_ranges=*/false);
+    arith::Analyzer analyzer;
+    c1.ToConstraints().Merge(c2.ToConstraints()).Populate(analyzer);
+    return analyzer.CanProveEqual(Substitute(value, sub1),
+                                  Substitute(value, sub2));
+  }
+
   /*!
    * \brief Try to prove that every thread reaches the same verdict on
    *        \p condition, using the live constraint set as premises.
@@ -858,12 +897,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
    */
   bool IsBlockUniformCondition(const PrimExpr &condition) {
     Map<Var, PrimExpr> sub1, sub2;
-    for (const auto &iv : env_threads_) {
-      if (runtime::ThreadScope::Create(iv->thread_tag).rank != 1)
-        continue;
-      sub1.Set(iv->var, Var(iv->var->name_hint + "<T1>", iv->var.dtype()));
-      sub2.Set(iv->var, Var(iv->var->name_hint + "<T2>", iv->var.dtype()));
-    }
+    AddThreadVaryingSubstitutions(sub1, sub2);
     if (sub1.empty()) {
       // Nothing is indexed by a thread, so the condition cannot diverge.
       return true;
@@ -886,12 +920,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
   /*! \brief Return whether every hardware warp agrees on \p condition. */
   bool IsWarpUniformCondition(const PrimExpr &condition) {
     Map<Var, PrimExpr> sub1, sub2;
-    for (const auto &iv : env_threads_) {
-      if (runtime::ThreadScope::Create(iv->thread_tag).rank != 1)
-        continue;
-      sub1.Set(iv->var, Var(iv->var->name_hint + "<T1>", iv->var.dtype()));
-      sub2.Set(iv->var, Var(iv->var->name_hint + "<T2>", iv->var.dtype()));
-    }
+    AddThreadVaryingSubstitutions(sub1, sub2);
     if (sub1.empty()) {
       return true;
     }
@@ -1002,7 +1031,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     allow_append_ = false;
     // Record let var properties
     auto let_prop = AnalyzeExprProperty(op->value);
-    let_var_properties_[op->var.get()] = let_prop;
+    let_var_properties_[op->var] = let_prop;
   }
   void VisitStmt_(const SBlockNode *op) final {
     auto block = Downcast<SBlock>(op);
@@ -1041,8 +1070,26 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
   }
 
   void VisitStmt_(const ForNode *op) final {
+    ConditionThreadProperty loop_var_property = AnalyzeExprProperty(op->min);
+    if (!loop_var_property.is_block_uniform && IsBlockUniformValue(op->min)) {
+      loop_var_property.is_block_uniform = true;
+    }
+    ConditionThreadProperty extent_property = AnalyzeExprProperty(op->extent);
+    bool extent_is_block_uniform =
+        extent_property.is_block_uniform || IsBlockUniformValue(op->extent);
+    auto [loop_var_it, inserted] =
+        let_var_properties_.emplace(op->loop_var, loop_var_property);
+    ICHECK(inserted);
+
+    std::unordered_set<const Object *> syncs_before_loop = syncs_inserted_;
+    if (!extent_is_block_uniform) {
+      ++non_uniform_control_flow_depth_;
+    }
     scope_.push_back(std::vector<StmtEntry>());
     ConstrVisitor::VisitStmt_(op);
+    if (!extent_is_block_uniform) {
+      --non_uniform_control_flow_depth_;
+    }
     StmtEntry s;
     s.stmt = op;
     s.access = Summarize(std::move(scope_.back()), op);
@@ -1066,6 +1113,19 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     if (!s.access.empty()) {
       scope_.back().emplace_back(std::move(s));
     }
+
+    if (!extent_is_block_uniform) {
+      for (const Object *sync : syncs_inserted_) {
+        if (syncs_before_loop.count(sync) == 0 && sync != op) {
+          LOG(FATAL) << "[ThreadSync] Cannot insert a required shared-memory "
+                        "sync inside a loop whose trip count differs across "
+                        "threads. Rewrite the kernel into uniform phases. "
+                        "Loop extent: "
+                     << op->extent;
+        }
+      }
+    }
+    let_var_properties_.erase(loop_var_it);
   }
 
   /*! \brief 汇总 if 两侧的访存，并为不安全的分支内 barrier 制定拆分计划。 */
@@ -1094,11 +1154,11 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       scope_.push_back(std::vector<StmtEntry>());
       {
         if (!condition_is_block_uniform) {
-          ++divergent_if_depth_;
+          ++non_uniform_control_flow_depth_;
         }
         this->VisitStmt(op->then_case);
         if (!condition_is_block_uniform) {
-          --divergent_if_depth_;
+          --non_uniform_control_flow_depth_;
         }
       }
 
@@ -1123,11 +1183,11 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       scope_.push_back(std::vector<StmtEntry>());
       {
         if (!condition_is_block_uniform) {
-          ++divergent_if_depth_;
+          ++non_uniform_control_flow_depth_;
         }
         this->VisitStmt(op->else_case.value());
         if (!condition_is_block_uniform) {
-          --divergent_if_depth_;
+          --non_uniform_control_flow_depth_;
         }
       }
       auto v = Summarize(std::move(scope_.back()), nullptr);
@@ -1178,9 +1238,10 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       bool split_else =
           !syncs_in_else.empty() && requires_split(tirx::Not(op->condition));
       if (split_then || split_else) {
-        if (divergent_if_depth_ != 0) {
+        if (non_uniform_control_flow_depth_ != 0) {
           LOG(FATAL) << "[ThreadSync] Cannot split a required shared-memory "
-                        "sync nested under another thread-divergent branch. "
+                        "sync nested under another thread-divergent control-"
+                        "flow statement. "
                         "Rewrite the kernel into explicit write and read "
                         "phases. Condition: "
                      << op->condition;
@@ -1206,6 +1267,11 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
 
   void VisitStmt_(const WhileNode *op) final {
     StmtEntry s;
+    ConditionThreadProperty condition_property =
+        AnalyzeExprProperty(op->condition);
+    bool condition_is_block_uniform = condition_property.is_block_uniform ||
+                                      IsBlockUniformCondition(op->condition);
+    std::unordered_set<const Object *> syncs_before_loop = syncs_inserted_;
     {
       auto guard = MakeGuard(op->condition);
       allow_append_ = true;
@@ -1215,7 +1281,13 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
 
       scope_.push_back(std::vector<StmtEntry>());
       {
+        if (!condition_is_block_uniform) {
+          ++non_uniform_control_flow_depth_;
+        }
         this->VisitStmt(op->body);
+        if (!condition_is_block_uniform) {
+          --non_uniform_control_flow_depth_;
+        }
       }
       s.stmt = op;
       s.access = Summarize(std::move(scope_.back()), nullptr);
@@ -1223,6 +1295,17 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       if (!cond_access.empty()) {
         s.access.insert(s.access.begin(), cond_access.begin(),
                         cond_access.end());
+      }
+    }
+    if (!condition_is_block_uniform) {
+      for (const Object *sync : syncs_inserted_) {
+        if (syncs_before_loop.count(sync) == 0) {
+          LOG(FATAL) << "[ThreadSync] Cannot insert a required shared-memory "
+                        "sync inside a while loop whose execution count may "
+                        "differ across threads. Rewrite the kernel into "
+                        "uniform phases. Condition: "
+                     << op->condition;
+        }
       }
     }
     scope_.back().emplace_back(std::move(s));
@@ -1671,15 +1754,14 @@ private:
   Array<IterVar> env_threads_;
   // Thread-uniform/runtime properties for let-bound vars visible in the
   // current lexical scope.
-  std::unordered_map<const VarNode *, ConditionThreadProperty>
-      let_var_properties_;
+  VarPropertyMap let_var_properties_;
   // The buffer map
   Map<Var, Buffer> buffer_data_to_buffer_;
   // synchronization scope
   StorageScope sync_scope_;
   // warp size from target
   int warp_size_;
-  int divergent_if_depth_{0};
+  int non_uniform_control_flow_depth_{0};
 
   void insert_syncs(const Object *obj) {
     if (syncs_inserted_.count(obj))

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -209,22 +209,41 @@ private:
   }
 };
 
+using StmtIdentitySet = std::unordered_set<Stmt, ObjectPtrHash, ObjectPtrEqual>;
+
+struct DivergentBranchSyncPlan {
+  StmtIdentitySet then_syncs;
+  StmtIdentitySet else_syncs;
+};
+
+using DivergentBranchSyncPlanMap =
+    std::unordered_map<IfThenElse, DivergentBranchSyncPlan, ObjectPtrHash,
+                       ObjectPtrEqual>;
+
 class ThreadSyncInserter : public StmtExprMutator {
 public:
   ThreadSyncInserter(StorageScope sync_scope,
-                     const std::unordered_set<const Object *> &syncs)
-      : sync_scope_(std::move(sync_scope)), syncs_(syncs) {}
+                     const std::unordered_set<const Object *> &syncs,
+                     const DivergentBranchSyncPlanMap &branch_sync_plans)
+      : sync_scope_(std::move(sync_scope)), syncs_(syncs),
+        branch_sync_plans_(branch_sync_plans) {}
 
   Stmt VisitStmt(const Stmt &stmt) final {
-    if (syncs_.empty())
+    if (syncs_.empty() && branch_sync_plans_.empty())
       return stmt;
+    if (const auto *if_node = stmt.as<IfThenElseNode>()) {
+      auto it = branch_sync_plans_.find(GetRef<IfThenElse>(if_node));
+      if (it != branch_sync_plans_.end()) {
+        Stmt rewritten = RewriteDivergentBranch(if_node, it->second);
+        if (syncs_.count(stmt.get())) {
+          rewritten = SeqStmt({MakeStorageSyncStmt(), rewritten});
+        }
+        return rewritten;
+      }
+    }
     if (syncs_.count(stmt.get())) {
-      Stmt barrier =
-          Evaluate(Call(DataType::Int(32), builtin::tvm_storage_sync(),
-                        {StringImm(sync_scope_.to_string())}));
-      // Mutate after query, to avoid stmt change.
       auto ret = StmtExprMutator::VisitStmt(stmt);
-      ret = SeqStmt({barrier, ret});
+      ret = SeqStmt({MakeStorageSyncStmt(), ret});
       return ret;
     } else {
       return StmtExprMutator::VisitStmt(stmt);
@@ -232,9 +251,117 @@ public:
   }
 
 private:
-  // data structure.
+  using BranchPhases = std::vector<Array<Stmt>>;
+
   StorageScope sync_scope_;
   const std::unordered_set<const Object *> &syncs_;
+  const DivergentBranchSyncPlanMap &branch_sync_plans_;
+
+  Stmt MakeStorageSyncStmt() const {
+    return Evaluate(Call(DataType::Int(32), builtin::tvm_storage_sync(),
+                         {StringImm(sync_scope_.to_string())}));
+  }
+
+  BranchPhases SplitBranch(const Stmt &body,
+                           const StmtIdentitySet &syncs) const {
+    Array<Stmt> statements;
+    if (const auto *seq = body.as<SeqStmtNode>()) {
+      statements = seq->seq;
+    } else {
+      statements.push_back(body);
+    }
+
+    BranchPhases phases(1);
+    StmtIdentitySet found_syncs;
+    for (const Stmt &statement : statements) {
+      if (syncs.count(statement)) {
+        found_syncs.insert(statement);
+        phases.emplace_back();
+      }
+      phases.back().push_back(statement);
+    }
+
+    if (found_syncs.size() != syncs.size()) {
+      LOG(FATAL)
+          << "[ThreadSync] Cannot split a divergent branch around a required "
+             "shared-memory sync because the sync is nested inside another "
+             "control-flow statement. Rewrite the kernel into explicit "
+             "write and read phases.";
+    }
+
+    std::unordered_set<const VarNode *> prior_phase_bindings;
+    for (const Array<Stmt> &phase : phases) {
+      for (const Stmt &statement : phase) {
+        if (UsesVar(statement, [&](const VarNode *var) {
+              return prior_phase_bindings.count(var) != 0;
+            })) {
+          LOG(FATAL) << "[ThreadSync] Cannot split a divergent branch because "
+                        "a scalar binding crosses the required shared-memory "
+                        "sync. Rewrite the kernel into explicit phases.";
+        }
+      }
+      for (const Stmt &statement : phase) {
+        if (const auto *bind = statement.as<BindNode>()) {
+          prior_phase_bindings.insert(bind->var.get());
+        }
+      }
+    }
+    return phases;
+  }
+
+  Stmt MutatePhase(const Array<Stmt> &phase, Span span) {
+    if (phase.empty()) {
+      return Stmt();
+    }
+    Array<Stmt> rewritten;
+    rewritten.reserve(phase.size());
+    for (const Stmt &statement : phase) {
+      rewritten.push_back(this->VisitStmt(statement));
+    }
+    return rewritten.size() == 1 ? rewritten[0]
+                                 : Stmt(SeqStmt(rewritten, span));
+  }
+
+  Stmt RewriteDivergentBranch(const IfThenElseNode *op,
+                              const DivergentBranchSyncPlan &plan) {
+    BranchPhases then_phases = SplitBranch(op->then_case, plan.then_syncs);
+    BranchPhases else_phases(1);
+    if (op->else_case.defined()) {
+      else_phases = SplitBranch(op->else_case.value(), plan.else_syncs);
+    } else {
+      ICHECK(plan.else_syncs.empty());
+    }
+
+    size_t phase_count = std::max(then_phases.size(), else_phases.size());
+    PrimExpr condition = this->VisitExpr(op->condition);
+    Var condition_snapshot("thread_sync_condition", condition.dtype(),
+                           op->span);
+    Array<Stmt> rewritten{Bind(condition_snapshot, condition, op->span)};
+
+    for (size_t i = 0; i < phase_count; ++i) {
+      Stmt then_phase = i < then_phases.size()
+                            ? MutatePhase(then_phases[i], op->span)
+                            : Stmt();
+      Stmt else_phase = i < else_phases.size()
+                            ? MutatePhase(else_phases[i], op->span)
+                            : Stmt();
+      if (then_phase.defined() && else_phase.defined()) {
+        rewritten.push_back(
+            IfThenElse(condition_snapshot, then_phase, else_phase, op->span));
+      } else if (then_phase.defined()) {
+        rewritten.push_back(
+            IfThenElse(condition_snapshot, then_phase, Stmt(), op->span));
+      } else if (else_phase.defined()) {
+        rewritten.push_back(IfThenElse(tirx::Not(condition_snapshot),
+                                       else_phase, Stmt(), op->span));
+      }
+      if (i + 1 < phase_count) {
+        rewritten.push_back(MakeStorageSyncStmt());
+      }
+    }
+    return rewritten.size() == 1 ? rewritten[0]
+                                 : Stmt(SeqStmt(rewritten, op->span));
+  }
 };
 
 namespace {
@@ -437,32 +564,20 @@ private:
 struct ConditionThreadProperty {
   bool depends_on_runtime{false};
   bool is_block_uniform{true};
-  bool requires_hoist{false};
+  bool requires_block_split{false};
 
   void Merge(const ConditionThreadProperty &other) {
     depends_on_runtime = depends_on_runtime || other.depends_on_runtime;
     is_block_uniform = is_block_uniform && other.is_block_uniform;
-    requires_hoist = requires_hoist || other.requires_hoist;
+    requires_block_split = requires_block_split || other.requires_block_split;
   }
 };
 
 /*!
- * \brief Analyze whether an if-condition is runtime-dependent and/or uniform
- * across all threads in a block.
+ * \brief 分析条件是否依赖运行时数据，以及 block 内线程是否得到相同结果。
  *
- * For sync hoisting decisions we care about two independent properties:
- *
- * 1. Does the condition depend on runtime values such as memory loads?
- * 2. Even if it does, is it still block-uniform, i.e. identical for every
- *    thread in the block?
- *
- * Example:
- * - `token_ids[tx] != -1` is runtime-dependent and non-uniform.
- * - `batch_sizes[bx] > 0` is runtime-dependent but block-uniform.
- *
- * Runtime-dependent, non-uniform conditions use the existing conservative
- * hoisting path. Thread-only conditions that otherwise remain in place need a
- * warp-uniformity proof before ThreadPartialSyncRewriter can lower them safely.
+ * 运行时且非 block-uniform 的条件需要拆分分支。仅依赖线程编号的条件若要
+ * 保留分支内 partial barrier，还必须证明参与线程按完整 warp 对齐。
  */
 class ConditionThreadPropertyChecker : public IRMutatorWithAnalyzer {
 public:
@@ -475,7 +590,7 @@ public:
         let_var_properties_(let_var_properties), warp_size_(warp_size) {}
 
   /*!
-   * \brief Analyze condition properties relevant to thread-sync hoisting.
+   * \brief 分析与分支同步变换有关的条件属性。
    */
   ConditionThreadProperty AnalyzeExpr(const PrimExpr &expr) {
     current_ = ConditionThreadProperty();
@@ -499,7 +614,7 @@ public:
           iv->var, thread_extent, /*min_consecutive=*/warp_size_);
       if (count < 0) {
         // ThreadPartialSyncRewriter cannot safely lower this condition.
-        current_.requires_hoist = true;
+        current_.requires_block_split = true;
       }
     }
     return current_;
@@ -953,21 +1068,10 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     }
   }
 
-  /**
-   * @brief Visit an IfThenElse statement and collect storage access summaries
-   * for its branches.
-   *
-   * Visits the if-then-else node's condition and both branches to summarize
-   * buffer reads, writes, and synchronization events under the condition's
-   * constraints.
-   *
-   * IMPORTANT: Before preserving a partial barrier in a thread-divergent
-   * branch, prove that every hardware warp agrees on branch participation.
-   * Conditions already handled by the legacy conservative hoisting path keep
-   * that behavior for compatibility.
-   */
+  /*! \brief 汇总 if 两侧的访存，并为不安全的分支内 barrier 制定拆分计划。 */
   void VisitStmt_(const IfThenElseNode *op) final {
     StmtEntry s;
+    bool condition_is_block_uniform = IsBlockUniformCondition(op->condition);
     // Track syncs inserted before visiting the if body
     std::unordered_set<const Object *> syncs_before_then;
     std::unordered_set<const Object *> syncs_before_else;
@@ -989,7 +1093,13 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
 
       scope_.push_back(std::vector<StmtEntry>());
       {
+        if (!condition_is_block_uniform) {
+          ++divergent_if_depth_;
+        }
         this->VisitStmt(op->then_case);
+        if (!condition_is_block_uniform) {
+          --divergent_if_depth_;
+        }
       }
 
       s.stmt = op;
@@ -1012,7 +1122,13 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       auto guard = MakeGuard(tirx::Not(op->condition));
       scope_.push_back(std::vector<StmtEntry>());
       {
+        if (!condition_is_block_uniform) {
+          ++divergent_if_depth_;
+        }
         this->VisitStmt(op->else_case.value());
+        if (!condition_is_block_uniform) {
+          --divergent_if_depth_;
+        }
       }
       auto v = Summarize(std::move(scope_.back()), nullptr);
       scope_.pop_back();
@@ -1037,69 +1153,51 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     bool has_syncs_inside = !syncs_in_then.empty() || !syncs_in_else.empty();
 
     if (has_syncs_inside) {
-      // Runtime-dependent conditions are only problematic when they can differ
-      // across threads in the same block. Block-uniform runtime conditions
-      // such as `batch_sizes[blockIdx.z] > 0` are safe to keep in-place.
-      //
-      // Separately, some threadIdx-only non-uniform conditions still need
-      // hoisting when ThreadPartialSyncRewriter cannot lower them safely.
       arith::Analyzer analyzer;
       ConstrSet constr_set = GetConstrSet();
       constr_set.Populate(analyzer);
       ConditionThreadPropertyChecker checker(&analyzer, env_threads_,
                                              let_var_properties_, warp_size_);
       IterVar tx = GetThreadVar("threadIdx.x");
-      auto must_hoist = [&](const PrimExpr &branch_condition,
-                            const char *branch_name) {
+      auto requires_split = [&](const PrimExpr &branch_condition) {
         auto condition_prop = checker.AnalyzeCondition(branch_condition, tx);
-        bool may_hoist =
-            condition_prop.depends_on_runtime || condition_prop.requires_hoist;
+        bool needs_uniformity_proof = condition_prop.depends_on_runtime ||
+                                      condition_prop.requires_block_split;
         bool proven_uniform =
-            may_hoist && IsBlockUniformCondition(branch_condition);
+            needs_uniformity_proof && IsBlockUniformCondition(branch_condition);
         bool is_block_uniform =
             condition_prop.is_block_uniform || proven_uniform;
-        bool should_hoist =
+        bool partial_barrier_unsupported =
             (condition_prop.depends_on_runtime && !is_block_uniform) ||
-            (condition_prop.requires_hoist && !proven_uniform);
-
-        if (!should_hoist && !is_block_uniform &&
-            !IsWarpUniformCondition(branch_condition)) {
-          LOG(FATAL)
-              << "[ThreadSync] Cannot lower a required shared-memory sync "
-                 "inside the "
-              << branch_name
-              << " branch: its participating threads are not warp-uniform. "
-                 "A partial barrier requires every non-exited thread in each "
-                 "participating warp to reach the barrier. Condition: "
-              << branch_condition;
-        }
-        return should_hoist;
+            (condition_prop.requires_block_split && !proven_uniform);
+        return partial_barrier_unsupported ||
+               (!is_block_uniform && !IsWarpUniformCondition(branch_condition));
       };
 
-      bool hoist_then =
-          !syncs_in_then.empty() && must_hoist(op->condition, "then");
-      bool hoist_else = !syncs_in_else.empty() &&
-                        must_hoist(tirx::Not(op->condition), "else");
-      if (hoist_then || hoist_else) {
-        LOG(WARNING)
-            << "[ThreadSync] Hoisting sync out of an if whose condition is not "
-               "safe for an in-if sync. This is not a fix: both ends of the "
-               "conflict are inside the branch, so the hoisted barrier no "
-               "longer separates them and the race remains. Constraining the "
-               "condition -- a T.assume on the parameters it reads -- keeps "
-               "the barrier in place instead. Condition: "
-            << op->condition;
-        if (hoist_then) {
-          for (const auto &sync : syncs_in_then) {
-            syncs_inserted_.erase(sync);
-          }
+      bool split_then = !syncs_in_then.empty() && requires_split(op->condition);
+      bool split_else =
+          !syncs_in_else.empty() && requires_split(tirx::Not(op->condition));
+      if (split_then || split_else) {
+        if (divergent_if_depth_ != 0) {
+          LOG(FATAL) << "[ThreadSync] Cannot split a required shared-memory "
+                        "sync nested under another thread-divergent branch. "
+                        "Rewrite the kernel into explicit write and read "
+                        "phases. Condition: "
+                     << op->condition;
         }
-        if (hoist_else) {
-          for (const auto &sync : syncs_in_else) {
-            syncs_inserted_.erase(sync);
-          }
+
+        DivergentBranchSyncPlan plan;
+        for (const Object *sync : syncs_in_then) {
+          plan.then_syncs.insert(
+              GetRef<Stmt>(static_cast<const StmtNode *>(sync)));
+          syncs_inserted_.erase(sync);
         }
-        insert_syncs(op);
+        for (const Object *sync : syncs_in_else) {
+          plan.else_syncs.insert(
+              GetRef<Stmt>(static_cast<const StmtNode *>(sync)));
+          syncs_inserted_.erase(sync);
+        }
+        branch_sync_plans_.emplace(GetRef<IfThenElse>(op), std::move(plan));
       }
     }
 
@@ -1536,6 +1634,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
   }
   // The syncs inserted before each statement
   std::unordered_set<const Object *> syncs_inserted_;
+  DivergentBranchSyncPlanMap branch_sync_plans_;
   const Array<IterVar> &env_threads() const { return env_threads_; }
 
 private:
@@ -1580,6 +1679,7 @@ private:
   StorageScope sync_scope_;
   // warp size from target
   int warp_size_;
+  int divergent_if_depth_{0};
 
   void insert_syncs(const Object *obj) {
     if (syncs_inserted_.count(obj))
@@ -2078,8 +2178,8 @@ PrimFunc TileLangThreadSync(PrimFunc func, const std::string &storage_scope) {
     planner.SetBufferDataToBuffer(buffer->data, buffer);
   }
   planner(stmt);
-  stmt =
-      ThreadSyncInserter(sync_scope, planner.syncs_inserted_)(std::move(stmt));
+  stmt = ThreadSyncInserter(sync_scope, planner.syncs_inserted_,
+                            planner.branch_sync_plans_)(std::move(stmt));
   n->body = ThreadPartialSyncRewriter::Rewrite(std::move(stmt), warp_size);
   return func;
 }

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -783,6 +783,8 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
   struct StmtEntry {
     /*! \brief The statement */
     const Object *stmt{};
+    /*! \brief The lexical constraints under which the statement executes */
+    ConstrSet cset;
     /*! \brief access patterns in the statement */
     std::vector<AccessEntry> access;
   };
@@ -987,6 +989,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     allow_append_ = true;
     ICHECK_EQ(curr_stmt_.access.size(), 0U);
     curr_stmt_.stmt = op;
+    curr_stmt_.cset = GetConstrSet();
 
     Var buf = op->buffer->data;
     buffer_data_to_buffer_.Set(GetRef<Var>(buf.get()), op->buffer);
@@ -1019,6 +1022,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     allow_append_ = true;
     ICHECK_EQ(curr_stmt_.access.size(), 0U);
     curr_stmt_.stmt = op;
+    curr_stmt_.cset = GetConstrSet();
     ConstrVisitor::VisitStmt_(op);
     // push to the scope
     if (!curr_stmt_.access.empty()) {
@@ -1032,6 +1036,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     allow_append_ = true;
     ICHECK_EQ(curr_stmt_.access.size(), 0U);
     curr_stmt_.stmt = op;
+    curr_stmt_.cset = GetConstrSet();
     RecordSharedMemoryAlias(op->var, op->value);
     this->VisitExpr(op->value);
     // push to the scope
@@ -1082,6 +1087,8 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
   }
 
   void VisitStmt_(const ForNode *op) final {
+    StmtEntry s;
+    s.cset = GetConstrSet();
     ConditionThreadProperty loop_var_property = AnalyzeExprProperty(op->min);
     if (!loop_var_property.is_block_uniform && IsBlockUniformValue(op->min)) {
       loop_var_property.is_block_uniform = true;
@@ -1102,7 +1109,6 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     if (!extent_is_block_uniform) {
       --non_uniform_control_flow_depth_;
     }
-    StmtEntry s;
     s.stmt = op;
     s.access = Summarize(std::move(scope_.back()), op);
     scope_.pop_back();
@@ -1128,10 +1134,12 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
 
     if (!extent_is_block_uniform) {
       for (const Object *sync : syncs_inserted_) {
-        if (syncs_before_loop.count(sync) == 0 && sync != op) {
+        if (syncs_before_loop.count(sync) == 0 && sync != op &&
+            !IsSafeSyncInNonUniformLoop(sync, op)) {
           LOG(FATAL) << "[ThreadSync] Cannot insert a required shared-memory "
-                        "sync inside a loop whose trip count differs across "
-                        "threads. Rewrite the kernel into uniform phases. "
+                        "sync inside a loop when its participant set or trip "
+                        "count can differ across threads. Rewrite the kernel "
+                        "into uniform phases. "
                         "Loop extent: "
                      << op->extent;
         }
@@ -1143,6 +1151,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
   /*! \brief Summarize both branches and plan splits for unsafe barriers. */
   void VisitStmt_(const IfThenElseNode *op) final {
     StmtEntry s;
+    s.cset = GetConstrSet();
     bool condition_is_block_uniform = IsBlockUniformCondition(op->condition);
     // Track syncs inserted before visiting the if body
     std::unordered_set<const Object *> syncs_before_then;
@@ -1264,11 +1273,13 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
           plan.then_syncs.insert(
               GetRef<Stmt>(static_cast<const StmtNode *>(sync)));
           syncs_inserted_.erase(sync);
+          sync_participation_.erase(sync);
         }
         for (const Object *sync : syncs_in_else) {
           plan.else_syncs.insert(
               GetRef<Stmt>(static_cast<const StmtNode *>(sync)));
           syncs_inserted_.erase(sync);
+          sync_participation_.erase(sync);
         }
         branch_sync_plans_.emplace(GetRef<IfThenElse>(op), std::move(plan));
       }
@@ -1279,6 +1290,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
 
   void VisitStmt_(const WhileNode *op) final {
     StmtEntry s;
+    s.cset = GetConstrSet();
     ConditionThreadProperty condition_property =
         AnalyzeExprProperty(op->condition);
     bool condition_is_block_uniform = condition_property.is_block_uniform ||
@@ -1653,7 +1665,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       }
 
       if (sync_before_stmt) {
-        insert_syncs(s.stmt);
+        insert_syncs(s.stmt, &s.cset);
       }
     }
     if (loop != nullptr) {
@@ -1726,7 +1738,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
           } else {
             // Fall back to inserting before the first conflicting statement
             // inside the loop to maintain correctness when reads are present.
-            insert_syncs(s.stmt);
+            insert_syncs(s.stmt, &s.cset);
           }
           break;
         }
@@ -2007,11 +2019,58 @@ private:
   // warp size from target
   int warp_size_;
   int non_uniform_control_flow_depth_{0};
+  std::unordered_map<const Object *, ConstrSet> sync_participation_;
 
-  void insert_syncs(const Object *obj) {
+  void insert_syncs(const Object *obj,
+                    const ConstrSet *participation = nullptr) {
     if (syncs_inserted_.count(obj))
       return;
     syncs_inserted_.insert(obj);
+    sync_participation_.emplace(obj, participation == nullptr ? GetConstrSet()
+                                                              : *participation);
+  }
+
+  /*! \brief Check whether a partial sync is safe in a non-uniform loop. */
+  bool IsSafeSyncInNonUniformLoop(const Object *sync,
+                                  const ForNode *loop) const {
+    auto participation_it = sync_participation_.find(sync);
+    if (participation_it == sync_participation_.end()) {
+      return false;
+    }
+    const ConstrSet &participation = participation_it->second;
+
+    for (const Constr &constr : participation.constrs_) {
+      if (constr.kind == Constr::kBindRange &&
+          constr.var.same_as(loop->loop_var)) {
+        continue;
+      }
+      if (UsesVar(constr.ToGenericConstr(), [&](const VarNode *var) {
+            return var == loop->loop_var.get();
+          })) {
+        return false;
+      }
+    }
+
+    Map<Var, PrimExpr> sub1, sub2;
+    for (const IterVar &iv : env_threads_) {
+      if (runtime::ThreadScope::Create(iv->thread_tag).rank != 1) {
+        continue;
+      }
+      sub1.Set(iv->var, Var(iv->var->name_hint + "<L1>", iv->var.dtype()));
+      sub2.Set(iv->var, Var(iv->var->name_hint + "<L2>", iv->var.dtype()));
+    }
+    if (sub1.empty()) {
+      return true;
+    }
+
+    ConstrSet c1 = participation.RenameFrom("<L1>", sub1, std::nullopt,
+                                            /*rename_ranges=*/false);
+    ConstrSet c2 = participation.RenameFrom("<L2>", sub2, std::nullopt,
+                                            /*rename_ranges=*/false);
+    arith::Analyzer analyzer;
+    c1.ToConstraints().Merge(c2.ToConstraints()).Populate(analyzer);
+    return analyzer.z3_prover.CanProve(Substitute(loop->extent, sub1) ==
+                                       Substitute(loop->extent, sub2));
   }
   bool PointerAccessIsDisjoint(const AccessEntry &lhs, const AccessEntry &rhs) {
     if (lhs.touched.size() != 1 || rhs.touched.size() != 1) {

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -1080,8 +1080,8 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     ConditionThreadProperty extent_property = AnalyzeExprProperty(op->extent);
     bool extent_is_block_uniform =
         extent_property.is_block_uniform || IsBlockUniformValue(op->extent);
-    auto [loop_var_it, inserted] =
-        let_var_properties_.emplace(op->loop_var, loop_var_property);
+    bool inserted =
+        let_var_properties_.emplace(op->loop_var, loop_var_property).second;
     ICHECK(inserted);
 
     std::unordered_set<const Object *> syncs_before_loop = syncs_inserted_;
@@ -1128,7 +1128,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
         }
       }
     }
-    let_var_properties_.erase(loop_var_it);
+    let_var_properties_.erase(op->loop_var);
   }
 
   /*! \brief Summarize both branches and plan splits for unsafe barriers. */

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -731,6 +731,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     kRead,
     kWrite,
     kSync,
+    kSyncWarp,
     kAlloc,
     // acquired version of read, only need to handle WAR dep.
     kReadAcquire
@@ -757,6 +758,8 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     AccessType type;
     /*! \brief The storage scope */
     StorageScope scope;
+    /*! \brief The mask used by an explicit warp-level synchronization. */
+    Optional<PrimExpr> warp_sync_mask;
     /*! \brief Whether the access is pointer access */
     bool is_pointer_access = false;
     /*! \brief Whether this access originates from an async copy context
@@ -771,6 +774,10 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
      * return values).
      */
     bool is_atomic = false;
+  };
+  struct LetBindingInfo {
+    PrimExpr value;
+    ConstrSet cset;
   };
   /*! \brief Access pattern about a single statement */
   struct StmtEntry {
@@ -1035,6 +1042,8 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     // Record let var properties
     auto let_prop = AnalyzeExprProperty(op->value);
     let_var_properties_[op->var] = let_prop;
+    let_bindings_.insert_or_assign(
+        op->var, LetBindingInfo{op->value, ConstrSet{constr_stack_}});
   }
   void VisitStmt_(const SBlockNode *op) final {
     auto block = Downcast<SBlock>(op);
@@ -1523,6 +1532,16 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       e.type = kSync;
       e.scope = sync_scope_;
       curr_stmt_.access.emplace_back(std::move(e));
+    } else if (op->op.same_as(tl::sync_warp())) {
+      ICHECK(allow_append_);
+      AccessEntry e{.cset = {constr_stack_}};
+      e.threads = env_threads();
+      e.type = kSyncWarp;
+      e.scope = sync_scope_;
+      if (!op->args.empty()) {
+        e.warp_sync_mask = op->args[0];
+      }
+      curr_stmt_.access.emplace_back(std::move(e));
     } else {
       ConstrVisitor::VisitExpr_(op);
     }
@@ -1550,9 +1569,38 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       }
     }
 
-    // Unsynced reads and writes
-    std::vector<AccessEntry> reads;
-    std::vector<AccessEntry> writes;
+    struct PendingAccess {
+      AccessEntry access;
+      std::vector<AccessEntry> warp_syncs_after;
+    };
+    std::vector<PendingAccess> reads;
+    std::vector<PendingAccess> writes;
+    auto has_conflict = [&](const std::vector<PendingAccess> &pending,
+                            const AccessEntry &curr, const ForNode *loop) {
+      for (const PendingAccess &item : pending) {
+        if (!FindConflict(item.access, curr, loop)) {
+          continue;
+        }
+        if (loop == nullptr && std::any_of(item.warp_syncs_after.begin(),
+                                           item.warp_syncs_after.end(),
+                                           [&](const AccessEntry &sync) {
+                                             return WarpSyncOrders(item.access,
+                                                                   curr, sync);
+                                           })) {
+          continue;
+        }
+        return true;
+      }
+      return false;
+    };
+    auto record_warp_sync = [&](const AccessEntry &sync) {
+      for (PendingAccess &item : reads) {
+        item.warp_syncs_after.push_back(sync);
+      }
+      for (PendingAccess &item : writes) {
+        item.warp_syncs_after.push_back(sync);
+      }
+    };
     // if it is a loop, rotate two times to consider effect of loop.
     // simulation based approach to find dependencies
     for (size_t i = 0; i < seq.size(); ++i) {
@@ -1569,14 +1617,14 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       for (const AccessEntry &acc : s.access) {
         if (acc.type == kRead) {
           // Same-iteration conflict: loop=nullptr
-          if (FindConflict(writes, acc, nullptr)) {
+          if (has_conflict(writes, acc, nullptr)) {
             sync_before_stmt = true;
             break;
           }
         } else if (acc.type == kWrite) {
           // Same-iteration conflict: loop=nullptr
-          if (FindConflict(reads, acc, nullptr) ||
-              FindConflict(writes, acc, nullptr)) {
+          if (has_conflict(reads, acc, nullptr) ||
+              has_conflict(writes, acc, nullptr)) {
             sync_before_stmt = true;
             break;
           }
@@ -1593,12 +1641,14 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       // Add the read/write of current statement
       for (const AccessEntry &acc : s.access) {
         if (acc.type == kRead) {
-          reads.push_back(acc);
+          reads.push_back({acc, {}});
         } else if (acc.type == kWrite) {
-          writes.push_back(acc);
+          writes.push_back({acc, {}});
         } else if (acc.type == kSync) {
           reads.clear();
           writes.clear();
+        } else if (acc.type == kSyncWarp) {
+          record_warp_sync(acc);
         }
       }
 
@@ -1649,20 +1699,22 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
         for (const AccessEntry &acc : s.access) {
           if (acc.type == kRead) {
             // Loop-carry conflict: pass loop for iteration shift analysis
-            if (FindConflict(writes, acc, loop)) {
+            if (has_conflict(writes, acc, loop)) {
               need_loop_sync = true;
               break;
             }
           } else if (acc.type == kWrite) {
             // Loop-carry conflict: pass loop for iteration shift analysis
-            if (FindConflict(reads, acc, loop) ||
-                FindConflict(writes, acc, loop)) {
+            if (has_conflict(reads, acc, loop) ||
+                has_conflict(writes, acc, loop)) {
               need_loop_sync = true;
               break;
             }
           } else if (acc.type == kSync) {
             reads.clear();
             writes.clear();
+          } else if (acc.type == kSyncWarp) {
+            record_warp_sync(acc);
           }
         }
         if (need_loop_sync) {
@@ -1733,6 +1785,193 @@ private:
     return checker.AnalyzeExpr(expr);
   }
 
+  PrimExpr StripCasts(PrimExpr expr) const {
+    while (const auto *cast = expr.as<CastNode>()) {
+      expr = cast->value;
+    }
+    return expr;
+  }
+
+  const LetBindingInfo *FindLetBinding(const PrimExpr &expr) const {
+    const auto *var = StripCasts(expr).as<VarNode>();
+    if (var == nullptr) {
+      return nullptr;
+    }
+    auto it = let_bindings_.find(GetRef<Var>(var));
+    return it == let_bindings_.end() ? nullptr : &it->second;
+  }
+
+  PrimExpr ResolveLetValue(PrimExpr expr) const {
+    VarIdentitySet visited;
+    while (true) {
+      expr = StripCasts(expr);
+      const auto *var = expr.as<VarNode>();
+      if (var == nullptr) {
+        return expr;
+      }
+      Var var_ref = GetRef<Var>(var);
+      if (!visited.insert(var_ref).second) {
+        return expr;
+      }
+      auto it = let_bindings_.find(var_ref);
+      if (it == let_bindings_.end()) {
+        return expr;
+      }
+      expr = it->second.value;
+    }
+  }
+
+  PrimExpr ParticipationCondition(const ConstrSet &cset) const {
+    PrimExpr condition = Bool(true);
+    for (const Constr &constr : cset.constrs_) {
+      if (constr.kind != Constr::kBindValue) {
+        condition = tirx::And(condition, constr.ToGenericConstr());
+      }
+    }
+    return condition;
+  }
+
+  bool HaveEquivalentParticipation(const PrimExpr &lhs, const PrimExpr &rhs,
+                                   const Array<IterVar> &lhs_threads,
+                                   const Array<IterVar> &rhs_threads) const {
+    if (ExprDeepEqual()(lhs, rhs)) {
+      return true;
+    }
+
+    arith::Analyzer analyzer;
+    VarIdentitySet bound;
+    for (const Array<IterVar> *threads : {&lhs_threads, &rhs_threads}) {
+      for (const IterVar &iv : *threads) {
+        if (iv->dom.defined() && bound.insert(iv->var).second) {
+          analyzer.Bind(iv->var, iv->dom);
+        }
+      }
+    }
+    PrimExpr equivalent = tirx::Or(tirx::And(lhs, rhs),
+                                   tirx::And(tirx::Not(lhs), tirx::Not(rhs)));
+    return analyzer.z3_prover.CanProve(equivalent);
+  }
+
+  bool HaveEquivalentParticipation(const AccessEntry &lhs,
+                                   const AccessEntry &rhs) const {
+    return HaveEquivalentParticipation(ParticipationCondition(lhs.cset),
+                                       ParticipationCondition(rhs.cset),
+                                       lhs.threads, rhs.threads);
+  }
+
+  bool IsExactBallotWarpSync(const AccessEntry &sync) const {
+    if (!sync.warp_sync_mask.defined()) {
+      return false;
+    }
+
+    const LetBindingInfo *participant_binding =
+        FindLetBinding(sync.warp_sync_mask.value());
+    if (participant_binding == nullptr) {
+      return false;
+    }
+    const auto *ballot =
+        ResolveLetValue(participant_binding->value).as<CallNode>();
+    if (ballot == nullptr || !ballot->op.same_as(tl::ballot_sync()) ||
+        ballot->args.size() != 2U) {
+      return false;
+    }
+
+    const LetBindingInfo *active_binding = FindLetBinding(ballot->args[0]);
+    if (active_binding == nullptr) {
+      return false;
+    }
+    const auto *active_mask =
+        ResolveLetValue(active_binding->value).as<CallNode>();
+    if (active_mask == nullptr || !active_mask->op.same_as(tl::activemask()) ||
+        !active_mask->args.empty()) {
+      return false;
+    }
+
+    PrimExpr active_participation =
+        ParticipationCondition(active_binding->cset);
+    PrimExpr ballot_participation =
+        ParticipationCondition(participant_binding->cset);
+    if (!HaveEquivalentParticipation(active_participation, ballot_participation,
+                                     sync.threads, sync.threads)) {
+      return false;
+    }
+
+    PrimExpr expected_participation =
+        tirx::And(ballot_participation, ResolveLetValue(ballot->args[1]));
+    return HaveEquivalentParticipation(ParticipationCondition(sync.cset),
+                                       expected_participation, sync.threads,
+                                       sync.threads);
+  }
+
+  bool ConflictsOnlyWithinWarp(const AccessEntry &prev,
+                               const AccessEntry &curr) const {
+    if (prev.is_pointer_access || curr.is_pointer_access ||
+        prev.buffer_indices.size() != 1U || curr.buffer_indices.size() != 1U) {
+      return false;
+    }
+
+    Map<Var, PrimExpr> prev_sub, curr_sub;
+    for (const IterVar &prev_iv : prev.threads) {
+      if (runtime::ThreadScope::Create(prev_iv->thread_tag).rank != 1) {
+        continue;
+      }
+      IterVar curr_iv;
+      for (const IterVar &candidate : curr.threads) {
+        if (candidate->thread_tag == prev_iv->thread_tag) {
+          curr_iv = candidate;
+          break;
+        }
+      }
+      if (!curr_iv.defined()) {
+        return false;
+      }
+      const std::string suffix = prev_iv->thread_tag;
+      prev_sub.Set(prev_iv->var, Var(suffix + "<W1>", prev_iv->var.dtype()));
+      curr_sub.Set(curr_iv->var, Var(suffix + "<W2>", curr_iv->var.dtype()));
+    }
+    if (prev_sub.empty() || curr_sub.empty()) {
+      return false;
+    }
+
+    ConstrSet prev_cset = prev.cset.RenameFrom("<W1>", prev_sub, std::nullopt,
+                                               /*rename_ranges=*/false);
+    ConstrSet curr_cset = curr.cset.RenameFrom("<W2>", curr_sub, std::nullopt,
+                                               /*rename_ranges=*/false);
+    arith::Analyzer analyzer;
+    prev_cset.ToConstraints()
+        .Merge(curr_cset.ToConstraints())
+        .Populate(analyzer);
+
+    DataType index_dtype = DataType::Int(64);
+    PrimExpr prev_index = Substitute(prev.buffer_indices[0], prev_sub);
+    PrimExpr curr_index = Substitute(curr.buffer_indices[0], curr_sub);
+    if (!prev_index.dtype().is_scalar() || !curr_index.dtype().is_scalar()) {
+      return false;
+    }
+    PrimExpr prev_address = Cast(index_dtype, prev_index) *
+                            make_const(index_dtype, prev.dtype.bytes());
+    PrimExpr curr_address = Cast(index_dtype, curr_index) *
+                            make_const(index_dtype, curr.dtype.bytes());
+
+    PrimExpr prev_linear =
+        Substitute(MakeLinearThreadId(prev.threads), prev_sub);
+    PrimExpr curr_linear =
+        Substitute(MakeLinearThreadId(curr.threads), curr_sub);
+    PrimExpr warp_size = make_const(index_dtype, warp_size_);
+    PrimExpr same_warp =
+        FloorDiv(prev_linear, warp_size) == FloorDiv(curr_linear, warp_size);
+    return analyzer.CanProve(
+        tirx::Or(same_warp, tirx::NE(prev_address, curr_address)));
+  }
+
+  bool WarpSyncOrders(const AccessEntry &prev, const AccessEntry &curr,
+                      const AccessEntry &sync) const {
+    return IsExactBallotWarpSync(sync) &&
+           HaveEquivalentParticipation(prev, sync) &&
+           HaveEquivalentParticipation(curr, sync) &&
+           ConflictsOnlyWithinWarp(prev, curr);
+  }
+
   bool Enabled(const VarNode *buf, const StorageScope &scope) {
     return in_device_env() && scope == sync_scope_;
   }
@@ -1758,6 +1997,9 @@ private:
   // Thread-uniform/runtime properties for let-bound vars visible in the
   // current lexical scope.
   VarPropertyMap let_var_properties_;
+  // Flat Bind definitions and their participation context.
+  std::unordered_map<Var, LetBindingInfo, ObjectPtrHash, ObjectPtrEqual>
+      let_bindings_;
   // The buffer map
   Map<Var, Buffer> buffer_data_to_buffer_;
   // synchronization scope
@@ -1855,6 +2097,9 @@ private:
       break;
     case kSync:
       type_str = "Sync";
+      break;
+    case kSyncWarp:
+      type_str = "SyncWarp";
       break;
     case kAlloc:
       type_str = "Alloc";
@@ -2189,6 +2434,35 @@ private:
         ICHECK(prev_indice_bytes.dtype() == curr_indice_bytes.dtype());
         provably_disjoint =
             analyzer.CanProve(tirx::NE(prev_indice_bytes, curr_indice_bytes));
+        // Enumerate short static unrolls when div/mod expressions are beyond
+        // the symbolic prover but each adjacent iteration is still disjoint.
+        if (!provably_disjoint && loop != nullptr &&
+            loop->kind == ForKind::kUnrolled) {
+          const auto *loop_min = loop->min.as<IntImmNode>();
+          const auto *loop_extent = loop->extent.as<IntImmNode>();
+          constexpr int64_t kMaxEnumeratedUnrollExtent = 64;
+          if (loop_min != nullptr && loop_extent != nullptr &&
+              loop_extent->value > 1 &&
+              loop_extent->value <= kMaxEnumeratedUnrollExtent) {
+            provably_disjoint = true;
+            for (int64_t offset = 0; offset < loop_extent->value - 1;
+                 ++offset) {
+              Map<Var, PrimExpr> iteration_sub;
+              iteration_sub.Set(
+                  loop->loop_var,
+                  make_const(loop->loop_var.dtype(), loop_min->value + offset));
+              PrimExpr prev_at_iteration =
+                  Substitute(prev_indice_bytes, iteration_sub);
+              PrimExpr curr_at_iteration =
+                  Substitute(curr_indice_bytes, iteration_sub);
+              if (!analyzer.CanProve(
+                      tirx::NE(prev_at_iteration, curr_at_iteration))) {
+                provably_disjoint = false;
+                break;
+              }
+            }
+          }
+        }
       } else {
         try {
           auto prev_min = analyzer.Simplify(
@@ -2227,16 +2501,6 @@ private:
     }
 
     return range_is_overlap;
-  }
-
-  bool FindConflict(const std::vector<AccessEntry> &prev,
-                    const AccessEntry &curr, const ForNode *loop) {
-    for (const AccessEntry &x : prev) {
-      if (FindConflict(x, curr, loop)) {
-        return true;
-      }
-    }
-    return false;
   }
 };
 

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -1029,9 +1029,78 @@ def test_nested_divergent_branch_split_is_rejected():
                 l[0] = s[(tx + 4) % 64]
 
     with pytest.raises(
-        Exception, match="nested under another thread-divergent branch"
+        Exception, match="nested under another thread-divergent control-flow"
     ):
         run_passes_script(func)
+
+
+def test_divergent_split_inside_non_uniform_loop_is_rejected():
+    """循环次数在线程间不一致时，不能在循环体中插入 full-block barrier。"""
+    import pytest
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 64)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        for i in T.serial(0, tx % 2 + 1):
+            if tx % 4 == 0:
+                s[tx] = T.cast(tx, "float32")
+                l[0] = s[(tx + 4) % 64]
+
+    with pytest.raises(
+        Exception, match="nested under another thread-divergent control-flow"
+    ):
+        run_passes_script(func)
+
+
+def test_sync_inside_non_uniform_loop_is_rejected():
+    """即使没有内层 if，线程间循环次数不同也不能执行 barrier。"""
+    import pytest
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 64)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        for i in T.serial(0, tx % 2 + 1):
+            s[tx] = T.cast(tx, "float32")
+            l[0] = s[63 - tx]
+
+    with pytest.raises(Exception, match="loop whose trip count differs"):
+        run_passes_script(func)
+
+
+def test_divergent_split_inside_uniform_loop_is_allowed():
+    """循环次数相同时，每轮拆分后的 barrier 都由整个 block 执行。"""
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 64)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        for i in T.serial(0, 2):
+            if tx % 4 == 0:
+                s[tx] = T.cast(tx + i, "float32")
+                l[0] = s[(tx + 4) % 64]
+
+    s = run_passes_script(func)
+    sync = 'T.tvm_storage_sync("shared")'
+    assert s.count("if thread_sync_condition") == 2, f"Expected a split branch:\n{s}"
+    loop_pos = s.index("for i in range(2)")
+    first_if = s.index("if thread_sync_condition", loop_pos)
+    second_if = s.index("if thread_sync_condition", first_if + 1)
+    sync_pos = s.index(sync, first_if)
+    assert first_if < sync_pos < second_if, f"Barrier must separate the loop phases:\n{s}"
 
 
 def test_aligned_else_partial_sync_is_preserved():

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -517,7 +517,7 @@ def test_loop_carry_different_indices():
 
 
 # =============================================================================
-# Tests for non-uniform if condition sync hoisting
+# 非 uniform if 条件下的同步测试
 # =============================================================================
 
 
@@ -772,11 +772,8 @@ def test_no_sync_for_thread_private_write_read_by_if_condition_in_loop():
     assert 'T.tvm_storage_sync("shared")' not in s, f"Unexpected sync:\n{s}"
 
 
-@tilelang.testing.requires_cuda
-def test_partial_sync_non_warp_multiple_rejected():
-    """Regression test for issue #2556: a required barrier inside a divergent
-    region that splits a warp must be a compile-time error, not silently
-    dropped or lowered to an invalid partial barrier."""
+def test_nested_non_warp_uniform_sync_is_rejected():
+    """分支内循环尚不能安全拆分，必须拒绝而不是生成错误 barrier。"""
     import pytest
 
     @T.prim_func(private=True)
@@ -796,7 +793,9 @@ def test_partial_sync_non_warp_multiple_rejected():
                 acc[0] += S[47 - tx]
 
     mod = tvm.IRModule({"main": func})
-    with pytest.raises(Exception, match="not warp-uniform"):
+    with pytest.raises(
+        Exception, match="nested inside another control-flow statement"
+    ):
         tilelang.transform.ThreadSync("shared")(mod)
 
 
@@ -894,14 +893,7 @@ def test_no_sync_for_thread_private_pair_read_modify_write():
 
 
 def test_no_plain_sync_inside_divergent_symbolic_guard():
-    """A barrier must never be emitted inside a thread-divergent guard.
-
-    ``bx * 4 + tx // 32 < n`` mixes a thread variable with a runtime parameter,
-    so for a tail block only some warps enter. A block-wide barrier inside the
-    branch is then waited on by a subset of the block, which hangs. Whether or
-    not the pass considers the guarded update a hazard, any barrier it emits has
-    to sit outside the guard.
-    """
+    """若保守分析插入 barrier，它必须位于拆开的两个 guard 之间。"""
 
     @T.prim_func(private=True)
     def func(n: T.int32):
@@ -917,21 +909,13 @@ def test_no_plain_sync_inside_divergent_symbolic_guard():
     s = run_passes_script(func)
     if 'T.tvm_storage_sync("shared")' in s:
         sync_pos = s.index('T.tvm_storage_sync("shared")')
-        if_pos = s.index("if ")
-        assert sync_pos < if_pos, f"Barrier must be hoisted out of the divergent guard:\n{s}"
+        first_if = s.index("if thread_sync_condition")
+        second_if = s.index("if thread_sync_condition", first_if + 1)
+        assert first_if < sync_pos < second_if, f"Barrier must separate the guarded phases:\n{s}"
 
 
-def test_unorderable_hazard_in_divergent_guard_is_reported(capfd):
-    """A hazard confined to a divergent branch has no correct barrier placement.
-
-    ``bx * 4 + tx // 32 < n`` mixes a thread variable with a runtime parameter, so
-    for a tail block only some warps enter, and both ends of the hazard are inside
-    that branch. A barrier inside it hangs on the threads that skip the branch,
-    while one in front of it is reached by everyone but no longer separates the
-    accesses. Ordering this needs the branch split around the barrier, which the
-    pass cannot express, so reporting the program is the only thing it can get
-    right. Where the barrier ends up is deliberately not asserted.
-    """
+def test_hazard_in_divergent_guard_is_split():
+    """动态分支被拆成写、整块同步、读三个阶段。"""
 
     @T.prim_func(private=True)
     def func(n: T.int32):
@@ -945,18 +929,17 @@ def test_unorderable_hazard_in_divergent_guard_is_reported(capfd):
             s[tx] = T.cast(tx, "float32")
             l[0] = s[(tx + 64) % 128]
 
-    run_passes_script(func)
-    warnings = capfd.readouterr().err
-    assert "no longer separates" in warnings, f"Expected the pass to report the hazard:\n{warnings}"
+    s = run_passes_script(func)
+    sync = 'T.tvm_storage_sync("shared")'
+    assert s.count(sync) == 1, f"Expected one full-block barrier:\n{s}"
+    assert s.count("if thread_sync_condition") == 2, f"Expected a split branch:\n{s}"
+    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), (
+        f"Barrier does not order the hazard:\n{s}"
+    )
 
 
-def test_unorderable_hazard_in_divergent_else_branch_is_reported(capfd):
-    """The else branch needs the same treatment as the then branch.
-
-    Syncs found in either arm are tracked separately, so a hazard placed only in
-    the else arm exercises the second of the two paths. It is as unorderable as
-    the one above, so again only the report is asserted.
-    """
+def test_hazard_in_divergent_else_branch_is_split():
+    """else 中的 hazard 也要拆到整块同步的两侧。"""
 
     @T.prim_func(private=True)
     def func(n: T.int32):
@@ -972,9 +955,83 @@ def test_unorderable_hazard_in_divergent_else_branch_is_reported(capfd):
             s[tx] = T.cast(tx, "float32")
             l[0] = s[(tx + 64) % 128]
 
-    run_passes_script(func)
-    warnings = capfd.readouterr().err
-    assert "no longer separates" in warnings, f"Expected the pass to report the hazard:\n{warnings}"
+    s = run_passes_script(func)
+    sync = 'T.tvm_storage_sync("shared")'
+    assert s.count(sync) == 1, f"Expected one full-block barrier:\n{s}"
+    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), (
+        f"Barrier does not order the else hazard:\n{s}"
+    )
+
+
+def test_non_warp_uniform_if_else_is_split():
+    """tx % 4 会拆散每个 warp，必须改写为所有线程都执行的 barrier。"""
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 64)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        if tx % 4 == 0:
+            s[tx] = T.cast(tx, "float32")
+            l[0] = s[(tx + 4) % 64]
+        else:
+            l[0] = T.float32(-1)
+
+    s = run_passes_script(func)
+    sync = 'T.tvm_storage_sync("shared")'
+    assert s.count(sync) == 1, f"Expected one full-block barrier:\n{s}"
+    assert s.count("if thread_sync_condition") == 2, f"Expected a split branch:\n{s}"
+    assert s.count("tx % 4 == 0") == 1, f"The condition must be evaluated once:\n{s}"
+    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), (
+        f"Barrier does not order the hazard:\n{s}"
+    )
+
+
+def test_divergent_split_rejects_binding_crossing_barrier():
+    """拆分不能让分支内定义的标量越过原有作用域。"""
+    import pytest
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 64)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        if tx % 4 == 0:
+            read_index: T.int32 = (tx + 4) % 64
+            s[tx] = T.cast(tx, "float32")
+            l[0] = s[read_index]
+
+    with pytest.raises(Exception, match="scalar binding crosses"):
+        run_passes_script(func)
+
+
+def test_nested_divergent_branch_split_is_rejected():
+    """外层分支已让部分线程退出时，内层不能直接插入 full-block barrier。"""
+    import pytest
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 64)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        if tx < 48:
+            if tx % 4 == 0:
+                s[tx] = T.cast(tx, "float32")
+                l[0] = s[(tx + 4) % 64]
+
+    with pytest.raises(
+        Exception, match="nested under another thread-divergent branch"
+    ):
+        run_passes_script(func)
 
 
 def test_aligned_else_partial_sync_is_preserved():
@@ -1000,9 +1057,8 @@ def test_aligned_else_partial_sync_is_preserved():
     assert s.index('T.tvm_storage_sync("shared"') > s.index("else:"), f"Barrier must stay in else branch:\n{s}"
 
 
-def test_misaligned_else_partial_sync_is_rejected():
-    """Consecutive threads spanning two partial warps cannot use bar.sync."""
-    import pytest
+def test_misaligned_else_partial_sync_is_split():
+    """跨越两个 warp 的 tx=1..32 不能用 partial bar.sync，要拆分分支。"""
 
     @T.prim_func(private=True)
     def func():
@@ -1018,8 +1074,12 @@ def test_misaligned_else_partial_sync_is_rejected():
             s[tx] = T.cast(tx, "float32")
             l[0] = s[33 - tx]
 
-    with pytest.raises(Exception, match="not warp-uniform"):
-        run_passes_script(func)
+    s = run_passes_script(func)
+    sync = 'T.tvm_storage_sync("shared")'
+    assert s.count(sync) == 1, f"Expected one full-block barrier:\n{s}"
+    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), (
+        f"Barrier does not order the else hazard:\n{s}"
+    )
 
 
 def test_sync_stays_inside_guard_proven_uniform_by_premise(capfd):
@@ -1054,14 +1114,8 @@ def test_sync_stays_inside_guard_proven_uniform_by_premise(capfd):
     assert "no longer separates" not in warnings, f"A provably uniform guard should not be reported:\n{warnings}"
 
 
-def test_premise_weaker_than_the_block_is_not_taken_as_uniform(capfd):
-    """The premise has to rule divergence out for the block size actually used.
-
-    ``n % 64 == 0`` with a block of 128 threads still admits ``n == 64``, where
-    half the block enters. This pins down the boundary of the check above: it must
-    accept a premise only when the premise really excludes divergence. The guard
-    is therefore treated as divergent, which for this shape means reported.
-    """
+def test_premise_weaker_than_the_block_is_split():
+    """n % 64 == 0 仍允许半个 block 进入，因此需要拆分分支。"""
 
     @T.prim_func(private=True)
     def func(n: T.int32):
@@ -1076,9 +1130,12 @@ def test_premise_weaker_than_the_block_is_not_taken_as_uniform(capfd):
                 s[tx] = T.cast(tx, "float32")
                 l[0] = s[(tx + 64) % 128]
 
-    run_passes_script(func)
-    warnings = capfd.readouterr().err
-    assert "no longer separates" in warnings, f"A premise that still allows divergence must not be accepted:\n{warnings}"
+    s = run_passes_script(func)
+    sync = 'T.tvm_storage_sync("shared")'
+    assert s.count(sync) == 1, f"Expected one full-block barrier:\n{s}"
+    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), (
+        f"Barrier does not order the hazard:\n{s}"
+    )
 
 
 def test_premise_holds_across_an_enclosing_guard():

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -793,9 +793,7 @@ def test_nested_non_warp_uniform_sync_is_rejected():
                 acc[0] += S[47 - tx]
 
     mod = tvm.IRModule({"main": func})
-    with pytest.raises(
-        Exception, match="nested inside another control-flow statement"
-    ):
+    with pytest.raises(Exception, match="nested inside another control-flow statement"):
         tilelang.transform.ThreadSync("shared")(mod)
 
 
@@ -933,9 +931,7 @@ def test_hazard_in_divergent_guard_is_split():
     sync = 'T.tvm_storage_sync("shared")'
     assert s.count(sync) == 1, f"Expected one full-block barrier:\n{s}"
     assert s.count("if thread_sync_condition") == 2, f"Expected a split branch:\n{s}"
-    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), (
-        f"Barrier does not order the hazard:\n{s}"
-    )
+    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), f"Barrier does not order the hazard:\n{s}"
 
 
 def test_hazard_in_divergent_else_branch_is_split():
@@ -958,9 +954,7 @@ def test_hazard_in_divergent_else_branch_is_split():
     s = run_passes_script(func)
     sync = 'T.tvm_storage_sync("shared")'
     assert s.count(sync) == 1, f"Expected one full-block barrier:\n{s}"
-    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), (
-        f"Barrier does not order the else hazard:\n{s}"
-    )
+    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), f"Barrier does not order the else hazard:\n{s}"
 
 
 def test_non_warp_uniform_if_else_is_split():
@@ -985,9 +979,7 @@ def test_non_warp_uniform_if_else_is_split():
     assert s.count(sync) == 1, f"Expected one full-block barrier:\n{s}"
     assert s.count("if thread_sync_condition") == 2, f"Expected a split branch:\n{s}"
     assert s.count("tx % 4 == 0") == 1, f"The condition must be evaluated once:\n{s}"
-    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), (
-        f"Barrier does not order the hazard:\n{s}"
-    )
+    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), f"Barrier does not order the hazard:\n{s}"
 
 
 def test_divergent_split_rejects_binding_crossing_barrier():
@@ -1028,9 +1020,7 @@ def test_nested_divergent_branch_split_is_rejected():
                 s[tx] = T.cast(tx, "float32")
                 l[0] = s[(tx + 4) % 64]
 
-    with pytest.raises(
-        Exception, match="nested under another thread-divergent control-flow"
-    ):
+    with pytest.raises(Exception, match="nested under another thread-divergent control-flow"):
         run_passes_script(func)
 
 
@@ -1051,9 +1041,7 @@ def test_divergent_split_inside_non_uniform_loop_is_rejected():
                 s[tx] = T.cast(tx, "float32")
                 l[0] = s[(tx + 4) % 64]
 
-    with pytest.raises(
-        Exception, match="nested under another thread-divergent control-flow"
-    ):
+    with pytest.raises(Exception, match="nested under another thread-divergent control-flow"):
         run_passes_script(func)
 
 
@@ -1146,9 +1134,7 @@ def test_misaligned_else_partial_sync_is_split():
     s = run_passes_script(func)
     sync = 'T.tvm_storage_sync("shared")'
     assert s.count(sync) == 1, f"Expected one full-block barrier:\n{s}"
-    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), (
-        f"Barrier does not order the else hazard:\n{s}"
-    )
+    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), f"Barrier does not order the else hazard:\n{s}"
 
 
 def test_sync_stays_inside_guard_proven_uniform_by_premise(capfd):
@@ -1202,9 +1188,7 @@ def test_premise_weaker_than_the_block_is_split():
     s = run_passes_script(func)
     sync = 'T.tvm_storage_sync("shared")'
     assert s.count(sync) == 1, f"Expected one full-block barrier:\n{s}"
-    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), (
-        f"Barrier does not order the hazard:\n{s}"
-    )
+    assert s.index("s_1[tx] =") < s.index(sync) < s.index("l_1[0] = s_1["), f"Barrier does not order the hazard:\n{s}"
 
 
 def test_premise_holds_across_an_enclosing_guard():

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -517,7 +517,7 @@ def test_loop_carry_different_indices():
 
 
 # =============================================================================
-# 非 uniform if 条件下的同步测试
+# Synchronization tests for non-uniform if conditions.
 # =============================================================================
 
 
@@ -773,7 +773,7 @@ def test_no_sync_for_thread_private_write_read_by_if_condition_in_loop():
 
 
 def test_nested_non_warp_uniform_sync_is_rejected():
-    """分支内循环尚不能安全拆分，必须拒绝而不是生成错误 barrier。"""
+    """Reject nested loops that cannot be split without an invalid barrier."""
     import pytest
 
     @T.prim_func(private=True)
@@ -893,7 +893,7 @@ def test_no_sync_for_thread_private_pair_read_modify_write():
 
 
 def test_no_plain_sync_inside_divergent_symbolic_guard():
-    """若保守分析插入 barrier，它必须位于拆开的两个 guard 之间。"""
+    """Keep a conservatively inserted barrier between the split guards."""
 
     @T.prim_func(private=True)
     def func(n: T.int32):
@@ -915,7 +915,7 @@ def test_no_plain_sync_inside_divergent_symbolic_guard():
 
 
 def test_hazard_in_divergent_guard_is_split():
-    """动态分支被拆成写、整块同步、读三个阶段。"""
+    """Split a dynamic branch into write, full-block sync, and read phases."""
 
     @T.prim_func(private=True)
     def func(n: T.int32):
@@ -939,7 +939,7 @@ def test_hazard_in_divergent_guard_is_split():
 
 
 def test_hazard_in_divergent_else_branch_is_split():
-    """else 中的 hazard 也要拆到整块同步的两侧。"""
+    """Split an else-branch hazard around a full-block barrier."""
 
     @T.prim_func(private=True)
     def func(n: T.int32):
@@ -964,7 +964,7 @@ def test_hazard_in_divergent_else_branch_is_split():
 
 
 def test_non_warp_uniform_if_else_is_split():
-    """tx % 4 会拆散每个 warp，必须改写为所有线程都执行的 barrier。"""
+    """Rewrite tx % 4 around a barrier reached by every thread."""
 
     @T.prim_func(private=True)
     def func():
@@ -991,7 +991,7 @@ def test_non_warp_uniform_if_else_is_split():
 
 
 def test_divergent_split_rejects_binding_crossing_barrier():
-    """拆分不能让分支内定义的标量越过原有作用域。"""
+    """Reject a split when a branch-local binding would cross the barrier."""
     import pytest
 
     @T.prim_func(private=True)
@@ -1012,7 +1012,7 @@ def test_divergent_split_rejects_binding_crossing_barrier():
 
 
 def test_nested_divergent_branch_split_is_rejected():
-    """外层分支已让部分线程退出时，内层不能直接插入 full-block barrier。"""
+    """Reject a full-block barrier nested under an outer divergent branch."""
     import pytest
 
     @T.prim_func(private=True)
@@ -1035,7 +1035,7 @@ def test_nested_divergent_branch_split_is_rejected():
 
 
 def test_divergent_split_inside_non_uniform_loop_is_rejected():
-    """循环次数在线程间不一致时，不能在循环体中插入 full-block barrier。"""
+    """Reject a full-block barrier in a loop with non-uniform trip counts."""
     import pytest
 
     @T.prim_func(private=True)
@@ -1058,7 +1058,7 @@ def test_divergent_split_inside_non_uniform_loop_is_rejected():
 
 
 def test_sync_inside_non_uniform_loop_is_rejected():
-    """即使没有内层 if，线程间循环次数不同也不能执行 barrier。"""
+    """Reject barriers in non-uniform loops without an inner conditional."""
     import pytest
 
     @T.prim_func(private=True)
@@ -1078,7 +1078,7 @@ def test_sync_inside_non_uniform_loop_is_rejected():
 
 
 def test_divergent_split_inside_uniform_loop_is_allowed():
-    """循环次数相同时，每轮拆分后的 barrier 都由整个 block 执行。"""
+    """Allow split barriers when every block thread has the same trip count."""
 
     @T.prim_func(private=True)
     def func():
@@ -1127,7 +1127,7 @@ def test_aligned_else_partial_sync_is_preserved():
 
 
 def test_misaligned_else_partial_sync_is_split():
-    """跨越两个 warp 的 tx=1..32 不能用 partial bar.sync，要拆分分支。"""
+    """Split tx=1..32 across two warps instead of using partial bar.sync."""
 
     @T.prim_func(private=True)
     def func():
@@ -1184,7 +1184,7 @@ def test_sync_stays_inside_guard_proven_uniform_by_premise(capfd):
 
 
 def test_premise_weaker_than_the_block_is_split():
-    """n % 64 == 0 仍允许半个 block 进入，因此需要拆分分支。"""
+    """Split the branch when n % 64 == 0 still allows half-block entry."""
 
     @T.prim_func(private=True)
     def func(n: T.int32):

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -1218,8 +1218,34 @@ def test_sync_inside_non_uniform_loop_is_rejected():
             s[tx] = T.cast(tx, "float32")
             l[0] = s[63 - tx]
 
-    with pytest.raises(Exception, match="loop whose trip count differs"):
+    with pytest.raises(Exception, match="participant set or trip count can differ"):
         run_passes_script(func)
+
+
+def test_partial_sync_inside_non_uniform_loop_is_allowed():
+    """Allow a fixed warp whose participating threads have equal trip counts."""
+    import re
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 64)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        for i in T.serial(0, tx // 32 + 1):
+            if tx >= 32:
+                s[i * 64 + tx] = T.cast(tx + i, "float32")
+                l[0] = s[i * 64 + 95 - tx]
+
+    s = run_passes_script(func)
+    sync_match = re.search(r'tvm_storage_sync\("shared",\s*\d+,\s*32\)', s)
+    assert sync_match, f"Expected a 32-thread barrier:\n{s}"
+    assert s.count('T.tvm_storage_sync("shared"') == 1, f"Expected exactly one partial barrier:\n{s}"
+    loop_pos = s.index("for i in range(tx // 32 + 1)")
+    if_pos = s.index("if tx >= 32", loop_pos)
+    assert sync_match.start() > if_pos, f"Barrier must remain inside the guarded loop body:\n{s}"
 
 
 def test_divergent_split_inside_uniform_loop_is_allowed():

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -377,6 +377,52 @@ def test_sync_shared_dyn_stmatrix_loop_hoist():
     assert s.index('T.tvm_storage_sync("shared.dyn")') < s.index("for i in T.unroll(8)")
 
 
+def test_unrolled_inplace_vector_update_has_no_loop_carry_sync():
+    """Disjoint in-place updates in a short unroll need no loop barrier."""
+
+    @T.prim_func(private=True)
+    def func():
+        S_shared = T.alloc_buffer((4096,), scope="shared.dyn")
+        scores_max = T.alloc_buffer((2,), scope="local")
+        logsum = T.alloc_buffer((2,), scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        if tx % 4 == 0:
+            for i in T.unroll(32):
+                S_shared[
+                    T.Ramp(
+                        tx // 32 * 1024 + i // 16 * 512 + tx % 32 // 4 * 64 + i % 16 * 4 - 4096,
+                        1,
+                        4,
+                    )
+                ] = T.exp2(
+                    S_shared[
+                        T.Ramp(
+                            tx // 32 * 1024 + i // 16 * 512 + tx % 32 // 4 * 64 + i % 16 * 4 - 4096,
+                            1,
+                            4,
+                        )
+                    ]
+                    - T.Broadcast(scores_max[i // 16], 4)
+                ) / T.Broadcast(logsum[i // 16], 4)
+
+    target = tvm.target.Target(
+        {
+            "kind": "cuda",
+            "arch": "sm_90",
+            "thread_warp_size": 32,
+            "max_num_threads": 1024,
+        },
+        host="llvm",
+    )
+    mod = tvm.IRModule({"main": func.with_attr({"global_symbol": "test", "target": target})})
+    mod = tilelang.transform.ThreadSync("shared.dyn")(mod)
+    s = str(mod.script())
+    assert 'T.tvm_storage_sync("shared.dyn")' not in s, f"Unexpected loop-carried sync:\n{s}"
+
+
 @tilelang.testing.requires_cuda
 def test_loop_carry_no_dependency_same_index():
     """Test that A[i] write followed by A[i] read in a loop does NOT need barrier.
@@ -822,6 +868,117 @@ def test_partial_sync_warp_multiple_still_lowered():
     mod = tilelang.transform.ThreadSync("shared")(mod)
     s = str(mod.script())
     assert re.search(r'tvm_storage_sync\("shared",\s*\d+,\s*32\)', s), f"Expected a partial barrier with thread_count=32:\n{s}"
+
+
+def test_masked_warp_sync_orders_only_intra_warp_hazards():
+    """A ballot-derived mask orders hazards within each hardware warp."""
+
+    @T.prim_func(private=True)
+    def func():
+        S = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        acc = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 64)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        active_mask = T.bind(
+            T.cast(
+                T.call_intrin("uint64", tvm.tirx.op.Op.get("tl.activemask")),
+                "uint32",
+            )
+        )
+        participant_mask = T.bind(
+            T.cast(
+                T.call_intrin(
+                    "uint64",
+                    tvm.tirx.op.Op.get("tl.ballot_sync"),
+                    active_mask,
+                    tx % 4 == 0,
+                ),
+                "uint32",
+            )
+        )
+        if tx % 4 == 0:
+            acc[0] = S[tx // 32 * 32 + (tx + 4) % 32]
+            T.evaluate(T.call_intrin("void", tvm.tirx.op.Op.get("tl.sync_warp"), participant_mask))
+            S[tx] = acc[0]
+
+    s = run_passes_script(func)
+    assert "T.tvm_storage_sync" not in s, f"Unexpected full-block sync:\n{s}"
+
+
+def test_masked_warp_sync_does_not_order_cross_warp_hazards():
+    """A masked warp sync must not hide a cross-warp shared-memory hazard."""
+
+    @T.prim_func(private=True)
+    def func():
+        S = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        acc = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 64)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        active_mask = T.bind(
+            T.cast(
+                T.call_intrin("uint64", tvm.tirx.op.Op.get("tl.activemask")),
+                "uint32",
+            )
+        )
+        participant_mask = T.bind(
+            T.cast(
+                T.call_intrin(
+                    "uint64",
+                    tvm.tirx.op.Op.get("tl.ballot_sync"),
+                    active_mask,
+                    tx % 4 == 0,
+                ),
+                "uint32",
+            )
+        )
+        if tx % 4 == 0:
+            acc[0] = S[(tx + 32) % 64]
+            T.evaluate(T.call_intrin("void", tvm.tirx.op.Op.get("tl.sync_warp"), participant_mask))
+            S[tx] = acc[0]
+
+    s = run_passes_script(func)
+    sync = 'T.tvm_storage_sync("shared")'
+    assert s.count(sync) == 1, f"Expected one full-block sync:\n{s}"
+    assert s.index("acc_1[0] = S_1[") < s.index(sync) < s.index("S_1[tx] = acc_1[0]")
+
+
+def test_hip_subwarp_allreduce_does_not_gain_full_sync():
+    """ThreadSync must respect the masked sync emitted for a HIP subwave."""
+
+    @T.prim_func(private=True)
+    def func(A: T.Buffer((8,), "float32"), C: T.Buffer((1,), "float32")):
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 8)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        value = T.alloc_buffer((1,), "float32", scope="local")
+        result = T.alloc_buffer((1,), "float32", scope="local")
+        value[0] = A[tx]
+        with T.attr(
+            T.comm_reducer(lambda x, y: x + y, [T.float32(0)]),
+            "reduce_scope",
+            T.reinterpret(T.uint64(0), dtype="handle"),
+        ):
+            T.tvm_thread_allreduce(T.uint32(1), value[0], T.bool(True), result[0], tx)
+        C[0] = result[0]
+
+    target = tvm.target.Target(
+        {"kind": "hip", "thread_warp_size": 64, "max_num_threads": 1024},
+        host="llvm",
+    )
+    mod = tvm.IRModule({"main": func.with_attr({"global_symbol": "test", "target": target})})
+    lowered = tilelang.transform.LowerThreadAllreduce()(mod)
+    before = str(lowered.script())
+    transformed = tilelang.transform.ThreadSync("shared")(lowered)
+    after = str(transformed.script())
+    assert "T.sync_warp" in after, f"Expected masked warp synchronization:\n{after}"
+    assert after.count('T.tvm_storage_sync("shared")') == before.count('T.tvm_storage_sync("shared")'), (
+        f"ThreadSync inserted an extra full-block sync:\n{after}"
+    )
 
 
 # =============================================================================


### PR DESCRIPTION
Follow-up to #3085, which was merged [here](https://github.com/tile-ai/tilelang/pull/3085#event-30295452585).

## What is left

#3085 made `ThreadSync` reject unsafe partial-barrier participation. It also kept a compatibility path that hoists the sync out of the branch.

That avoids emitting an invalid partial `bar.sync`, but hoisting does not fix the shared-memory dependency when both accesses are still inside the same branch.

## Small repro

This is the `with_if_else` case from `test.py`:

```python
if tx % 4 == 0:
    S[tx] = T.Cast("float32", tx)
    acc[0] = S[(tx + 4) % 64]
else:
    acc[0] = T.float32(-1.0)
```

Only one thread out of every four enters the `then` branch. Those threads do not form complete warps, so we cannot keep a partial barrier inside the branch. But they do exchange shared-memory values, so the write and read still need to be ordered.

After #3085, the compatibility path generated this:

```python
T.tvm_storage_sync("shared")
if tx % 4 == 0:
    S[tx] = T.Cast("float32", tx)
    acc[0] = S[(tx + 4) % 64]
else:
    acc[0] = T.float32(-1.0)
```

The full-block barrier itself is legal, but it is too early. It does not sit between the shared write and read, so the race is still there.

## Fix

Instead of treating hoisting as the repair, split the divergent branch around the required sync point.

The pass now produces:

```python
thread_sync_condition: T.bool = tx % 4 == 0
if thread_sync_condition:
    S[tx] = T.Cast("float32", tx)
else:
    acc[0] = T.float32(-1.0)
T.tvm_storage_sync("shared")
if thread_sync_condition:
    acc[0] = S[(tx + 4) % 64]
```

Now every thread in the block reaches the full barrier, while the participating threads write before it and read after it. The condition is also evaluated only once.

The existing warp-uniform cases still keep their partial barriers. If a split cannot be represented safely, for example because a scalar binding crosses the barrier or the barrier would run inside a loop with different trip counts across threads, the pass reports the unsupported case instead of silently generating unsafe IR.

## Tested

- full CMake build
- full `test_tilelang_transform_thread_sync.py`: `29 passed, 20 skipped`
- `test.py`, including the `with_if_else` pass output above
- pre-commit on the changed C++ and Python files

@SiriusNEO this follows up on the partial-barrier discussion in #3085. Would you mind taking another look?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Replace unsafe barrier hoisting in divergent branches with branch splitting.
- Place shared-memory writes before the full-block barrier and reads after it.
- Preserve partial barriers for warp-uniform cases.
- Reject unsupported cases, including scalar bindings across barriers and synchronization inside divergent loops.
- Evaluate branch conditions only once.
- Track synchronization participation constraints.
- Recognize warp-level synchronization and prove when ballot-based synchronization orders intra-warp hazards.
- Prove disjoint updates in short, statically unrolled loops.
- Update thread-sync tests for branch splitting, rejection cases, warp synchronization, and uniform-loop handling.

## Validation

- Full CMake build.
- Complete thread-sync test suite: 29 passed, 20 skipped.
- `test.py`.
- Pre-commit checks.

## C++ style / lint notes

- The PR changes C++ implementation code.
- The PR does not change rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains advisory.
- No correctness, build, or test issues are reported. Warning-only style findings should not block merge unless they introduce a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->