### PR TITLE
[CUDA] Add async-proxy fences for sparse MMA intrinsics

### DIFF
--- a/src/cuda/transform/inject_fence_proxy.cc
+++ b/src/cuda/transform/inject_fence_proxy.cc
@@ -102,7 +102,10 @@ bool IsAsyncIntrinsic(const CallNode *call) {
       call->op.same_as(tma_load_gather4()) ||
       call->op.same_as(tma_store_scatter4()) ||
       call->op.same_as(ptx_wgmma_ss()) || call->op.same_as(ptx_wgmma_rs()) ||
+      call->op.same_as(ptx_wgmma_sp_ss()) ||
+      call->op.same_as(ptx_wgmma_sp_rs()) ||
       call->op.same_as(ptx_tcgen05_mma_ss()) ||
+      call->op.same_as(ptx_tcgen05_mma_blockscaled_ss()) ||
       call->op.same_as(ptx_tcgen05_mma_ts())) {
     return true;
   }

--- a/testing/python/transform/test_tilelang_transform_inject_fence_proxy.py
+++ b/testing/python/transform/test_tilelang_transform_inject_fence_proxy.py
@@ -383,6 +383,40 @@ def test_wgmma_marked_async():
 
 
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_sparse_mma_intrinsics_marked_async():
+    for op_name in (
+        "tl.ptx_wgmma_sp_ss",
+        "tl.ptx_wgmma_sp_rs",
+        "tl.ptx_tcgen05_mma_blockscaled_ss",
+    ):
+        target_op = tirx.op.Op.get(op_name)
+
+        @T.prim_func
+        def before():
+            with T.Kernel(1):
+                smem = T.decl_buffer((1,), T.float16, scope="shared")
+                smem[0] = T.float16(0)
+                T.evaluate(T.call_intrin("handle", target_op))
+
+        mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+        mod = tvm.tirx.transform.BindTarget(auto_target)(mod)
+        mod = tl.cuda.transform.InjectFenceProxy()(mod)
+        order = []
+
+        def visit(node):
+            if isinstance(node, tirx.Evaluate):
+                call = node.value
+                if isinstance(call, tirx.Call):
+                    order.append(getattr(call.op, "name", ""))
+
+        tirx.stmt_functor.post_order_visit(mod["main"].body, visit)
+
+        assert op_name in order
+        assert "tl.fence_proxy_async" in order
+        assert order.index("tl.fence_proxy_async") < order.index(op_name)
+
+
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_shared_barrier_ops_do_not_trigger_fence_proxy():
     @T.prim_func
     def before(A_desc: T.handle("uint8x128", "grid_constant")):

--- a/testing/python/transform/test_tilelang_transform_inject_fence_proxy.py
+++ b/testing/python/transform/test_tilelang_transform_inject_fence_proxy.py
@@ -404,15 +404,19 @@ def test_sparse_mma_intrinsics_marked_async():
         order = []
 
         def visit(node):
-            if isinstance(node, tirx.Evaluate):
+            if isinstance(node, tirx.BufferStore):
+                order.append("shared_store")
+            elif isinstance(node, tirx.Evaluate):
                 call = node.value
                 if isinstance(call, tirx.Call):
                     order.append(getattr(call.op, "name", ""))
 
         tirx.stmt_functor.post_order_visit(mod["main"].body, visit)
 
+        assert order.count("shared_store") == 1
+        assert order.count("tl.fence_proxy_async") == 1
+        assert order.index("shared_store") < order.index("tl.fence_proxy_async")
         assert op_name in order
-        assert "tl.fence_proxy_async" in order
         assert order.index("tl.fence_proxy_async") < order.index(op_name)
 
 


### PR DESCRIPTION
## Summary

- classify sparse WGMMA `ss` and `rs` calls as async-proxy operations
- classify block-scaled TCGen05 `ss` calls as an async-proxy operation
- add a transform-level regression covering fence placement after generic shared-memory writes

Fixes #2634.

## Rationale

`LowerTileOp` emits these intrinsics for sparse Hopper and block-scaled Blackwell MMA. `InjectFenceProxy` handles their dense siblings at the same compiler boundary. Classifying the three sparse calls restores `fence.proxy.async` between a generic shared-memory write and the following async-proxy MMA.

## Validation

- `bash format.sh --files src/cuda/transform/inject_fence_proxy.cc testing/python/transform/test_tilelang_transform_inject_fence_proxy.py`
- `python -m py_compile testing/python/transform/test_tilelang_transform_inject_fence_proxy.py`

Repository CI will execute the native transform coverage on its self-hosted NVIDIA runner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Classifies sparse WGMMA `ss`/`rs` and block-scaled TCGen05 `ss` intrinsics as async-proxy operations.
- Inserts `fence.proxy.async` after generic shared-memory writes and before sparse MMA reads.
- Adds regression coverage for all three intrinsics.

## C++ style / lint notes

- The PR changes C++ code but does not modify rules in `docs/developer_guide/cpp_style.md`.
- CI runs the **C++ API Style Audit (warning only)** step.
- Any audit findings are advisory and separate from correctness, build, and test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->