### PR TITLE
[Bugfix][Quantize] Use plain int masks in interleave_weight special branches

### DIFF
--- a/examples/dequantize_gemm/quantize/utils.py
+++ b/examples/dequantize_gemm/quantize/utils.py
@@ -101,25 +101,25 @@ def interleave_weight(qweight, nbits=4, target_dtype="float16"):
 
     if nbits == 1 and target_dtype == "int8":
         # special handling for 1b interleave
-        n16_weight = new_qweight & torch.int32(0xF0F00F0F)
-        n16_weight |= ((new_qweight & torch.int32(0x000000F0)) >> 4) << 16
-        n16_weight |= ((new_qweight & torch.int32(0x0000F000)) >> 12) << 24
-        n16_weight |= ((new_qweight & torch.int32(0x000F0000)) >> 16) << 4
-        n16_weight |= ((new_qweight & torch.int32(0x0F000000)) >> 24) << 12
+        n16_weight = new_qweight & 0xF0F00F0F
+        n16_weight |= ((new_qweight & 0x000000F0) >> 4) << 16
+        n16_weight |= ((new_qweight & 0x0000F000) >> 12) << 24
+        n16_weight |= ((new_qweight & 0x000F0000) >> 16) << 4
+        n16_weight |= ((new_qweight & 0x0F000000) >> 24) << 12
         return n16_weight.view(torch.int8)
     elif nbits == 2 and target_dtype == "float16":
-        n8_weight = new_qweight & torch.int32(0xFF0000FF)
-        n8_weight |= ((new_qweight & torch.int32(0x0000FF00)) >> 8) << 16
-        n8_weight |= ((new_qweight & torch.int32(0x00FF0000)) >> 16) << 8
+        n8_weight = new_qweight & 0xFF0000FF
+        n8_weight |= ((new_qweight & 0x0000FF00) >> 8) << 16
+        n8_weight |= ((new_qweight & 0x00FF0000) >> 16) << 8
         return n8_weight.view(torch.int8)
     elif nbits == 1 and target_dtype == "float16":
-        n8_weight = new_qweight & torch.int32(0xF000000F)
-        n8_weight |= ((new_qweight & torch.int32(0x000000F0)) >> 4) << 8
-        n8_weight |= ((new_qweight & torch.int32(0x00000F00)) >> 8) << 16
-        n8_weight |= ((new_qweight & torch.int32(0x0000F000)) >> 12) << 24
-        n8_weight |= ((new_qweight & torch.int32(0x000F0000)) >> 16) << 4
-        n8_weight |= ((new_qweight & torch.int32(0x00F00000)) >> 20) << 12
-        n8_weight |= ((new_qweight & torch.int32(0x0F000000)) >> 24) << 20
+        n8_weight = new_qweight & 0xF000000F
+        n8_weight |= ((new_qweight & 0x000000F0) >> 4) << 8
+        n8_weight |= ((new_qweight & 0x00000F00) >> 8) << 16
+        n8_weight |= ((new_qweight & 0x0000F000) >> 12) << 24
+        n8_weight |= ((new_qweight & 0x000F0000) >> 16) << 4
+        n8_weight |= ((new_qweight & 0x00F00000) >> 20) << 12
+        n8_weight |= ((new_qweight & 0x0F000000) >> 24) << 20
         return n8_weight.view(torch.int8)
 
     return new_qweight.view(torch.int8)

--- a/testing/python/issue/test_tilelang_issue_3018.py
+++ b/testing/python/issue/test_tilelang_issue_3018.py
@@ -1,0 +1,83 @@
+# Regression test for https://github.com/tile-ai/tilelang/issues/3018
+# interleave_weight used ``torch.int32(0x...)`` to build bit masks on its
+# nbits=1 / nbits=2 branches; ``torch.int32`` is a dtype object, not a
+# constructor, so those branches raised ``TypeError`` instead of returning.
+# Host-side only: the utility is a plain CPU torch tensor transform.
+import pytest
+import torch
+
+import tilelang.testing
+from examples.dequantize_gemm.quantize.utils import interleave_weight
+
+_MASK32 = 0xFFFFFFFF
+
+
+def _reference_interleave(word: int, nbits: int, target_dtype: str) -> int:
+    """Pure-Python reference for interleave_weight on a single uint32 word."""
+    bits_stride = 8 if target_dtype == "int8" else 16
+    mask = (1 << nbits) - 1
+    num_groups = 32 // bits_stride
+    elems_per_group = bits_stride // nbits
+    new = 0
+    for i in range(num_groups):
+        for j in range(elems_per_group):
+            offset = i * elems_per_group + j
+            shift = (offset % num_groups) * bits_stride + (offset // num_groups) * nbits
+            new |= ((word >> (nbits * offset)) & mask) << shift
+    new &= _MASK32
+
+    if nbits == 1 and target_dtype == "int8":
+        out = new & 0xF0F00F0F
+        out |= ((new & 0x000000F0) >> 4) << 16
+        out |= ((new & 0x0000F000) >> 12) << 24
+        out |= ((new & 0x000F0000) >> 16) << 4
+        out |= ((new & 0x0F000000) >> 24) << 12
+        return out & _MASK32
+    if nbits == 2 and target_dtype == "float16":
+        out = new & 0xFF0000FF
+        out |= ((new & 0x0000FF00) >> 8) << 16
+        out |= ((new & 0x00FF0000) >> 16) << 8
+        return out & _MASK32
+    if nbits == 1 and target_dtype == "float16":
+        out = new & 0xF000000F
+        out |= ((new & 0x000000F0) >> 4) << 8
+        out |= ((new & 0x00000F00) >> 8) << 16
+        out |= ((new & 0x0000F000) >> 12) << 24
+        out |= ((new & 0x000F0000) >> 16) << 4
+        out |= ((new & 0x00F00000) >> 20) << 12
+        out |= ((new & 0x0F000000) >> 24) << 20
+        return out & _MASK32
+    return new
+
+
+def _as_uint32_words(tensor: torch.Tensor) -> list[int]:
+    return [w & _MASK32 for w in tensor.contiguous().view(torch.int32).flatten().tolist()]
+
+
+@pytest.mark.parametrize(
+    "nbits,target_dtype",
+    [
+        # The three special branches that previously raised TypeError.
+        (1, "int8"),
+        (2, "float16"),
+        (1, "float16"),
+        # Generic tail, kept as controls.
+        (2, "int8"),
+        (4, "float16"),
+        (4, "int8"),
+    ],
+)
+def test_interleave_weight_matches_reference(nbits, target_dtype):
+    torch.manual_seed(0)
+    qweight = torch.randint(-128, 128, (4, 8), dtype=torch.int8)
+
+    out = interleave_weight(qweight.clone(), nbits, target_dtype)
+
+    assert out.dtype == torch.int8
+    assert out.shape == qweight.shape
+    expected = [_reference_interleave(w, nbits, target_dtype) for w in _as_uint32_words(qweight)]
+    assert _as_uint32_words(out) == expected
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

`interleave_weight` in `examples/dequantize_gemm/quantize/utils.py` raises `TypeError: 'torch.dtype' object is not callable` on its `(nbits=1, "int8")`, `(nbits=2, "float16")` and `(nbits=1, "float16")` branches, so those input combinations never return.

## Root cause

The three special branches build their bit masks with `torch.int32(0x...)`. `torch.int32` is a dtype object, not a constructor, so the first mask expression aborts the call. The generic `nbits=4` tail uses a plain int mask and is unaffected, which is why the shipped example and CI never reach the failing lines.

## Changes

- Replace each `torch.int32(0x...)` mask with the plain int literal. torch widens a Python int to the tensor dtype for `&` and `|`, matching the existing `mask = (1 << nbits) - 1` path.
- Add `testing/python/issue/test_tilelang_issue_3018.py`, which checks all six `(nbits, target_dtype)` combinations bit-exactly against a pure-Python reference of the interleave.

## Validation

- `python -m pytest -q testing/python/issue/test_tilelang_issue_3018.py`: 6 passed. On main, the three special-branch cases fail with the `TypeError`.
- `bash format.sh --files ...`: clean.
- Host-side, no GPU required to verify.

Fixes #3018


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaced invalid `torch.int32(...)` mask construction with Python integer masks in the affected `interleave_weight` branches.
- Preserved generic `nbits=4` behavior.
- Added regression coverage for six `(nbits, target_dtype)` combinations against a pure-Python reference.
- Verified output dtype, shape, and bit-exact values.

## Testing

- Six regression tests pass.
- Formatting checks pass.
- Tests run on the host without GPU requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->