### PR TITLE
[Bugfix][Language] Support unary plus on PrimExpr in the eager frontend

### DIFF
--- a/testing/python/issue/test_tilelang_issue_2991.py
+++ b/testing/python/issue/test_tilelang_issue_2991.py
@@ -1,0 +1,84 @@
+# Regression test for https://github.com/tile-ai/tilelang/issues/2991
+# Unary plus on a traced expression (``+A[i]``) raised
+# ``TypeError: bad operand type for unary +: 'BufferLoad'`` at trace time
+# because PrimExpr overloads unary minus and invert but not unary plus.
+# The structural checks below are host-side and need no GPU.
+import pytest
+import torch
+
+import tilelang
+import tilelang.testing
+from tilelang import language as T, tvm
+
+N = 4
+
+
+def _unary_plus_kernel(dtype):
+    @T.prim_func
+    def kernel(A: T.Tensor((N,), dtype), Out: T.Tensor((N,), dtype)):
+        with T.Kernel(1, threads=1):
+            for i in T.serial(N):
+                Out[i] = +A[i]
+
+    return kernel
+
+
+def _identity_kernel(dtype):
+    @T.prim_func
+    def kernel(A: T.Tensor((N,), dtype), Out: T.Tensor((N,), dtype)):
+        with T.Kernel(1, threads=1):
+            for i in T.serial(N):
+                Out[i] = A[i]
+
+    return kernel
+
+
+def _compound_unary_plus_kernel():
+    @T.macro
+    def plus(x):
+        return +x
+
+    @T.prim_func
+    def kernel(A: T.Tensor((N,), "float32"), Out: T.Tensor((N,), "float32")):
+        with T.Kernel(1, threads=1):
+            # Python scalars keep their native unary plus; PrimExpr operands,
+            # including loop vars, compound expressions and macro results,
+            # trace to the operand itself.
+            for i in T.serial(+N):
+                Out[i] = +(A[i] * 2.0) + plus(A[i]) + T.cast(+i, "float32") + (+1.5)
+
+    return kernel
+
+
+def _compound_expected_kernel():
+    @T.macro
+    def ident(x):
+        return x
+
+    @T.prim_func
+    def kernel(A: T.Tensor((N,), "float32"), Out: T.Tensor((N,), "float32")):
+        with T.Kernel(1, threads=1):
+            for i in T.serial(N):
+                Out[i] = A[i] * 2.0 + ident(A[i]) + T.cast(i, "float32") + 1.5
+
+    return kernel
+
+
+@pytest.mark.parametrize("dtype", ["int32", "float32"])
+def test_unary_plus_traces_to_identity(dtype):
+    tvm.ir.assert_structural_equal(_unary_plus_kernel(dtype), _identity_kernel(dtype))
+
+
+def test_unary_plus_on_loop_var_compound_expr_and_macro():
+    tvm.ir.assert_structural_equal(_compound_unary_plus_kernel(), _compound_expected_kernel())
+
+
+@tilelang.testing.requires_cuda
+def test_unary_plus_runs_on_cuda():
+    kernel = tilelang.compile(_unary_plus_kernel("int32"), out_idx=[1])
+    a = torch.tensor([-5, 10, 0, 7], dtype=torch.int32, device="cuda")
+    assert kernel(a).tolist() == a.tolist()
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/language/eager/ast.py
+++ b/tilelang/language/eager/ast.py
@@ -83,6 +83,7 @@ def quote_expr(expr: str, **kws: QuoteReplacement) -> ast.expr:
 
 Operator = Literal["Add", "Sub", "Mult", "MatMult", "Div", "Mod", "Pow", "LShift", "RShift", "BitOr", "BitXor", "BitAnd", "FloorDiv"]
 BoolOp = Literal["And", "Or", "Not"]
+UnaryOp = Literal["UAdd"]
 
 
 def get_operator_name(operator: ast.operator) -> Operator:
@@ -241,6 +242,11 @@ class BaseBuilder:
         if op == "Not":
             return not left
         raise ValueError(f"Unknown boolop: {op}")
+
+    def unaryop(self, op: UnaryOp, operand: Any) -> Any:
+        if op == "UAdd":
+            return +operand
+        raise ValueError(f"Unknown unaryop: {op}")
 
     def ifexp(self, cond: Any, then: Callable[[], Any], otherwise: Callable[[], Any]) -> Any:
         return then() if cond else otherwise()
@@ -573,6 +579,8 @@ class DSLMutator(ast.NodeTransformer):
         node = self.generic_visit(node)
         if isinstance(node.op, ast.Not):
             return quote_expr("__tb.boolop('Not', operand)", operand=node.operand, span=node)
+        if isinstance(node.op, ast.UAdd):
+            return quote_expr("__tb.unaryop('UAdd', operand)", operand=node.operand, span=node)
         return node
 
     def visit_Compare(self, node: ast.Compare) -> ast.expr:

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -743,6 +743,13 @@ class Builder(BaseBuilder):
         else:
             return super().boolop(op, left, right)
 
+    def unaryop(self, op, operand):
+        if op == "UAdd" and isinstance(operand, PrimExpr):
+            # PrimExpr overloads unary minus and invert but not unary plus.
+            # Unary plus is the identity on numbers, so hand back the operand.
+            return operand
+        return super().unaryop(op, operand)
+
     def ifexp(self, cond, then, otherwise):
         cond = unwrap_cond(cond)
         if isinstance(cond, PrimExpr):


### PR DESCRIPTION
## Summary

Unary plus on any traced expression (`Out[i] = +A[i]`, `+i`, `+(A[i] * 2)`) fails at trace time in the eager frontend with `TypeError: bad operand type for unary +: 'BufferLoad'`, so the kernel never compiles. Unary minus and invert on the same operands work.

## Root cause

`PrimExpr` (TVM's `ExprOp`) overloads `__neg__` and `__invert__` but not `__pos__`, so Python's unary `+` on a `BufferLoad` or `Var` falls through to the default `TypeError`. The eager frontend's AST rewriter (`DSLMutator.visit_UnaryOp`) only intercepts `not`; `+` was executed natively.

## Changes

- `tilelang/language/eager/ast.py`: rewrite `+operand` to `__tb.unaryop('UAdd', operand)` in `visit_UnaryOp`, the mechanism already used for `not`, and add `BaseBuilder.unaryop`, which keeps Python's native unary plus for non-IR values.
- `tilelang/language/eager/builder.py`: `Builder.unaryop` returns a `PrimExpr` operand unchanged (unary plus is the identity on numbers) and defers everything else to the base implementation.
- `testing/python/issue/test_tilelang_issue_2991.py`: structural checks that `+A[i]` traces to the same TIR as `A[i]` for int32 and float32; coverage for loop vars, compound expressions, macro results and Python scalars; a CUDA run guarded by `requires_cuda`.

No change to the vendored TVM. `-` and `~` keep their existing overloads. The classic `tilelang.language.parser` package is not importable on main (`from tvm.runtime import String` fails), so this targets the eager frontend only.

## Validation

- `python -m pytest -q testing/python/issue/test_tilelang_issue_2991.py`: 3 passed, 1 skipped (CUDA) on a CPU-only macOS host. The three host-side tests fail on main with the `TypeError`.
- `python -m pytest -q testing/python/language/test_tilelang_language_frontend_v2.py`: 179 passed; the 6 failures are the CUDA-only tests on this host and are identical on main.
- `bash format.sh --files ...`: clean.
- Host-side, no GPU required to verify.

Fixes #2991


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes unary plus for traced `PrimExpr` values in the eager frontend.

- Rewrites `UAdd` AST nodes through `BaseBuilder.unaryop`.
- Returns `PrimExpr` operands unchanged.
- Preserves Python unary-plus behavior for non-IR values.
- Adds regression coverage for buffer loads, loop variables, compound expressions, macros, casts, Python scalars, and CUDA execution.

This resolves trace-time `TypeError` for expressions such as `+A[i]`, `+i`, and `+(A[i] * 2)`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->