### PR TITLE
[Bugfix][Language] Reject loop else clauses in the eager frontend

### DIFF
--- a/testing/python/issue/test_tilelang_issue_2946.py
+++ b/testing/python/issue/test_tilelang_issue_2946.py
@@ -1,0 +1,72 @@
+# Regression test for https://github.com/tile-ai/tilelang/issues/2946
+# A ``for ... else`` / ``while ... else`` inside a kernel used to trace
+# without error while the ``else`` body was silently dropped from the IR.
+# The eager frontend now rejects loop ``else`` clauses with a clear error.
+# Host-side only: the check runs at trace time, no GPU required.
+import pytest
+
+import tilelang
+import tilelang.testing
+from tilelang import language as T
+
+N = 8
+
+
+def test_for_else_is_rejected():
+    with pytest.raises(NotImplementedError, match=r"`for \.\.\. else` is not supported"):
+
+        @T.prim_func
+        def kernel(A: T.Tensor((N,), "int32"), B: T.Tensor((N,), "int32")):
+            with T.Kernel(1, threads=1):
+                for i in T.serial(N):
+                    B[i] = A[i] + 1
+                else:
+                    for j in T.serial(N):
+                        B[j] = B[j] + 100
+
+
+def test_while_else_is_rejected():
+    with pytest.raises(NotImplementedError, match=r"`while \.\.\. else` is not supported"):
+
+        @T.prim_func
+        def kernel(A: T.Tensor((N,), "int32"), B: T.Tensor((N,), "int32")):
+            with T.Kernel(1, threads=1):
+                i = T.alloc_local((1,), "int32")
+                i[0] = 0
+                while i[0] < N:
+                    B[i[0]] = A[i[0]] + 1
+                    i[0] = i[0] + 1
+                else:
+                    B[0] = B[0] + 100
+
+
+def test_for_else_inside_macro_is_rejected():
+    with pytest.raises(NotImplementedError, match="not supported"):
+
+        @T.macro
+        def body(B):
+            for j in T.serial(N):
+                B[j] = B[j] + 100
+            else:
+                B[0] = 0
+
+
+def test_if_else_inside_loop_still_traces():
+    # `if ... else` inside a loop is unaffected; only loop `else` clauses are rejected.
+    @T.prim_func
+    def kernel(A: T.Tensor((N,), "int32"), B: T.Tensor((N,), "int32")):
+        with T.Kernel(1, threads=1):
+            for i in T.serial(N):
+                if A[i] > 0:
+                    B[i] = A[i]
+                else:
+                    B[i] = 0
+
+    script = kernel.script()
+    assert "if A[i] > 0:" in script
+    assert "B[i] = A[i]" in script
+    assert "B[i] = 0" in script
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/language/eager/ast.py
+++ b/tilelang/language/eager/ast.py
@@ -315,7 +315,16 @@ class DSLMutator(ast.NodeTransformer):
             s = ast.unparse(target)
             raise NotImplementedError(f"Unsupported for target `{s}`")
 
+    def _reject_loop_else(self, node: ast.For | ast.While):
+        if node.orelse:
+            loop = "for" if isinstance(node, ast.For) else "while"
+            raise NotImplementedError(
+                f"`{loop} ... else` is not supported in TileLang kernels (line {node.lineno}); "
+                "the `else` body would be silently dropped. Move it after the loop instead."
+            )
+
     def visit_For(self, node: ast.For):
+        self._reject_loop_else(node)
         node = self.generic_visit(node)
         tmp = self.get_tmp()
         # names = self._parse_names(node.target)
@@ -480,6 +489,7 @@ class DSLMutator(ast.NodeTransformer):
         return self._emit_assign_target(node.target, rval, annot=node.annotation)
 
     def visit_While(self, node):
+        self._reject_loop_else(node)
         node = self.generic_visit(node)
         return quote1("for _ in __tb.ctx_while(lambda: cond):\n  pass", cond=node.test, passes=[node.body], span=node)
 


### PR DESCRIPTION
## Summary

A `for ... else:` or `while ... else:` written inside a kernel traced without any error while the `else` body was silently dropped from the generated IR, so the kernel computed the wrong result. The eager frontend now rejects loop `else` clauses with a clear `NotImplementedError` at trace time.

## Root cause

`DSLMutator.visit_For` and `visit_While` rewrite only `node.body` into the builder loop context; `node.orelse` was never visited or emitted, so the clause vanished without a diagnostic.

## Changes

- `tilelang/language/eager/ast.py`: `visit_For` and `visit_While` raise `NotImplementedError` naming the construct and line when a loop carries an `else` clause. `if ... else` is untouched.
- `testing/python/issue/test_tilelang_issue_2946.py`: `for ... else`, `while ... else` and a macro variant are rejected; an `if ... else` inside a loop still traces.

Rejecting is the conservative fix: TIR has no loop-else construct, and implementing "run unless the loop broke" would need a flag variable per loop. Kernels that hit this were already computing without the `else` body.

## Validation

- `python -m pytest -q testing/python/issue/test_tilelang_issue_2946.py`: 4 passed. On main the three rejection tests fail because the loops trace successfully with the `else` body missing.
- `python -m pytest -q testing/python/language/test_tilelang_language_frontend_v2.py`: 179 passed; the 6 failures are the CUDA-only tests on this CPU host and are identical on main.
- `bash format.sh --files ...`: clean.
- Host-side, no GPU required to verify.

Fixes #2946


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Rejects `for ... else` and `while ... else` during eager frontend tracing.
- Reports the loop type and source line with `NotImplementedError`.
- Adds regression tests for loop clauses, macro usage, and valid `if ... else` behavior.
- Prevents silent omission of loop `else` bodies and incorrect kernel results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->