### PR TITLE
[Cache] Store cached kernel params as JSON instead of cloudpickle

### DIFF
--- a/docs/programming_guides/autotuning.md
+++ b/docs/programming_guides/autotuning.md
@@ -208,7 +208,7 @@ The autotuner caches best artifacts both in‑memory (per process) and on disk u
 Disk cache contents (per key)
 - Best config and latency: `best_config.json`, `latency.json`
 - Kernel sources and library: `device_kernel.cu`, `host_kernel.cu`, `kernel_lib.so` (or `kernel.cubin`/`executable.so` depending on backend)
-- Function and params: `function.pkl`, `params.pkl`
+- Function and params: `function.pkl`, `params.json`
 
 Control via env vars (tilelang.env)
 - `TILELANG_CACHE_DIR` (default `~/.tilelang/cache`)

--- a/testing/python/autotune/test_tilelang_autotune_atomic_save.py
+++ b/testing/python/autotune/test_tilelang_autotune_atomic_save.py
@@ -15,7 +15,9 @@ from tilelang.autotuner.param import (
     KERNEL_PY_PATH,
     PARAMS_PATH,
 )
+from tilelang.engine.param import KernelParam
 from tilelang.env import env
+from tilelang import tvm
 
 
 class _FakeAdapter:
@@ -34,7 +36,7 @@ class _FakeKernel:
         self.execution_backend = execution_backend
         self.adapter = _FakeAdapter(libpath)
         self.kernel_source = "// device kernel"
-        self.params = ["param"]
+        self.params = [KernelParam(tvm.DataType("float32"), [4])]
 
 
 def _fake_func():

--- a/testing/python/cache/test_tilelang_cuda_binary_cache.py
+++ b/testing/python/cache/test_tilelang_cuda_binary_cache.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-import cloudpickle
 import os
 
 import tilelang
+from tilelang import tvm
 import tilelang.cache.kernel_cache as kernel_cache_mod
 from tilelang.backend import create_backend_context
 from tilelang.cache.cuda_binary_cache import CUDABinaryCache
 from tilelang.cache.kernel_cache import KernelCache
+from tilelang.engine.param import KernelParam, dump_kernel_params
 from tilelang.env import env
 from tvm.target import Target
 
@@ -127,8 +128,7 @@ def test_disk_cache_load_failure_is_cache_miss(monkeypatch, tmp_path):
     (cache_path / cache.device_kernel_path).write_text("// device")
     (cache_path / cache.host_kernel_path).write_text("// host")
     (cache_path / cache.kernel_lib_path).write_bytes(b"not-loadable")
-    with (cache_path / cache.params_path).open("wb") as f:
-        cloudpickle.dump(["param"], f)
+    (cache_path / cache.params_path).write_text(dump_kernel_params([KernelParam(tvm.DataType("float32"), [4])]))
     cache._write_manifest(str(cache_path))
 
     def fail_from_database(*args, **kwargs):

--- a/testing/python/cache/test_tilelang_kernel_cache_atomic_save.py
+++ b/testing/python/cache/test_tilelang_kernel_cache_atomic_save.py
@@ -3,12 +3,14 @@ import errno
 from pathlib import Path
 from types import SimpleNamespace
 
-import cloudpickle
 import pytest
+
+from tilelang import tvm
 
 import tilelang.cache.kernel_cache as kernel_cache_mod
 from tilelang.backend import create_backend_context
 from tilelang.cache.kernel_cache import KernelCache
+from tilelang.engine.param import KernelParam, dump_kernel_params
 from tilelang.env import env
 from tilelang.jit.adapter.base import CachedTextSource
 from tilelang.jit.adapter.kernel_cache import TVMFFIKernelCache
@@ -27,7 +29,7 @@ class _FakeKernel:
     def __init__(self, libpath: str):
         self.adapter = _FakeAdapter(libpath)
         self.kernel_source = "// device kernel"
-        self.params = ["param"]
+        self.params = [KernelParam(tvm.DataType("float32"), [4])]
 
 
 @pytest.fixture
@@ -62,8 +64,7 @@ def _write_complete_kernel_cache_entry(
     (cache_path / cache.device_kernel_path).write_text(device_source)
     (cache_path / cache.host_kernel_path).write_text(host_source)
     (cache_path / cache.kernel_lib_path).write_bytes(b"fake-so")
-    with (cache_path / cache.params_path).open("wb") as f:
-        cloudpickle.dump(["param"], f)
+    (cache_path / cache.params_path).write_text(dump_kernel_params([KernelParam(tvm.DataType("float32"), [4])]))
     cache._write_manifest(str(cache_path))
     return cache_path
 
@@ -100,7 +101,7 @@ def test_kernel_cache_disk_hit_defers_source_loading(cache_dirs, monkeypatch):
     assert captured["host_kernel_source"] == CachedTextSource(path=str(cache_path / cache.host_kernel_path))
     assert captured["device_kernel_source"] == CachedTextSource(path=str(cache_path / cache.device_kernel_path))
     assert captured["kernel_lib_path"] == str(cache_path / cache.kernel_lib_path)
-    assert captured["params"] == ["param"]
+    assert captured["params"] == [KernelParam(tvm.DataType("float32"), [4])]
     assert captured["backend_context"] is backend_context
 
 
@@ -201,8 +202,7 @@ def test_kernel_cache_disk_hit_rejects_entries_missing_sources(cache_dirs, monke
     cache_path = Path(cache._get_cache_path(key))
     cache_path.mkdir(parents=True)
     (cache_path / cache.kernel_lib_path).write_bytes(b"fake-so")
-    with (cache_path / cache.params_path).open("wb") as f:
-        cloudpickle.dump(["param"], f)
+    (cache_path / cache.params_path).write_text(dump_kernel_params([KernelParam(tvm.DataType("float32"), [4])]))
 
     def fail_from_database(cls, **kwargs):
         raise AssertionError("incomplete cache entries should miss before rebuilding from database")

--- a/testing/python/cache/test_tilelang_kernel_cache_integrity.py
+++ b/testing/python/cache/test_tilelang_kernel_cache_integrity.py
@@ -12,12 +12,14 @@ import json
 from hashlib import sha256
 from pathlib import Path
 
-import cloudpickle
 import pytest
+
+from tilelang import tvm
 
 import tilelang.cache.kernel_cache as kernel_cache_mod
 from tilelang.backend import create_backend_context
 from tilelang.cache.kernel_cache import KernelCache
+from tilelang.engine.param import KernelParam, dump_kernel_params
 from tilelang.env import env
 
 
@@ -33,7 +35,7 @@ class _FakeKernel:
     def __init__(self, libpath: str):
         self.adapter = _FakeAdapter(libpath)
         self.kernel_source = "// device kernel"
-        self.params = ["param"]
+        self.params = [KernelParam(tvm.DataType("float32"), [4])]
 
 
 @pytest.fixture
@@ -163,8 +165,7 @@ def test_legacy_entry_without_manifest_misses_and_save_repairs(cache_dirs, tmp_p
     (cache_path / cache.device_kernel_path).write_text("// device kernel")
     (cache_path / cache.host_kernel_path).write_text("// host kernel")
     (cache_path / cache.kernel_lib_path).write_bytes(b"legacy-truncated")
-    with (cache_path / cache.params_path).open("wb") as f:
-        cloudpickle.dump(["param"], f)
+    (cache_path / cache.params_path).write_text(dump_kernel_params([KernelParam(tvm.DataType("float32"), [4])]))
 
     assert _load_expecting_no_build(cache, key, monkeypatch) is None
 

--- a/testing/python/issue/test_tilelang_issue_2817.py
+++ b/testing/python/issue/test_tilelang_issue_2817.py
@@ -1,0 +1,92 @@
+# Regression test for https://github.com/tile-ai/tilelang/issues/2817
+# Cached kernel parameters used to be stored with cloudpickle, so loading a
+# cache entry deserialized arbitrary pickle bytes. They are now stored as
+# JSON produced by TVM's reflection (``tvm.ir.save_json``), which only
+# rebuilds IR nodes and never executes code. Host-side only, no GPU needed.
+import json
+from pathlib import Path
+
+import pytest
+
+import tilelang
+import tilelang.testing
+from tilelang import tvm
+from tilelang.cache.kernel_cache import KernelCache
+from tilelang.engine.param import KernelParam, dump_kernel_params, load_kernel_params
+from tilelang.env import env
+from tvm import tirx
+
+
+def _params():
+    n = tirx.Var("n", "int32")
+    return [
+        KernelParam(tvm.DataType("float16"), [n, 64]),
+        KernelParam(tvm.DataType("int8"), [n * 2, 8]),
+        KernelParam(tvm.DataType("float8_e4m3"), [4, 4]),
+        KernelParam(tvm.DataType("int32"), []),
+    ]
+
+
+def _check_round_trip(params, loaded):
+    assert [str(p.dtype) for p in loaded] == [str(p.dtype) for p in params]
+    assert [len(p.shape) for p in loaded] == [2, 2, 2, 0]
+    assert loaded[0].shape[1] == 64 and isinstance(loaded[0].shape[1], int)
+    assert isinstance(loaded[0].shape[0], tirx.Var) and loaded[0].shape[0].name == "n"
+    # A symbolic dim shared by two params is the same Var after loading.
+    assert loaded[1].shape[0].a.same_as(loaded[0].shape[0])
+    tvm.ir.assert_structural_equal(loaded[1].shape[0], loaded[0].shape[0] * 2)
+    assert loaded[2].is_float8()
+    assert loaded[3].is_scalar()
+
+
+def test_kernel_params_round_trip_through_json():
+    params = _params()
+    text = dump_kernel_params(params)
+    # Plain JSON text, not a pickle stream.
+    assert isinstance(text, str)
+    json.loads(text)
+    _check_round_trip(params, load_kernel_params(text))
+
+
+def test_load_kernel_params_rejects_non_json_input():
+    with pytest.raises(ValueError):
+        load_kernel_params("\x80\x04not a json document")
+
+
+class _FakeAdapter:
+    def __init__(self, libpath: str):
+        self.libpath = libpath
+
+    def get_kernel_source(self):
+        return "// host kernel"
+
+
+class _FakeKernel:
+    def __init__(self, libpath: str, params):
+        self.adapter = _FakeAdapter(libpath)
+        self.kernel_source = "// device kernel"
+        self.params = params
+
+
+def test_kernel_cache_stores_params_as_json(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(env, "TILELANG_CACHE_DIR", str(cache_dir))
+    cache = KernelCache()
+    lib_path = tmp_path / "kernel_lib.so"
+    lib_path.write_bytes(b"fake-so")
+    params = _params()
+
+    cache._save_kernel_to_disk("json-params", _FakeKernel(str(lib_path), params))
+
+    cache_path = Path(cache._get_cache_path("json-params"))
+    params_file = cache_path / cache.params_path
+    assert params_file.suffix == ".json"
+    assert not (cache_path / "params.pkl").exists()
+    text = params_file.read_text()
+    json.loads(text)
+    _check_round_trip(params, load_kernel_params(text))
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -18,7 +18,7 @@ from tilelang.jit.adapter.base import CachedTextSource
 import cloudpickle
 import os
 import shutil
-from tilelang.engine.param import KernelParam
+from tilelang.engine.param import KernelParam, dump_kernel_params, load_kernel_params
 from tilelang import logger
 import json
 import hashlib
@@ -40,7 +40,7 @@ EXECUTABLE_PATH = "executable.so"
 KERNEL_LIB_PATH = "kernel_lib.so"
 KERNEL_CUBIN_PATH = "kernel.cubin"
 KERNEL_PY_PATH = "kernel.py"
-PARAMS_PATH = "params.pkl"
+PARAMS_PATH = "params.json"
 TargetLike = str | dict[str, object] | Target
 
 
@@ -225,7 +225,7 @@ class AutotuneResult:
             - kernel.cu: The compiled kernel source code
             - wrapped_kernel.cu: The wrapped kernel source code
             - kernel_lib.so: The compiled kernel library
-            - params.pkl: The serialized kernel parameters
+            - params.json: The serialized kernel parameters
         """
         os.makedirs(cache_path, exist_ok=True)  # Ensure directory exists.
 
@@ -311,7 +311,7 @@ class AutotuneResult:
         params_path = os.path.join(cache_path, PARAMS_PATH)
         if verbose:
             logger.debug(f"Saving kernel parameters to disk: {params_path}")
-        self._safe_write_file(params_path, "wb", lambda f: cloudpickle.dump(kernel.params, f))
+        self._safe_write_file(params_path, "w", lambda f: f.write(dump_kernel_params(kernel.params)))
 
     def _load_kernel_from_disk(
         self,
@@ -380,8 +380,8 @@ class AutotuneResult:
         try:
             if verbose:
                 logger.debug(f"Loading kernel parameters from file: {params_path}")
-            with open(params_path, "rb") as f:
-                kernel_params = cloudpickle.load(f)
+            with open(params_path) as f:
+                kernel_params = load_kernel_params(f.read())
         except Exception as e:
             logger.error(f"Error loading kernel parameters from disk: {e}")
 

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -17,12 +17,11 @@ from hashlib import sha256
 from typing import Literal
 from collections.abc import Callable
 
-import cloudpickle
 from tvm.target import Target
 from tvm.tirx import PrimFunc
 from tvm.runtime import Executable
 from tilelang.backend.module import BackendContext, create_backend_context
-from tilelang.engine.param import KernelParam
+from tilelang.engine.param import KernelParam, dump_kernel_params, load_kernel_params
 from tilelang.utils.language import get_prim_func_name
 from tilelang import env
 from tilelang.jit import JITKernel
@@ -40,7 +39,7 @@ class KernelCache:
         kernel.cu: The compiled kernel source code
         wrapped_kernel.cu: The compiled wrapped kernel source code
         kernel_lib.so: The compiled kernel library
-        params.pkl: The compiled kernel parameters
+        params.json: The compiled kernel parameters
     """
 
     _instance = None  # For implementing singleton pattern
@@ -52,7 +51,7 @@ class KernelCache:
     device_kernel_path = "device_kernel.cu"
     host_kernel_path = "host_kernel.cu"
     kernel_lib_path = "kernel_lib.so"
-    params_path = "params.pkl"
+    params_path = "params.json"
     resource_usage_path = "resource_usage.json"
     manifest_path = "manifest.json"
     cache_root_dir = "kernels"
@@ -597,7 +596,7 @@ class KernelCache:
             params_path = os.path.join(staging_path, self.params_path)
             if verbose:
                 self.logger.debug(f"Saving kernel parameters to disk: {params_path}")
-            KernelCache._safe_write_file(params_path, "wb", lambda file: cloudpickle.dump(kernel.params, file))
+            KernelCache._safe_write_file(params_path, "w", lambda file: file.write(dump_kernel_params(kernel.params)))
 
             # Persist HIP kernel-resource-usage remarks
             usage = getattr(kernel, "_resource_usage", None) or {}
@@ -692,8 +691,8 @@ class KernelCache:
         try:
             if verbose:
                 self.logger.debug(f"Loading kernel parameters from file: {params_path}")
-            with open(params_path, "rb") as f:
-                kernel_params = cloudpickle.load(f)
+            with open(params_path) as f:
+                kernel_params = load_kernel_params(f.read())
         except Exception:
             self.logger.exception("Error loading kernel parameters from disk")
 
@@ -809,7 +808,7 @@ class KernelCache:
         """Check a cache entry against its manifest.
 
         Every listed file must match its recorded size; the required binary
-        artifacts (e.g. kernel_lib.so, params.pkl) must also match their
+        artifacts (e.g. kernel_lib.so, params.json) must also match their
         recorded content hash. Source files are size-checked only so disk
         cache hits keep deferring source reads. Returns False for entries
         whose manifest is unreadable or that do not cover the required files.

--- a/tilelang/engine/param.py
+++ b/tilelang/engine/param.py
@@ -164,3 +164,25 @@ class CompiledArtifact:
     rt_mod: tvm.runtime.Module | None = None  # Runtime module for execution, may be lazily initialized
     target: tvm.target.Target | None = None  # Normalized device target used for lowering
     target_host: tvm.target.Target | None = None  # Normalized host target used for host codegen/export
+
+
+def dump_kernel_params(params: list[KernelParam]) -> str:
+    """Serialize kernel parameters to JSON text.
+
+    Uses TVM's JSON reflection (``tvm.ir.save_json``) so symbolic shape
+    expressions round-trip, including shared ``Var`` identity across params.
+    The result contains only IR node data and can be loaded without executing
+    any code, unlike a pickle.
+    """
+    records = [{"dtype": str(param.dtype), "shape": list(param.shape)} for param in params]
+    return tvm.ir.save_json(tvm.runtime.convert(records))
+
+
+def load_kernel_params(text: str) -> list[KernelParam]:
+    """Reconstruct kernel parameters written by :func:`dump_kernel_params`."""
+    params = []
+    for record in tvm.ir.load_json(text):
+        dtype = tvm.DataType(str(record["dtype"]))
+        shape = [dim if isinstance(dim, PrimExpr) else int(dim) for dim in record["shape"]]
+        params.append(KernelParam(dtype, shape))
+    return params


### PR DESCRIPTION
## Summary

The disk kernel cache and the autotuner result cache stored kernel parameters with `cloudpickle` and loaded them with `cloudpickle.load()`, so anyone who can write to `TILELANG_CACHE_DIR` (default `~/.tilelang/cache`) could get arbitrary code executed on the next cache hit (CWE-502). Kernel parameters are plain data (a dtype plus a shape of ints and symbolic exprs), so this stores them as JSON instead.

## Root cause

`KernelCache._load_kernel_from_disk` and `AutotuneResult._load_kernel_from_disk` called `cloudpickle.load()` on `params.pkl`. Pickle reconstructs objects by importing and calling whatever the stream names, so a crafted `params.pkl` runs code during deserialization. The manifest hash check does not help because whoever writes the entry also writes the manifest.

## Changes

- `tilelang/engine/param.py`: add `dump_kernel_params` and `load_kernel_params`, which serialize `KernelParam` lists through TVM's JSON reflection (`tvm.ir.save_json` / `tvm.ir.load_json`). Static dims stay ints, symbolic dims and expressions round-trip as IR nodes, and a `Var` shared by several params is still one `Var` after loading. Loading only rebuilds IR nodes from registered node types and never executes code.
- `tilelang/cache/kernel_cache.py`, `tilelang/autotuner/param.py`: write and read `params.json` with the helpers. `kernel_cache.py` no longer imports `cloudpickle`.
- Existing cache tests write the new format for their fake entries; the autotuning guide names the new file.
- `testing/python/issue/test_tilelang_issue_2817.py`: round trip (static, symbolic, expression, scalar and float8 params), plain-JSON check, malformed-input rejection, and a `KernelCache._save_kernel_to_disk` check that the entry contains `params.json` and no pickle.

Old entries: the cache key already includes the TileLang version, and an entry without `params.json` is treated as incomplete and rebuilt, so there is no migration step. The autotuner's `function.pkl` (the user's Python callable) still uses cloudpickle; it needs a different design (for example the tuner supplying its own function instead of unpickling one) and is left out of this change.

## Validation

- `python -m pytest -q testing/python/issue/test_tilelang_issue_2817.py testing/python/cache testing/python/autotune`: 36 passed, 28 skipped; the 6 failures are the CUDA-only autotune tests on this CPU host and are identical on main.
- `bash format.sh --files ...`: clean.
- Host-side, no GPU required to verify.

Fixes #2817


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaced cloudpickle serialization for cached kernel parameters with JSON using TVM reflection.
- Added `dump_kernel_params` and `load_kernel_params` helpers.
- Preserved static and symbolic dimensions, expressions, shared variables, scalar parameters, and float8 parameters.
- Updated `KernelCache` and `AutotuneResult` to use `params.json`.
- Rebuilt cache entries that lack `params.json`.
- Kept `function.pkl` cloudpickle-based because it stores user Python callables.
- Added tests for round trips, JSON validity, malformed input rejection, and cache contents.
- Fixes unsafe parameter deserialization described in issue `#2817`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->