### PR TITLE
[BugFix][Carver] Compare sm_version numerically in plan_rasterization

### DIFF
--- a/testing/python/carver/test_tilelang_carver_policy_rasterization.py
+++ b/testing/python/carver/test_tilelang_carver_policy_rasterization.py
@@ -1,0 +1,92 @@
+"""CPU regression test for the arch gate in ``TensorCorePolicy.plan_rasterization``.
+
+The gate compared ``arch.compute_capability`` -- the bare digit string
+``CUDA.__init__`` derives from ``device.compute_version`` -- as a *string*:
+``compute_capability < "80"``.  Lexicographically ``"100" < "80"`` and
+``"120" < "80"``, so Blackwell targets never received a rasterization plan
+while sm_86 / sm_89 did.  Now gated on ``arch.sm_version`` (an int).
+
+No GPU is needed: the policy is built without a device, following
+``test_tilelang_carver_sm_version.py``.
+"""
+
+import tilelang.testing
+from tilelang.carver.arch.arch_base import TileDevice
+from tilelang.carver.arch.cuda import CUDA
+from tilelang.carver.roller.policy.tensorcore import TensorCorePolicy
+from tilelang.carver.roller.rasterization import NoRasterization, Rasterization2DColumn
+
+
+def _cuda_arch(sm_version: int, compute_max_core: int = 108) -> CUDA:
+    arch = CUDA.__new__(CUDA)
+    arch.sm_version = sm_version
+    arch.compute_capability = str(sm_version)
+    arch.compute_max_core = compute_max_core
+    arch.l2_cache_size_bytes = 40 << 20
+    return arch
+
+
+class _NonCudaArch(TileDevice):
+    """A device that is neither CUDA nor RDNA (e.g. CDNA): the gates must not
+    touch ``sm_version`` on it."""
+
+    def __init__(self):
+        self.compute_capability = "gfx942"
+        self.compute_max_core = 304
+        self.l2_cache_size_bytes = 4 << 20  # MI300X L2 per XCD; must be < _BIG (64 MiB)
+
+
+class _Node:
+    def __init__(self, tags=None, input_buffers=()):
+        self._tags = tags or {}
+        self.input_buffers = list(input_buffers)
+
+    def get_tag(self, k):
+        return self._tags.get(k)
+
+
+class _Buffer:
+    def __init__(self, shape, dtype="float16"):
+        self.shape = shape
+        self.dtype = dtype
+
+
+def _policy(arch, node) -> TensorCorePolicy:
+    policy = TensorCorePolicy.__new__(TensorCorePolicy)
+    policy.arch = arch
+    policy.prim_func_node = node
+    policy.ordered_nodes = [node]
+    return policy
+
+
+_BIG = [_Buffer([4096, 4096]), _Buffer([4096, 4096])]  # 64 MiB > l2
+
+
+def test_rasterization_enabled_on_ampere_and_newer():
+    for sm in (80, 86, 89, 90, 100, 120):
+        plan = _policy(_cuda_arch(sm), _Node(input_buffers=_BIG)).plan_rasterization(None)
+        assert isinstance(plan, Rasterization2DColumn), sm
+        assert plan.panel_width_ == int(108**0.5)
+
+
+def test_rasterization_disabled_pre_ampere():
+    for sm in (70, 75):
+        plan = _policy(_cuda_arch(sm), _Node(input_buffers=_BIG)).plan_rasterization(None)
+        assert isinstance(plan, NoRasterization), sm
+
+
+def test_rasterization_disabled_when_inputs_fit_l2():
+    small = [_Buffer([256, 256]), _Buffer([256, 256])]
+    plan = _policy(_cuda_arch(80), _Node(input_buffers=small)).plan_rasterization(None)
+    assert isinstance(plan, NoRasterization)
+
+
+def test_rasterization_non_cuda_arch_unchanged():
+    # Non-CUDA devices were never gated by the string compare ("gfx942" > "80");
+    # keep that behaviour.
+    plan = _policy(_NonCudaArch(), _Node(input_buffers=_BIG)).plan_rasterization(None)
+    assert isinstance(plan, Rasterization2DColumn)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/carver/roller/policy/tensorcore.py
+++ b/tilelang/carver/roller/policy/tensorcore.py
@@ -9,7 +9,7 @@ from ..node import PrimFuncNode
 from .common import coalesced_factor, factorize, get_all_factors
 from .default import DefaultPolicy
 from ..rasterization import NoRasterization, Rasterization2DColumn
-from ...arch import is_rdna_arch
+from ...arch import is_cuda_arch, is_rdna_arch
 
 logger = logging.getLogger(__name__)
 
@@ -344,7 +344,7 @@ class TensorCorePolicy(DefaultPolicy):
         # only support single node for now
         conditions.append(len(self.ordered_nodes) > 1)
         # only on Ampere+ arch
-        conditions.append(self.arch.compute_capability < "80")
+        conditions.append(is_cuda_arch(self.arch) and self.arch.sm_version < 80)
 
         def _check_memory_size():
             overall_gmem_size_in_bytes: int = 0


### PR DESCRIPTION
plan_rasterization compared the runtime compute-capability string lexicographically. That classified sm_100 and sm_120 as older than sm_80 and disabled rasterization on Blackwell targets.

Use the target-derived integer sm_version for CUDA targets while preserving existing non-CUDA behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fix CUDA architecture checks in `TensorCorePolicy.plan_rasterization`.
- Compare numeric `sm_version` values instead of compute-capability strings.
- Enable rasterization for Ampere and newer targets, including `sm_100` and `sm_120`.
- Preserve pre-Ampere and non-CUDA behavior.
- Add CPU-only tests for architecture gates, L2-fit cases, and non-CUDA targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->