### PR TITLE
[BugFix][Carver] Gate _legalize_info fallback on sm_version

### DIFF
--- a/testing/python/carver/test_tilelang_carver_policy_legalize_info.py
+++ b/testing/python/carver/test_tilelang_carver_policy_legalize_info.py
@@ -1,0 +1,98 @@
+"""CPU regression test for the ``_legalize_info`` fallback in TensorCorePolicy.
+
+When the ``pipeline_stage`` / ``use_async_copy`` tags are absent the policy
+falls back on ``arch.compute_capability``.  ``CUDA.__init__`` fills that with
+the bare digits of ``device.compute_version`` ("80", "90"), but the fallback
+compared it against ``{"sm_80", "sm_90", "sm_90a"}`` -- never true -- so every
+CUDA arch silently got 1 pipeline stage and no ``cp.async`` on this path.
+
+Now gated on ``arch.sm_version in {80, 90}`` -- the faithful translation of the
+old literal set (``sm_90a`` also parses to 90), and the same membership the tag
+path in ``matmul_analysis.py`` uses.  Whether sm_86/89/100+ should enable the
+pipeline too is a separate behavioural question, deliberately not part of this
+fix.  No GPU is needed: the policy is
+built without a device, following ``test_tilelang_carver_sm_version.py``.
+"""
+
+import tilelang.testing
+from tilelang.carver.arch.arch_base import TileDevice
+from tilelang.carver.arch.cuda import CUDA
+from tilelang.carver.roller.policy.tensorcore import TensorCorePolicy
+
+
+def _cuda_arch(sm_version: int, compute_max_core: int = 108) -> CUDA:
+    arch = CUDA.__new__(CUDA)
+    arch.sm_version = sm_version
+    arch.compute_capability = str(sm_version)
+    arch.compute_max_core = compute_max_core
+    arch.l2_cache_size_bytes = 40 << 20
+    return arch
+
+
+class _NonCudaArch(TileDevice):
+    """A device that is neither CUDA nor RDNA (e.g. CDNA): the gates must not
+    touch ``sm_version`` on it."""
+
+    def __init__(self):
+        self.compute_capability = "gfx942"
+        self.compute_max_core = 304
+        self.l2_cache_size_bytes = 256 << 20
+
+
+class _Node:
+    def __init__(self, tags=None, input_buffers=()):
+        self._tags = tags or {}
+        self.input_buffers = list(input_buffers)
+
+    def get_tag(self, k):
+        return self._tags.get(k)
+
+
+class _Buffer:
+    def __init__(self, shape, dtype="float16"):
+        self.shape = shape
+        self.dtype = dtype
+
+
+def _policy(arch, node) -> TensorCorePolicy:
+    policy = TensorCorePolicy.__new__(TensorCorePolicy)
+    policy.arch = arch
+    policy.prim_func_node = node
+    policy.ordered_nodes = [node]
+    return policy
+
+
+def test_legalize_info_tags_win():
+    policy = _policy(_cuda_arch(75), _Node({"pipeline_stage": 3, "use_async_copy": True}))
+    policy._legalize_info()
+    assert policy.pipeline_stage == 3
+    assert policy.use_async_copy is True
+
+
+def test_legalize_info_fallback_sm80_sm90():
+    for sm in (80, 90):
+        policy = _policy(_cuda_arch(sm), _Node())
+        policy._legalize_info()
+        assert policy.pipeline_stage == 2, sm
+        assert policy.use_async_copy is True, sm
+
+
+def test_legalize_info_fallback_other_cuda_arches():
+    # Same membership as the tag path in matmul_analysis.py: only {80, 90}
+    # enable the 2-stage pipeline + cp.async; everything else stays at 1/False.
+    for sm in (70, 75, 86, 89, 100, 120):
+        policy = _policy(_cuda_arch(sm), _Node())
+        policy._legalize_info()
+        assert policy.pipeline_stage == 1, sm
+        assert policy.use_async_copy is False, sm
+
+
+def test_legalize_info_fallback_non_cuda_arch():
+    policy = _policy(_NonCudaArch(), _Node())
+    policy._legalize_info()
+    assert policy.pipeline_stage == 1
+    assert policy.use_async_copy is False
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/carver/roller/policy/tensorcore.py
+++ b/tilelang/carver/roller/policy/tensorcore.py
@@ -39,7 +39,7 @@ class TensorCorePolicy(DefaultPolicy):
             else:
                 self.pipeline_stage = 1
         use_async_copy = self.prim_func_node.get_tag("use_async_copy")
-        if use_async_copy:
+        if use_async_copy is not None:
             self.use_async_copy = use_async_copy
         else:
             # `compute_capability` is the bare "80"/"90" string, so it could

--- a/tilelang/carver/roller/policy/tensorcore.py
+++ b/tilelang/carver/roller/policy/tensorcore.py
@@ -9,7 +9,7 @@ from ..node import PrimFuncNode
 from .common import coalesced_factor, factorize, get_all_factors
 from .default import DefaultPolicy
 from ..rasterization import NoRasterization, Rasterization2DColumn
-from ...arch import is_rdna_arch
+from ...arch import is_cuda_arch, is_rdna_arch
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class TensorCorePolicy(DefaultPolicy):
         else:
             if is_rdna_arch(self.arch):
                 self.pipeline_stage = self.arch.tuning.pipeline_stage
-            elif self.arch.compute_capability in {"sm_80", "sm_90", "sm_90a"}:
+            elif is_cuda_arch(self.arch) and self.arch.sm_version in {80, 90}:
                 self.pipeline_stage = 2
             else:
                 self.pipeline_stage = 1
@@ -42,10 +42,10 @@ class TensorCorePolicy(DefaultPolicy):
         if use_async_copy:
             self.use_async_copy = use_async_copy
         else:
-            if self.arch.compute_capability in {"sm_80", "sm_90", "sm_90a"}:
-                self.use_async_copy = True
-            else:
-                self.use_async_copy = False
+            # `compute_capability` is the bare "80"/"90" string, so it could
+            # never match an "sm_80"-style literal.  Gate on `sm_version` with
+            # the same {80, 90} set the tag path uses (matmul_analysis).
+            self.use_async_copy = is_cuda_arch(self.arch) and self.arch.sm_version in {80, 90}
         # TODO: block reduction depth is not used for now.
         # As there still exists some performance issues for block reduction.
         block_reduction_depth = self.prim_func_node.get_tag("block_reduction_depth")


### PR DESCRIPTION
TensorCorePolicy._legalize_info compared the bare compute-capability values reported by CUDA against sm_-prefixed literals. The fallback therefore selected one pipeline stage and disabled asynchronous copies even for SM 80 and SM 90.

Gate the fallback on the normalized numeric sm_version while preserving non-CUDA behavior. Keep the membership at {80, 90}, matching the existing matmul_analysis tag path; do not enable targets above SM 90 without real-machine validation of the pipeline and asynchronous-copy effects.

Constraint: No GPU above SM 90 was available for functional or performance validation, so the supported fallback set remains {80, 90}.
Rejected: Broaden the fallback to additional SM versions | It would exceed the existing tag-path policy, and above-SM-90 behavior has not been validated on hardware.
Confidence: high
Scope-risk: narrow
Directive: Keep fallback and tag-path SM membership aligned until additional architectures have real-machine evidence.
Tested: Ruff check and format; Python syntax compilation; 10-case _legalize_info source behavior harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Gate the `_legalize_info` fallback on normalized numeric `sm_version`.
- Enable 2-stage pipelining and `cp.async` only for CUDA SM 80 and SM 90.
- Preserve explicit `pipeline_stage` and `use_async_copy` tags.
- Preserve non-CUDA behavior and exclude targets above SM 90.

## Testing

- Ruff checks and formatting.
- Python syntax compilation.
- 10-case `_legalize_info` behavior harness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->