### PR TITLE
[ROCm] Validate block-causal attention kernels

### DIFF
--- a/testing/python/amd/test_tilelang_hip_block_causal_attention.py
+++ b/testing/python/amd/test_tilelang_hip_block_causal_attention.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import torch
+
+import tilelang.testing
+
+
+_EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "block_causal_attention"
+sys.path.insert(0, str(_EXAMPLE_DIR))
+
+from block_causal_attention import _run_fixed_case  # noqa: E402
+from block_causal_attention_varlen import _run_varlen_case  # noqa: E402
+
+
+@tilelang.testing.requires_rocm
+def test_block_causal_attention_fixed_forward_backward():
+    _run_fixed_case(
+        batch=1,
+        seq_len=128,
+        heads=1,
+        dim=64,
+        dllm_block=16,
+        dtype=torch.float16,
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_block_causal_attention_varlen_forward_backward():
+    _run_varlen_case(
+        lengths=[128, 256],
+        heads=1,
+        dim=64,
+        dllm_block=16,
+        block_size=64,
+        dtype=torch.float16,
+    )


### PR DESCRIPTION
## Summary

- add ROCm runtime coverage for the existing fixed-length block-causal attention forward and backward kernels
- add ROCm runtime coverage for the existing variable-length packed-sequence forward and backward kernels
- keep the permanent per-PR gate bounded while separately validating every supported dLLM block size on gfx942

## Why

The block-causal attention implementation uses backend-neutral TileLang copies, GEMMs, reductions, and pipelines, but its example tests are CUDA-gated and the ROCm CI job runs only `testing/python`. This left both fixed and variable-length kernels unvalidated on AMD hardware.

## Retained test coverage

- fixed: batch 1, sequence 128, one head, head dimension 64, dLLM block 16
- variable length: sequences 128 and 256, one head, head dimension 64, dLLM block 16, tile size 64
- both cases compare forward output and Q/K/V gradients against the existing PyTorch reference

## Validation

- changed-file pre-commit hooks: passed
- Python syntax compilation: passed
- representative gfx942 run at `df308cfb`: `2228 passed, 1574 skipped`
- exhaustive gfx942 run at `79b16677`: fixed and variable-length forward/backward passed for dLLM block sizes `1, 2, 4, 8, 16, 32, 64`; full suite `2240 passed, 1574 skipped`
- final exact-head CI at `5894110f`: ROCm `2228 passed, 1574 skipped`; CUDA `3359 passed, 446 skipped`; Metal and CuTeDSL passed; Quick Lint, pre-commit.ci, and CodeRabbit passed

No kernel implementation is changed preemptively. The retained tests exercise complete autograd paths without permanently adding the exhaustive matrix runtime to every ROCm CI run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add ROCm-gated tests for fixed-length and variable-length block-causal attention.
- Cover forward and backward paths.
- Compare outputs and Q/K/V gradients with PyTorch references.
- Test FP16 inputs with one head and head dimension 64.
- Cover fixed-length sequences of 128 tokens.
- Cover variable-length sequences of 128 and 256 tokens with tile size 64.
- Validate dLLM block sizes 1, 2, 4, 8, 16, 32, and 64.
- Pre-commit hooks and Python syntax checks pass.
- MI300X gfx942 validation passes with 2,240 tests passed and 1,574 skipped.
- Retain bounded regression cases because the full 14-case matrix takes approximately 6 minutes 24 seconds.
- No kernel implementation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->