### PR TITLE
[ROCm] Support DeepSeek-V3.2 Top-K selector

### DIFF
--- a/examples/deepseek_v32/topk_selector.py
+++ b/examples/deepseek_v32/topk_selector.py
@@ -5,6 +5,7 @@ import tilelang.language as T
 pass_configs = {
     tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
 }
+_RADIX = 1 << 8
 
 
 def convert_to_uint16(x):
@@ -25,12 +26,12 @@ def convert_to_uint32(x):
 
 
 @tilelang.jit(pass_configs=pass_configs)
-def tl_topk_impl(input, index, starts, ends, in_dtype=T.float32, out_dtype=T.int32):
+def tl_topk_impl(input, index, starts, ends, threads=1024, in_dtype=T.float32, out_dtype=T.int32):
     topk = T.const("topk")
     batch = T.dynamic("batch")
     seq_len = T.dynamic("seq_len")
-    RADIX = 1 << 8
-    BLOCK_SIZE = 1024
+    RADIX = _RADIX
+    histogram_size = RADIX * 2 if threads == RADIX else RADIX + 1
     SMEM_INPUT_SIZE = 4096  # assume the threshold bucket size after first pass is less than 4K
 
     input: T.Tensor[(batch, seq_len), in_dtype]
@@ -38,11 +39,13 @@ def tl_topk_impl(input, index, starts, ends, in_dtype=T.float32, out_dtype=T.int
     starts: T.Tensor[(batch), out_dtype]
     ends: T.Tensor[(batch), out_dtype]
 
-    with T.Kernel(batch, threads=BLOCK_SIZE) as (bx):
+    with T.Kernel(batch, threads=threads) as (bx):
         tx = T.get_thread_binding()
 
         s_threshold_bin_id = T.alloc_shared([1], T.int32)
-        s_histogram = T.alloc_shared([RADIX + 1], T.int32)
+        # Pad the 257 logical entries when using 256 threads so T.fill has a
+        # bijective two-element-per-thread layout on the ROCm launch.
+        s_histogram = T.alloc_shared([histogram_size], T.int32)
         s_num_input = T.alloc_shared([2], T.int32)
         s_input_idx = T.alloc_shared([2, SMEM_INPUT_SIZE], T.int32)
 
@@ -71,8 +74,8 @@ def tl_topk_impl(input, index, starts, ends, in_dtype=T.float32, out_dtype=T.int
         T.fill(s_threshold_bin_id, 0)
 
         T.sync_threads()
-        for s in T.serial(T.ceildiv(seq_len, BLOCK_SIZE * 4)):
-            input_base = s * BLOCK_SIZE * 4 + tx * 4
+        for s in T.serial(T.ceildiv(seq_len, threads * 4)):
+            input_base = s * threads * 4 + tx * 4
             for j in T.serial(4):
                 input_idx = input_base + j
                 if input_idx < l_end_idx and input_idx >= l_start_idx and input_idx < seq_len:
@@ -103,9 +106,9 @@ def tl_topk_impl(input, index, starts, ends, in_dtype=T.float32, out_dtype=T.int
         T.sync_threads()
 
         # collect all elements with exponent ≥ threshold
-        for s in T.serial(T.ceildiv(seq_len, BLOCK_SIZE * 4)):
+        for s in T.serial(T.ceildiv(seq_len, threads * 4)):
             T.sync_threads()
-            input_base = s * BLOCK_SIZE * 4 + tx * 4
+            input_base = s * threads * 4 + tx * 4
             for j in T.serial(4):
                 input_idx = input_base + j
                 if input_idx < l_end_idx and input_idx >= l_start_idx and input_idx < seq_len:
@@ -136,10 +139,10 @@ def tl_topk_impl(input, index, starts, ends, in_dtype=T.float32, out_dtype=T.int
             T.sync_threads()
 
             l_num_input = s_num_input[r_idx]
-            for s in T.serial(T.ceildiv(l_num_input, BLOCK_SIZE)):
-                if s * BLOCK_SIZE + tx < l_num_input:
+            for s in T.serial(T.ceildiv(l_num_input, threads)):
+                if s * threads + tx < l_num_input:
                     l_bin_id32 = T.cast(
-                        ((convert_to_uint32(input[bx, s_input_idx[r_idx, s * BLOCK_SIZE + tx]]) >> (24 - round * 8)) & 0xFF), T.int32
+                        ((convert_to_uint32(input[bx, s_input_idx[r_idx, s * threads + tx]]) >> (24 - round * 8)) & 0xFF), T.int32
                     )
                     T.atomic_add(s_histogram[l_bin_id32], 1)
             T.sync_threads()
@@ -166,29 +169,34 @@ def tl_topk_impl(input, index, starts, ends, in_dtype=T.float32, out_dtype=T.int
             l_new_topk = l_new_topk - s_histogram[l_threshold_bin_id + 1]
             T.sync_threads()
 
-            for s in T.serial(T.ceildiv(l_num_input, BLOCK_SIZE)):
+            for s in T.serial(T.ceildiv(l_num_input, threads)):
                 T.sync_threads()
-                if s * BLOCK_SIZE + tx < l_num_input:
+                if s * threads + tx < l_num_input:
                     l_bin_id32 = T.cast(
-                        ((convert_to_uint32(input[bx, s_input_idx[r_idx, s * BLOCK_SIZE + tx]]) >> (24 - round * 8)) & 0xFF), T.int32
+                        ((convert_to_uint32(input[bx, s_input_idx[r_idx, s * threads + tx]]) >> (24 - round * 8)) & 0xFF), T.int32
                     )
                     if l_bin_id32 > l_threshold_bin_id:
                         pos = T.atomic_add(s_histogram[l_bin_id32 + 1], 1, return_prev=True) + l_start_pos
-                        index[bx, pos] = s_input_idx[r_idx, s * BLOCK_SIZE + tx]
+                        index[bx, pos] = s_input_idx[r_idx, s * threads + tx]
                     elif l_bin_id32 == l_threshold_bin_id and l_new_topk > 0:
                         if round == 3:
                             l_out_pos = T.atomic_add(s_histogram[l_bin_id32 + 1], 1, return_prev=True) + l_start_pos
                             if l_out_pos < topk:
-                                index[bx, l_out_pos] = s_input_idx[r_idx, s * BLOCK_SIZE + tx]
+                                index[bx, l_out_pos] = s_input_idx[r_idx, s * threads + tx]
                         else:
                             pos = T.atomic_add(s_num_input[r_idx ^ 1], 1, return_prev=True)
-                            s_input_idx[r_idx ^ 1, pos] = s_input_idx[r_idx, s * BLOCK_SIZE + tx]
+                            s_input_idx[r_idx ^ 1, pos] = s_input_idx[r_idx, s * threads + tx]
 
 
 def tl_topk(input, starts, ends, topk):
     batch, seq_len = input.shape
     indexes = torch.zeros(batch, topk, dtype=torch.int32, device=input.device)
-    tl_topk_impl(input, indexes, starts, ends)
+    # CUDA supports named barriers for the 256-thread radix subgroup. HIP
+    # currently lowers that synchronization to a full workgroup barrier, so
+    # launch exactly the radix participants there to keep every barrier
+    # convergent without changing the tuned CUDA configuration.
+    threads = _RADIX if torch.version.hip is not None else 1024
+    tl_topk_impl(input, indexes, starts, ends, threads=threads)
     return indexes
 
 

--- a/testing/python/amd/test_tilelang_hip_deepseek_v32_topk.py
+++ b/testing/python/amd/test_tilelang_hip_deepseek_v32_topk.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+import torch
+
+import tilelang.testing
+
+
+_EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "deepseek_v32"
+sys.path.insert(0, str(_EXAMPLE_DIR))
+
+from topk_selector import tl_topk  # noqa: E402
+
+
+@tilelang.testing.requires_rocm
+def test_deepseek_v32_topk_selector():
+    torch.manual_seed(0)
+    batch, seq_len, topk = 2, 4096, 256
+    values = torch.randn(batch, seq_len, dtype=torch.float32, device="cuda")
+    starts = torch.tensor([0, 257], dtype=torch.int32, device="cuda")
+    ends = torch.tensor([seq_len, seq_len - 137], dtype=torch.int32, device="cuda")
+
+    indices = tl_topk(values, starts, ends, topk)
+
+    valid = torch.arange(seq_len, device=values.device).unsqueeze(0)
+    valid = (valid >= starts.unsqueeze(1)) & (valid < ends.unsqueeze(1))
+    reference = torch.topk(values.masked_fill(~valid, float("-inf")), topk, dim=-1).indices.to(torch.int32)
+
+    torch.testing.assert_close(
+        torch.sort(indices, dim=-1).values,
+        torch.sort(reference, dim=-1).values,
+        rtol=0,
+        atol=0,
+    )


### PR DESCRIPTION
## Summary

- make the DeepSeek-V3.2 radix Top-K launch size a compile-time parameter
- preserve the tuned 1024-thread CUDA launch
- use the 256 radix-participating threads on ROCm so HIP full-workgroup barriers remain convergent
- pad the HIP histogram allocation to a bijective two-elements-per-thread fill layout while retaining 257 logical bins
- add a gfx942 runtime regression with exact selected-index validation and nonzero valid-range offsets

## Why

The kernel launches 1024 threads but performs its radix prefix scans inside `tx < 256` with `T.sync_threads(3, 256)`. CUDA lowers this to a named 256-thread barrier. HIP currently lowers shared-memory synchronization to block-wide `__syncthreads()` and ignores the barrier id/count, so only one quarter of the workgroup reaches a full-workgroup barrier.

On ROCm, launching exactly the 256 radix participants makes that full-workgroup barrier semantically correct. The 257-entry histogram is padded to 512 physical entries for this launch so `T.fill` receives a bijective layout; only the original 257 logical bins are read or updated. CUDA continues to use the existing 1024-thread configuration and 257-entry allocation.

## Test coverage

- batch 2, sequence length 4096, Top-K 256
- different nonzero `starts`/`ends` ranges per row
- compare sorted TileLang indices exactly against `torch.topk`, which catches missing and duplicate selections without assuming atomic output order

## Validation

- changed-file pre-commit hooks: passed
- Python syntax compilation: passed
- first gfx942 run exposed the non-bijective 257-entry fill layout before launch
- final gfx942 job at `4e67e07a`: `2227 passed, 1574 skipped`; the new exact-index test passed in 4.85s
- final exact-head CI at `4e67e07a`: ROCm `2227 passed, 1574 skipped`; CUDA `3359 passed, 445 skipped`; Metal `45 passed, 4 skipped`; CuTeDSL, Quick Lint, pre-commit.ci, and CodeRabbit passed
