### PR TITLE
[ROCm] Validate attention sink kernels

### DIFF
--- a/testing/python/amd/test_tilelang_hip_attention_sink.py
+++ b/testing/python/amd/test_tilelang_hip_attention_sink.py
@@ -1,0 +1,60 @@
+import sys
+from pathlib import Path
+
+import torch
+
+import tilelang.testing
+
+
+_EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "attention_sink"
+sys.path.insert(0, str(_EXAMPLE_DIR))
+
+import example_gqa_sink_bwd_bhsd as gqa  # noqa: E402
+import example_mha_sink_bwd_bhsd as mha  # noqa: E402
+
+
+def _clone_with_grad(tensor):
+    return tensor.detach().clone().requires_grad_(True)
+
+
+def _assert_forward_backward(module, *, heads, groups=1):
+    torch.manual_seed(0)
+    batch, seq_len, dim = 1, 128, 64
+    kv_heads = heads // groups
+
+    query = torch.randn(batch, heads, seq_len, dim, device="cuda", dtype=torch.float16)
+    key = torch.randn(batch, kv_heads, seq_len, dim, device="cuda", dtype=torch.float16)
+    value = torch.randn_like(key)
+    sinks = torch.randn(heads, device="cuda", dtype=torch.float16)
+    grad = torch.randn_like(query)
+
+    q_tl, k_tl, v_tl, sinks_tl = (_clone_with_grad(t) for t in (query, key, value, sinks))
+    q_ref, k_ref, v_ref, sinks_ref = (_clone_with_grad(t) for t in (query, key, value, sinks))
+
+    if groups == 1:
+        output = module.attention(q_tl, k_tl, v_tl, sinks_tl, None)
+    else:
+        output = module.attention(q_tl, k_tl, v_tl, sinks_tl, None, groups)
+    reference = module.ref_program(q_ref, k_ref, v_ref, sinks_ref, dtype=torch.float16)
+
+    torch.testing.assert_close(output, reference, rtol=1e-2, atol=1e-2)
+
+    output.backward(grad)
+    reference.backward(grad)
+    for actual, expected in (
+        (q_tl.grad, q_ref.grad),
+        (k_tl.grad, k_ref.grad),
+        (v_tl.grad, v_ref.grad),
+        (sinks_tl.grad, sinks_ref.grad),
+    ):
+        torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_rocm
+def test_mha_attention_sink_forward_backward():
+    _assert_forward_backward(mha, heads=1)
+
+
+@tilelang.testing.requires_rocm
+def test_gqa_attention_sink_forward_backward():
+    _assert_forward_backward(gqa, heads=4, groups=2)


### PR DESCRIPTION
## Summary

- add gfx942 runtime coverage for the existing MHA attention-sink forward and backward kernels
- add gfx942 runtime coverage for the existing GQA attention-sink forward and backward kernels
- compare output plus Q/K/V/sink gradients against the existing PyTorch references

## Why

The attention-sink examples are CUDA-gated and the ROCm CI job runs only `testing/python`, so these backend-neutral TileLang kernels previously had no AMD runtime coverage. The bounded fixed-shape tests showed that no kernel implementation change was required.

## Test coverage

- FP16, batch 1, sequence length 128, head dimension 64
- MHA: one query/KV head
- GQA: four query heads, two KV heads
- forward output and Q/K/V/sink gradients

## Validation

- PR head: `100cc28f`; merged as `f797c02a`
- changed-file pre-commit hooks and Python syntax compilation: passed
- gfx942: `2228 passed, 1574 skipped`
- focused MHA forward/backward: passed in 14.49s
- focused GQA forward/backward: passed in 14.11s
- CUDA examples: `74 passed, 9 skipped`
- CUDA test suite: `3359 passed, 446 skipped`
- CodeRabbit: passed with no actionable findings
- Metal remained in progress when the PR was merged

No production kernel implementation was changed.