### PR TITLE
[ROCm] Select feasible flash-decoding tiles

### DIFF
--- a/examples/flash_decoding/example_mha_inference.py
+++ b/examples/flash_decoding/example_mha_inference.py
@@ -2,10 +2,13 @@ import torch
 import torch.nn.functional as F
 import tilelang
 from tilelang.autotuner import *
+from tilelang.carver.arch import get_arch
 import tilelang.language as T
 from functools import partial
 
 num_split = 4
+_KERNEL_THREADS = 128
+_TILE_CANDIDATES = ((128, 64), (64, 64))
 
 
 @tilelang.jit(out_idx=[3])
@@ -27,7 +30,7 @@ def flashattn(batch, heads, seqlen_q, seqlen_kv, dim, is_causal, block_M, block_
         glse = T.alloc_global([batch, heads, num_split, seqlen_q], dtype)
         Output_partial = T.alloc_global(part_shape, dtype)  # [batch, seqlen_q, heads, num_split, dim]
         # split
-        with T.Kernel(T.ceildiv(seqlen_q, block_M), heads * batch, num_split, threads=128) as (bx, by, bz):
+        with T.Kernel(T.ceildiv(seqlen_q, block_M), heads * batch, num_split, threads=_KERNEL_THREADS) as (bx, by, bz):
             Q_shared = T.alloc_shared([block_M, dim], dtype)
             K_shared = T.alloc_shared([block_N, dim], dtype)
             V_shared = T.alloc_shared([block_N, dim], dtype)
@@ -113,7 +116,7 @@ def flashattn(batch, heads, seqlen_q, seqlen_kv, dim, is_causal, block_M, block_
             T.copy(O_shared, Output_partial[bid, mid * block_M : (mid + 1) * block_M, hid, sid, :], disable_tma=True)
 
         # combine
-        with T.Kernel(T.ceildiv(seqlen_q, block_M), heads, batch, threads=128) as (bx, by, bz):
+        with T.Kernel(T.ceildiv(seqlen_q, block_M), heads, batch, threads=_KERNEL_THREADS) as (bx, by, bz):
             po_local = T.alloc_fragment([block_M, dim], dtype)
             o_accum_local = T.alloc_fragment([block_M, dim], accum_dtype)
             o_shared = T.alloc_shared([block_M, dim], dtype)
@@ -153,6 +156,49 @@ def flashattn(batch, heads, seqlen_q, seqlen_kv, dim, is_causal, block_M, block_
             T.copy(o_shared, Output[bz, bx * block_M : (bx + 1) * block_M, by, :], disable_tma=True)
 
     return flashattn_mha_inference
+
+
+def _max_dynamic_shared_memory(kernel):
+    """Return the largest dynamic shared-memory allocation in a compiled module."""
+    allocations = getattr(kernel.adapter, "dynamic_smem_buf", {}).values()
+    return max((int(size) for size in allocations if size is not None), default=0)
+
+
+def _fits_current_hip_device(kernel):
+    """Check generated HIP resources before attempting a potentially invalid launch."""
+    arch = get_arch(kernel.target)
+    dynamic_smem = _max_dynamic_shared_memory(kernel)
+    if dynamic_smem > arch.smem_cap:
+        return False, f"dynamic shared memory {dynamic_smem} exceeds device limit {arch.smem_cap}"
+
+    for name, usage in kernel.resource_usage.items():
+        if usage.n_regs and usage.n_regs * _KERNEL_THREADS >= arch.reg_cap:
+            return False, f"{name} uses {usage.n_regs} VGPRs per thread at the device register-file limit"
+
+    return True, ""
+
+
+def compile_flashattn_for_current_device(batch, heads, seqlen_q, seqlen_kv, dim, is_causal):
+    """Compile the largest feasible MHA tile for the current device.
+
+    CUDA keeps the original 128x64 configuration. HIP candidates are checked
+    against the generated module's actual LDS and VGPR usage before launch so
+    devices with larger resource budgets can retain the larger tile.
+    """
+    rejected = []
+    for block_M, block_N in _TILE_CANDIDATES:
+        kernel = flashattn(batch, heads, seqlen_q, seqlen_kv, dim, is_causal, block_M, block_N)
+        config = {"block_M": block_M, "block_N": block_N}
+        if kernel.target.kind.name != "hip":
+            return kernel, config
+
+        fits, reason = _fits_current_hip_device(kernel)
+        if fits:
+            return kernel, config
+        rejected.append(f"{block_M}x{block_N}: {reason}")
+
+    details = "; ".join(rejected)
+    raise RuntimeError(f"No feasible flash-decoding tile for the current HIP device ({details}).")
 
 
 def ref_program(Q, K, V, causal):
@@ -241,9 +287,8 @@ def main(BATCH=1, H=32, Q_CTX=128, KV_CTX=8192, D_HEAD=128, causal=False):
     total_flops = 2 * flops_per_matmul
     if causal:
         total_flops *= 0.5
-    BLOCK_M = 128
-    BLOCK_N = 64  # if D_HEAD <= 128 else 32
-    kernel = flashattn(BATCH, H, Q_CTX, KV_CTX, D_HEAD, causal, BLOCK_M, BLOCK_N)
+    kernel, config = compile_flashattn_for_current_device(BATCH, H, Q_CTX, KV_CTX, D_HEAD, causal)
+    print(f"Selected tile: {config['block_M']}x{config['block_N']}")
     ref_fn = partial(ref_program, causal=causal)
     profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
     profiler.assert_allclose(ref_fn, rtol=0.01, atol=0.01)

--- a/testing/python/amd/test_tilelang_hip_flash_decoding.py
+++ b/testing/python/amd/test_tilelang_hip_flash_decoding.py
@@ -1,0 +1,32 @@
+import sys
+from functools import partial
+from pathlib import Path
+
+import tilelang
+import tilelang.testing
+
+
+_EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "flash_decoding"
+sys.path.insert(0, str(_EXAMPLE_DIR))
+
+import example_mha_inference as mha  # noqa: E402
+
+
+@tilelang.testing.requires_rocm
+def test_mha_flash_decoding_selects_launchable_tile():
+    """Run the resource-selected MHA kernel against its PyTorch reference."""
+    batch, heads, query_length, kv_length, head_dim = 1, 2, 128, 512, 128
+    kernel, config = mha.compile_flashattn_for_current_device(
+        batch,
+        heads,
+        query_length,
+        kv_length,
+        head_dim,
+        False,
+    )
+
+    assert config in ({"block_M": 128, "block_N": 64}, {"block_M": 64, "block_N": 64})
+    if "gfx942" in str(kernel.target.attrs.get("mcpu", "")):
+        assert config == {"block_M": 64, "block_N": 64}
+    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+    profiler.assert_allclose(partial(mha.ref_program, causal=False), rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
## Summary

- preserve the existing `128x64` flash-decoding MHA tile as the first choice and unchanged CUDA path
- inspect generated HIP LDS and VGPR usage before launch
- fall back to the existing correct `64x64` tile only when the larger tile exceeds the current AMD device's resource budget
- add a gfx942 runtime regression against the PyTorch reference

## Why

`examples/flash_decoding/example_mha_inference.py` currently hardcodes `BLOCK_M=128`, `BLOCK_N=64`. On gfx942 the generated split kernel requires 66,048 bytes of dynamic LDS against a 65,536-byte device limit and reaches the 256-VGPR ceiling, so `hipModuleLaunchKernel` fails with `invalid argument`.

A device-name conditional would unnecessarily freeze smaller tiles onto future AMD GPUs. Instead, this change compiles candidates in descending order and accepts the first whose generated module fits `get_arch(target).smem_cap` and the available register-file budget. CUDA returns the original `128x64` candidate without entering the HIP resource-selection path.

## Test coverage

- batch 1, two heads, query length 128, KV length 512, head dimension 128
- non-causal split MHA path
- assert gfx942 selects `64x64`
- compare output against the existing PyTorch reference

## Validation

- exact head: `33e0223a`
- changed-file pre-commit hooks: passed
- Python syntax compilation: passed
- gfx942 job [`100527389226`](https://github.com/tile-ai/tilelang/actions/runs/33716628301/job/100527389226): passed
  - focused flash-decoding test: passed in 8.73s
  - full suite: 2236 passed, 1574 skipped
- CUDA and Metal: passed
- CodeRabbit: passed with no unresolved review threads
- CuTeDSL CUDA examples: pending

The existing causal split TODO is unchanged and remains out of scope.

Closes #2912
