### PR TITLE
[ROCm] Validate Seer block-sparse attention

### DIFF
--- a/testing/python/amd/test_tilelang_hip_seer_attention.py
+++ b/testing/python/amd/test_tilelang_hip_seer_attention.py
@@ -1,0 +1,77 @@
+import math
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+import tilelang.testing
+
+
+_EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "seer_attention"
+sys.path.insert(0, str(_EXAMPLE_DIR))
+
+import block_sparse_attn_tilelang as seer  # noqa: E402
+
+
+def _reference(query, key, value, block_mask, block_size):
+    query_length = query.shape[-2]
+    kv_length = key.shape[-2]
+    past_length = kv_length - query_length
+
+    full_mask = torch.kron(
+        block_mask.float(),
+        torch.ones(block_size, block_size, device=query.device),
+    ).bool()
+    full_mask = full_mask[..., :kv_length, :kv_length]
+    full_mask = full_mask[..., past_length : past_length + query_length, :]
+
+    query_positions = torch.arange(past_length, past_length + query_length, device=query.device).unsqueeze(1)
+    key_positions = torch.arange(kv_length, device=query.device).unsqueeze(0)
+    full_mask &= key_positions <= query_positions
+
+    scores = torch.einsum("bhsd,bhtd->bhst", query, key) / math.sqrt(query.shape[-1])
+    scores = scores.masked_fill(~full_mask, float("-inf"))
+    return torch.einsum("bhst,bhtd->bhsd", torch.softmax(scores, dim=-1), value)
+
+
+@pytest.mark.parametrize(
+    ("heads", "query_length", "kv_length", "topk"),
+    ((2, 128, 128, 2), (1, 128, 256, 1)),
+    ids=("self-attention", "query-shorter-than-kv"),
+)
+@tilelang.testing.requires_rocm
+def test_seer_block_sparse_attention(heads, query_length, kv_length, topk):
+    """Cover causal self-attention and decode-style Q/KV length mismatch."""
+    torch.manual_seed(0)
+    batch, head_dim, block_size = 1, 64, 64
+    downsample_length = math.ceil(kv_length / block_size)
+
+    query = torch.randn(batch, heads, query_length, head_dim, device="cuda", dtype=torch.float16)
+    key = torch.randn(batch, heads, kv_length, head_dim, device="cuda", dtype=torch.float16)
+    value = torch.randn_like(key)
+
+    mask_scores = torch.randn(
+        batch,
+        heads,
+        downsample_length,
+        downsample_length,
+        device="cuda",
+        dtype=torch.float16,
+    )
+    mask_scores[..., 0] = 100
+    block_mask = seer.get_sparse_attn_mask_from_topk(mask_scores, topk=topk)
+
+    kernel = seer.blocksparse_flashattn(
+        batch,
+        heads,
+        query_length,
+        kv_length,
+        head_dim,
+        downsample_length,
+        is_causal=True,
+    )
+    output = kernel(query, key, value, block_mask.to(torch.int8))
+    reference = _reference(query, key, value, block_mask, block_size)
+
+    torch.testing.assert_close(output, reference, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
## Summary

- add gfx942 runtime coverage for the existing Seer block-sparse attention kernel
- cover causal self-attention and a query-shorter-than-KV decode shape
- compare the TileLang output against a direct PyTorch masked-attention reference

## Why

The Seer TileLang kernel uses backend-neutral copy, GEMM, reduction, and masking operations, but its example test is CUDA-gated and the ROCm CI job runs only `testing/python`. This PR adds bounded AMD runtime coverage and leaves the production kernel unchanged because the exact-head gfx942 run passed without a backend-specific fix.

## Test coverage

- FP16, batch 1, head dimension 64, block size 64
- self-attention: two heads, query/KV length 128, top-2 block mask
- decode-style shape: one head, query length 128, KV length 256, top-1 block mask
- causal masking and output comparison against PyTorch

## Validation

- exact head: `c47a2e94`
- changed-file pre-commit hooks: passed
- Python syntax compilation: passed
- gfx942 job [`100527419589`](https://github.com/tile-ai/tilelang/actions/runs/33716658170/job/100527419589): passed
  - focused Seer cases passed in 4.08s and 3.83s
  - full suite: 2237 passed, 1574 skipped
- CUDA and Metal: passed
- CodeRabbit: passed with no unresolved review threads
- CuTeDSL CUDA examples: pending

Local pytest collection was unavailable because the macOS Python environment does not have PyTorch installed. No production kernel implementation is changed.
