### PR TITLE
[ROCm] Validate linear attention forward and backward

### DIFF
--- a/examples/linear_attention/example_linear_attn_bwd.py
+++ b/examples/linear_attention/example_linear_attn_bwd.py
@@ -9,6 +9,11 @@ from einops import rearrange
 from typing import Optional, Tuple
 
 
+def get_chunk_size() -> int:
+    """Use a smaller chunk on HIP to keep the backward kernel within LDS limits."""
+    return 32 if torch.version.hip is not None else 64
+
+
 @tilelang.jit(pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True})
 def tl_fused_chunk_bwd_kernel(
     B,
@@ -23,7 +28,7 @@ def tl_fused_chunk_bwd_kernel(
         scale = DK**-0.5
     accum_dtype = T.float32
 
-    chunk_size = 64
+    chunk_size = get_chunk_size()
     BK = BV = 64  # Set to 128 can be faster, but has some numerical differences with FLA
     assert S % chunk_size == 0 and DK % BK == 0 and DV % BV == 0
     NK = tilelang.cdiv(DK, BK)
@@ -134,7 +139,7 @@ def ref_program(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, scale: Option
     q, k, v = q.float(), k.float(), v.float()
     if scale is None:
         scale = q.shape[-1] ** -0.5
-    chunk_size = 64
+    chunk_size = get_chunk_size()
     q = rearrange(q, "b (n c) h d -> b h n c d", c=chunk_size) * scale
     k = rearrange(k, "b (n c) h d -> b h n c d", c=chunk_size)
     v = rearrange(v, "b (n c) h d -> b h n c d", c=chunk_size)

--- a/testing/python/amd/test_tilelang_hip_linear_attention.py
+++ b/testing/python/amd/test_tilelang_hip_linear_attention.py
@@ -1,4 +1,5 @@
 import sys
+from math import prod
 from pathlib import Path
 
 import torch
@@ -19,19 +20,25 @@ import example_linear_attn_bwd as linear_attention_bwd  # noqa: E402
 def _assert_launchable(kernel):
     """Report generated HIP resource overflows before the runtime launch."""
     arch = get_arch(kernel.target)
-    dynamic_smem = max(
-        (int(size) for size in kernel.adapter.dynamic_smem_buf.values() if size is not None),
-        default=0,
-    )
-    assert dynamic_smem <= arch.smem_cap, f"dynamic shared memory {dynamic_smem} exceeds device limit {arch.smem_cap}"
+    resource_usage = kernel.resource_usage
 
-    for name, usage in kernel.resource_usage.items():
-        block_size = 1
-        for extent in kernel.adapter.block_info[name]:
-            block_size *= int(extent)
-        assert not usage.n_regs or usage.n_regs * block_size < arch.reg_cap, (
-            f"{name} uses {usage.n_regs} VGPRs per thread at the device register-file limit"
+    for global_var, func in kernel.artifact.device_mod.functions.items():
+        name = global_var.name_hint
+        attrs = func.attrs
+        dynamic_smem = int(attrs["dyn_shared_memory_buf"]) if "dyn_shared_memory_buf" in attrs else 0
+        thread_extent = attrs.get("thread_extent", {})
+        block_size = prod(int(extent) for tag, extent in thread_extent.items() if str(tag).startswith("threadIdx"))
+        usage = resource_usage.get(name)
+
+        assert dynamic_smem <= arch.smem_cap, (
+            f"{name} uses {dynamic_smem} bytes of dynamic shared memory, exceeding the device limit of {arch.smem_cap} bytes"
         )
+        if usage is not None and usage.n_regs:
+            assert usage.n_regs * block_size <= arch.reg_cap, (
+                f"{name} uses {usage.n_regs} VGPRs per thread across {block_size} threads "
+                f"({usage.n_regs * block_size} total), exceeding the device register-file "
+                f"limit of {arch.reg_cap}"
+            )
 
 
 @tilelang.testing.requires_rocm
@@ -88,14 +95,14 @@ def test_fused_chunk_linear_attention_backward():
     _assert_launchable(kernel)
     actual = tuple(torch.zeros_like(query, dtype=torch.float32) for _ in range(3))
     kernel(query, key, value, grad_output, *actual)
-    actual = tuple(grad.to(torch.float16) for grad in actual)
 
-    query_ref = query.detach().clone().requires_grad_(True)
-    key_ref = key.detach().clone().requires_grad_(True)
-    value_ref = value.detach().clone().requires_grad_(True)
+    query_ref = query.float().detach().requires_grad_(True)
+    key_ref = key.float().detach().requires_grad_(True)
+    value_ref = value.float().detach().requires_grad_(True)
     output_ref, _ = linear_attention_bwd.ref_program(query_ref, key_ref, value_ref)
-    output_ref.backward(grad_output)
+    output_ref.backward(grad_output.float())
     expected = (query_ref.grad, key_ref.grad, value_ref.grad)
 
+    assert len(actual) == len(expected) == 3
     for actual_grad, expected_grad in zip(actual, expected):
         torch.testing.assert_close(actual_grad, expected_grad, rtol=1e-2, atol=1e-2)

--- a/testing/python/amd/test_tilelang_hip_linear_attention.py
+++ b/testing/python/amd/test_tilelang_hip_linear_attention.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+import tilelang
+import tilelang.testing
+
+
+_EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "linear_attention"
+sys.path.insert(0, str(_EXAMPLE_DIR))
+
+import example_linear_attn_fwd as linear_attention  # noqa: E402
+
+
+@tilelang.testing.requires_rocm
+def test_fused_chunk_linear_attention_forward():
+    """Validate output and final recurrent state on a bounded gfx942 shape."""
+    torch.manual_seed(0)
+    batch, seq_len, heads, dim = 1, 128, 2, 64
+
+    query = F.normalize(
+        torch.randn(batch, seq_len, heads, dim, device="cuda", dtype=torch.float32),
+        dim=-1,
+    ).to(torch.float16)
+    key = F.normalize(
+        torch.randn(batch, seq_len, heads, dim, device="cuda", dtype=torch.float32),
+        dim=-1,
+    ).to(torch.float16)
+    value = torch.randn_like(key)
+
+    kernel = linear_attention.tl_fused_chunk_fwd_kernel(batch, seq_len, heads, dim, dim)
+    output = torch.zeros(
+        batch,
+        seq_len,
+        heads,
+        dim,
+        device="cuda",
+        dtype=torch.float32,
+    )
+    final_state = kernel(query, key, value, output)
+    output_ref, final_state_ref = linear_attention.ref_program(query, key, value)
+
+    torch.testing.assert_close(output, output_ref, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(final_state, final_state_ref, rtol=1e-2, atol=1e-2)

--- a/testing/python/amd/test_tilelang_hip_linear_attention.py
+++ b/testing/python/amd/test_tilelang_hip_linear_attention.py
@@ -2,12 +2,17 @@ import sys
 from math import prod
 from pathlib import Path
 
+import pytest
 import torch
 import torch.nn.functional as F
 
 import tilelang
 import tilelang.testing
 from tilelang.carver.arch import get_arch
+
+
+if torch.version.hip is None:
+    pytest.skip("DeepSeek linear-attention ROCm tests require HIP", allow_module_level=True)
 
 
 _EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "linear_attention"

--- a/testing/python/amd/test_tilelang_hip_linear_attention.py
+++ b/testing/python/amd/test_tilelang_hip_linear_attention.py
@@ -6,12 +6,32 @@ import torch.nn.functional as F
 
 import tilelang
 import tilelang.testing
+from tilelang.carver.arch import get_arch
 
 
 _EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "linear_attention"
 sys.path.insert(0, str(_EXAMPLE_DIR))
 
 import example_linear_attn_fwd as linear_attention  # noqa: E402
+import example_linear_attn_bwd as linear_attention_bwd  # noqa: E402
+
+
+def _assert_launchable(kernel):
+    """Report generated HIP resource overflows before the runtime launch."""
+    arch = get_arch(kernel.target)
+    dynamic_smem = max(
+        (int(size) for size in kernel.adapter.dynamic_smem_buf.values() if size is not None),
+        default=0,
+    )
+    assert dynamic_smem <= arch.smem_cap, f"dynamic shared memory {dynamic_smem} exceeds device limit {arch.smem_cap}"
+
+    for name, usage in kernel.resource_usage.items():
+        block_size = 1
+        for extent in kernel.adapter.block_info[name]:
+            block_size *= int(extent)
+        assert not usage.n_regs or usage.n_regs * block_size < arch.reg_cap, (
+            f"{name} uses {usage.n_regs} VGPRs per thread at the device register-file limit"
+        )
 
 
 @tilelang.testing.requires_rocm
@@ -31,6 +51,7 @@ def test_fused_chunk_linear_attention_forward():
     value = torch.randn_like(key)
 
     kernel = linear_attention.tl_fused_chunk_fwd_kernel(batch, seq_len, heads, dim, dim)
+    _assert_launchable(kernel)
     output = torch.zeros(
         batch,
         seq_len,
@@ -44,3 +65,37 @@ def test_fused_chunk_linear_attention_forward():
 
     torch.testing.assert_close(output, output_ref, rtol=1e-2, atol=1e-2)
     torch.testing.assert_close(final_state, final_state_ref, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_rocm
+def test_fused_chunk_linear_attention_backward():
+    """Validate query, key, and value gradients on a bounded gfx942 shape."""
+    torch.manual_seed(0)
+    batch, seq_len, heads, dim = 1, 128, 1, 64
+
+    query = F.normalize(
+        torch.randn(batch, seq_len, heads, dim, device="cuda", dtype=torch.float32),
+        dim=-1,
+    ).to(torch.float16)
+    key = F.normalize(
+        torch.randn(batch, seq_len, heads, dim, device="cuda", dtype=torch.float32),
+        dim=-1,
+    ).to(torch.float16)
+    value = torch.randn_like(key)
+    grad_output = torch.randn_like(value)
+
+    kernel = linear_attention_bwd.tl_fused_chunk_bwd_kernel(batch, seq_len, heads, dim, dim)
+    _assert_launchable(kernel)
+    actual = tuple(torch.zeros_like(query, dtype=torch.float32) for _ in range(3))
+    kernel(query, key, value, grad_output, *actual)
+    actual = tuple(grad.to(torch.float16) for grad in actual)
+
+    query_ref = query.detach().clone().requires_grad_(True)
+    key_ref = key.detach().clone().requires_grad_(True)
+    value_ref = value.detach().clone().requires_grad_(True)
+    output_ref, _ = linear_attention_bwd.ref_program(query_ref, key_ref, value_ref)
+    output_ref.backward(grad_output)
+    expected = (query_ref.grad, key_ref.grad, value_ref.grad)
+
+    for actual_grad, expected_grad in zip(actual, expected):
+        torch.testing.assert_close(actual_grad, expected_grad, rtol=1e-2, atol=1e-2)

--- a/testing/python/amd/test_tilelang_hip_linear_attention.py
+++ b/testing/python/amd/test_tilelang_hip_linear_attention.py
@@ -33,7 +33,8 @@ def _assert_launchable(kernel):
         assert dynamic_smem <= arch.smem_cap, (
             f"{name} uses {dynamic_smem} bytes of dynamic shared memory, exceeding the device limit of {arch.smem_cap} bytes"
         )
-        if usage is not None and usage.n_regs:
+        assert usage is not None, f"{name} is missing HIP compiler resource metadata"
+        if usage.n_regs:
             assert usage.n_regs * block_size <= arch.reg_cap, (
                 f"{name} uses {usage.n_regs} VGPRs per thread across {block_size} threads "
                 f"({usage.n_regs * block_size} total), exceeding the device register-file "


### PR DESCRIPTION
## Summary

- add bounded gfx942 runtime tests for the existing fused chunk linear-attention forward and backward kernels
- validate the sequence output, final recurrent state, and query/key/value gradients against the existing PyTorch reference
- report missing HIP resource metadata and LDS/VGPR overflows before kernel launch
- select a 32-token backward chunk on HIP so the generated kernel fits gfx942 LDS, while retaining the existing 64-token CUDA chunk

## Why

The linear-attention examples were gated to CUDA even though their core operations are backend-neutral. Exact-head gfx942 validation proved that the forward kernel runs correctly, while the original backward kernel compiled to 81,920 bytes of dynamic shared memory and exceeded the gfx942 limit of 65,536 bytes.

Reducing only the HIP backward chunk from 64 to 32 lowers its working-set requirement without changing the CUDA default or the mathematical operation. The PyTorch reference uses the same target-specific chunk partition.

## Test coverage

- FP16 inputs with FP32 accumulation
- batch 1, sequence length 128, head dimension 64
- forward: two heads; output tensor and final recurrent state
- backward: one head; query, key, and value gradients
- normalized query/key inputs to match intended linear-attention usage
- FP32 gradient comparison against a direct PyTorch reference
- explicit generated-kernel resource checks before launch

## Validation

- exact head: `25c4c875` on `main` at `021592f4`
- changed-file pre-commit hooks: passed
- Python syntax compilation: passed
- gfx942 job [`100550146608`](https://github.com/tile-ai/tilelang/actions/runs/33724346542/job/100550146608): passed
  - forward: passed in 3.59s
  - backward: passed in 5.22s
  - full suite: 2241 passed, 1574 skipped
- Metal: passed
- CodeRabbit: passed with no unresolved review threads
- CUDA: pending

The previous diagnostic showed that the 64-token HIP backward kernel requested 81,920 bytes of LDS versus the 65,536-byte gfx942 device limit. Local GPU execution is unavailable on macOS.
