### PR TITLE
[ROCm] Support DeepSeek NSA forward and decode

### DIFF
--- a/examples/deepseek_nsa/example_tilelang_nsa_decode.py
+++ b/examples/deepseek_nsa/example_tilelang_nsa_decode.py
@@ -51,7 +51,7 @@ def native_sparse_attention(
     BS = block_S
     BK = BV = block_T
     num_stages = 0
-    threads = 32
+    threads = 64 if torch.version.hip is not None else 32
 
     Q: T.Tensor(q_shape, dtype)  # [batch, 1, heads, dim]
     K: T.Tensor(kv_shape, dtype)  # [batch, seq_len, head_kv, dim]

--- a/examples/deepseek_nsa/example_tilelang_nsa_fwd.py
+++ b/examples/deepseek_nsa/example_tilelang_nsa_fwd.py
@@ -42,7 +42,7 @@ def native_sparse_attention(Q, K, V, BlockIndices, dim, is_causal, scale=None, b
     BS = block_S
     BK = BV = block_T
     num_stages = 2
-    threads = 32
+    threads = 64 if torch.version.hip is not None else 32
 
     Q: T.Tensor(q_shape, dtype)
     K: T.Tensor(kv_shape, dtype)

--- a/testing/python/amd/test_tilelang_hip_deepseek_nsa.py
+++ b/testing/python/amd/test_tilelang_hip_deepseek_nsa.py
@@ -1,0 +1,109 @@
+import sys
+from pathlib import Path
+
+import torch
+
+import tilelang.testing
+
+
+_EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "deepseek_nsa"
+sys.path.insert(0, str(_EXAMPLE_DIR))
+
+import example_tilelang_nsa_decode as nsa_decode  # noqa: E402
+import example_tilelang_nsa_fwd as nsa_forward  # noqa: E402
+from reference import naive_nsa, naive_nsa_simple_inference  # noqa: E402
+
+
+def _inputs(query_length: int):
+    """Create a bounded grouped-query NSA case with one valid selected block."""
+    batch, sequence_length, kv_heads, query_heads, dim = 1, 64, 1, 16, 32
+    selected_blocks, block_size = 1, 32
+
+    query = torch.randn(
+        batch,
+        query_length,
+        query_heads,
+        dim,
+        device="cuda",
+        dtype=torch.float16,
+    )
+    key = torch.randn(batch, sequence_length, kv_heads, dim, device="cuda", dtype=torch.float16)
+    value = torch.randn_like(key)
+    block_indices = torch.zeros(
+        batch,
+        query_length,
+        kv_heads,
+        selected_blocks,
+        device="cuda",
+        dtype=torch.int32,
+    )
+    block_counts = torch.ones(
+        batch,
+        query_length,
+        kv_heads,
+        device="cuda",
+        dtype=torch.int32,
+    )
+    return query, key, value, block_indices, block_counts, block_size
+
+
+@tilelang.testing.requires_rocm
+def test_deepseek_nsa_forward():
+    """Validate causal NSA forward on a wave64 launch."""
+    torch.manual_seed(0)
+    query, key, value, block_indices, block_counts, block_size = _inputs(query_length=64)
+    scale = 0.1
+
+    output = nsa_forward.native_sparse_attention(
+        query,
+        key,
+        value,
+        block_indices,
+        dim=query.shape[-1],
+        is_causal=True,
+        block_size=block_size,
+        groups=query.shape[2] // key.shape[2],
+        selected_blocks=block_indices.shape[-1],
+        scale=scale,
+    )
+    reference = naive_nsa(
+        q=query,
+        k=key,
+        v=value,
+        g_slc=torch.ones(query.shape[:-1], device="cuda", dtype=query.dtype),
+        g_swa=torch.ones(query.shape[:-1], device="cuda", dtype=query.dtype),
+        block_indices=block_indices.to(torch.long),
+        block_counts=block_counts.to(torch.long),
+        block_size=block_size,
+        scale=scale,
+    )
+
+    torch.testing.assert_close(output, reference, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_rocm
+def test_deepseek_nsa_decode():
+    """Validate single-token NSA decode on a wave64 launch."""
+    torch.manual_seed(0)
+    query, key, value, block_indices, block_counts, block_size = _inputs(query_length=1)
+
+    output = nsa_decode.native_sparse_attention(
+        query,
+        key,
+        value,
+        block_indices,
+        dim=query.shape[-1],
+        block_size=block_size,
+        groups=query.shape[2] // key.shape[2],
+        selected_blocks=block_indices.shape[-1],
+    )
+    reference = naive_nsa_simple_inference(
+        q=query,
+        k=key,
+        v=value,
+        block_indices=block_indices.to(torch.long),
+        block_counts=block_counts.to(torch.long),
+        block_size=block_size,
+    )
+
+    torch.testing.assert_close(output, reference, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
## Summary

- select one 64-lane wave for the DeepSeek NSA forward and decode kernels on HIP
- preserve the existing 32-thread CUDA launch configuration
- add bounded gfx942 correctness coverage for causal forward and single-token decode

## Why

The kernels use backend-neutral TileLang copies, GEMMs, reductions, and masking, but both examples hardcoded a 32-thread block. TileLang rejects sub-wavefront HIP blocks on gfx942, whose wavefront size is 64.

## Test coverage

- FP16 grouped-query attention with 16 query heads and one KV head
- sequence length 64, head dimension 32, block size 32
- causal full-sequence forward
- single-token decode
- direct comparison against the existing PyTorch NSA references

## Validation

- exact head: `3af2e119` on `main` at `021592f4`
- changed-file pre-commit hooks: passed
- Python syntax compilation: passed
- gfx942 job [`100542035213`](https://github.com/tile-ai/tilelang/actions/runs/33721620010/job/100542035213): passed
  - forward: passed in 3.08s
  - decode: passed in 2.78s
  - full suite: 2241 passed, 1574 skipped
- CUDA and Metal: passed
- CodeRabbit: passed with no unresolved review threads
- CuTeDSL CUDA examples: pending

Local runtime validation is unavailable because the macOS environment does not provide a GPU-enabled PyTorch runtime.
