### PR TITLE
[BugFix] Fix 256-bit vectorized codegen for fp4/int4/fp16

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -985,7 +985,9 @@ void CodeGenTileLangCUDA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
         os << "int4";
         return;
       } else if (t.lanes() == 64) {
-        os << "int8";
+        // 256 bits; CUDA has no (u)int8 vector type, use (u)longlong4 like
+        // int8x32.
+        os << "longlong4";
         return;
       } else {
         LOG(FATAL) << "Cannot convert type " << t << " to CUDA type!";
@@ -4277,16 +4279,20 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::ldg256())) {
     need_copy_sm100_h_ = true;
     // Explicit 256-bit global memory load: load_global_256(ptr) or
-    // load_global_256_conditional(ptr, pred)
+    // load_global_256_conditional(ptr, pred). The builtin's result dtype is
+    // uint32x8 (ulonglong4), while the pointer argument carries the buffer's
+    // element type, so route through the exact ulonglong4 overload instead of
+    // letting the generic template deduce (and return) the element type.
     ICHECK(!op->args.empty()) << "T.ldg256 expects a pointer argument.";
     if (op->args.size() > 1) {
-      os << "tl::load_global_256_conditional(";
+      os << "tl::load_global_256_conditional((const ulonglong4*)(";
       this->PrintExpr(op->args[0], os);
-      os << ", ";
+      os << "), ";
       this->PrintExpr(op->args[1], os);
     } else {
-      os << "tl::load_global_256(";
+      os << "tl::load_global_256((const ulonglong4*)(";
       this->PrintExpr(op->args[0], os);
+      os << ")";
     }
     os << ")";
   } else if (op->op.same_as(tl::stg32())) {
@@ -5875,6 +5881,22 @@ void CodeGenTileLangCUDA::VisitExpr_(const BroadcastNode *op,
     return;
   }
 
+  // fp4 vectors are nibble-packed structs; make_fp4_e2_<N>_t constructors
+  // only exist up to 32 lanes. Pack one fp4x2 byte and replicate it, which
+  // covers every lane count uniformly (including 64 lanes for 256-bit
+  // vectorization on sm_100+).
+  if (op->dtype.is_float4_e2m1fn() && lanes % 2 == 0) {
+    std::string sval = SSAGetID(PrintExpr(op->value), op->value.dtype());
+    if (lanes == 2) {
+      os << "make_fp4_e2_2_t(" << sval << ", " << sval << ")";
+    } else {
+      os << "tl::broadcast<";
+      PrintType(op->dtype, os);
+      os << ">(make_fp4_e2_2_t(" << sval << ", " << sval << "))";
+    }
+    return;
+  }
+
   // Note that packed 4-bit broadcast cannot trivially fallback to the
   // generic make_<Type>(v, ...) path, as it can emit malformed make_int16_t()
   // calls that cause nvcc compilation errors when lanes==4.
@@ -5924,6 +5946,24 @@ void CodeGenTileLangCUDA::VisitExpr_(const BroadcastNode *op,
           os << ", ";
         os << (op->dtype.is_uint() ? "(uint)" : "(int)");
         emit_packed_field(8);
+      }
+      os << ')';
+      return;
+    } else if (lanes == 64) {
+      // 256-bit carrier is (u)longlong4: combine two 8-nibble 32-bit fields
+      // per 64-bit component. emit_packed_field only works on 32-bit fields
+      // (its non-constant path shifts within an unsigned int).
+      os << "make_";
+      PrintType(op->dtype, os);
+      os << '(';
+      for (int i = 0; i < 4; ++i) {
+        if (i != 0)
+          os << ", ";
+        os << "(unsigned long long)(";
+        emit_packed_field(8);
+        os << ") | ((unsigned long long)(";
+        emit_packed_field(8);
+        os << ") << 32)";
       }
       os << ')';
       return;

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -416,6 +416,23 @@ TL_DEVICE float fast_rcp(float x) {
   asm volatile("rcp.approx.ftz.f32 %0, %1;" : "=f"(ret) : "f"(x));
   return ret;
 }
+
+// Replicate a small repeating unit across a wider vector type, e.g. one
+// packed fp4x2 byte across fp4_e2_64_t. Works for any (V, U) with
+// sizeof(V) % sizeof(U) == 0, so codegen does not need a make_<type>
+// constructor for every lane count.
+template <typename V, typename U> TL_DEVICE V broadcast(const U unit) {
+  static_assert(sizeof(V) % sizeof(U) == 0,
+                "tl::broadcast requires the vector size to be a multiple of "
+                "the unit size");
+  V result;
+  U *parts = reinterpret_cast<U *>(&result);
+#pragma unroll
+  for (int i = 0; i < static_cast<int>(sizeof(V) / sizeof(U)); ++i) {
+    parts[i] = unit;
+  }
+  return result;
+}
 } // namespace tl
 
 // Pack four char values. Build the 32-bit pattern from unsigned bytes: a

--- a/src/tl_templates/cuda/copy_sm100.h
+++ b/src/tl_templates/cuda/copy_sm100.h
@@ -95,20 +95,28 @@ load_global_256_conditional(const ulonglong4 *ptr, bool pred) {
   return ret;
 }
 
-// Generic 256-bit load for FP8 and other types (returns ulonglong4)
+// Generic 256-bit load: returns the pointee type so that assignments to
+// vector structs (fp8_e4_32_t, fp4_e2_64_t, ...) type-check without a
+// hand-written operator= from ulonglong4 on every such type. The load is
+// performed as ulonglong4 and bit-cast back.
 template <typename T>
-__device__ __forceinline__ ulonglong4 load_global_256(const T *ptr) {
+__device__ __forceinline__ T load_global_256(const T *ptr) {
+  static_assert(sizeof(T) == 32,
+                "tl::load_global_256 requires a 32-byte vector type");
   ulonglong4 ret{};
   global_load_256(ret, ptr, true);
-  return ret;
+  return *reinterpret_cast<T *>(&ret);
 }
 
 template <typename T>
-__device__ __forceinline__ ulonglong4 load_global_256_conditional(const T *ptr,
-                                                                  bool pred) {
+__device__ __forceinline__ T load_global_256_conditional(const T *ptr,
+                                                         bool pred) {
+  static_assert(sizeof(T) == 32,
+                "tl::load_global_256_conditional requires a 32-byte vector "
+                "type");
   ulonglong4 ret{};
   global_load_256(ret, ptr, pred);
-  return ret;
+  return *reinterpret_cast<T *>(&ret);
 }
 
 // 256-bit store specialization for ulonglong4
@@ -166,8 +174,11 @@ pack_bfloat16x4(const bfloat16_t x, const bfloat16_t y, const bfloat16_t z,
   return (v0 | (v1 << 16) | (v2 << 32) | (v3 << 48));
 }
 
+// Takes half_t (cutlass::half_t) like __pack_half2 and pack_bfloat16x4:
+// codegen prints fp16 scalars as half_t, which does not implicitly convert
+// to __half.
 __device__ __forceinline__ unsigned long long
-pack_float16x4(const half x, const half y, const half z, const half w) {
+pack_float16x4(const half_t x, const half_t y, const half_t z, const half_t w) {
   unsigned long long v0 = *((unsigned short *)&x);
   unsigned long long v1 = *((unsigned short *)&y);
   unsigned long long v2 = *((unsigned short *)&z);

--- a/src/tl_templates/cuda/cuda_fp4.h
+++ b/src/tl_templates/cuda/cuda_fp4.h
@@ -97,14 +97,6 @@ struct __CUDA_ALIGN__(8) fp4_e2_16_t {
 struct __CUDA_ALIGN__(16) fp4_e2_32_t {
   fp4_e2_16_t x;
   fp4_e2_16_t y;
-
-  TL_DEVICE fp4_e2_32_t &operator=(const ulonglong4 &rhs) {
-    x.x = *(fp4_e2_8_t *)&rhs.x;
-    x.y = *(fp4_e2_8_t *)&rhs.y;
-    y.x = *(fp4_e2_8_t *)&rhs.z;
-    y.y = *(fp4_e2_8_t *)&rhs.w;
-    return *this;
-  }
 };
 
 struct __CUDA_ALIGN__(32) fp4_e2_64_t {

--- a/src/tl_templates/cuda/cuda_fp8.h
+++ b/src/tl_templates/cuda/cuda_fp8.h
@@ -45,14 +45,6 @@ struct __CUDA_ALIGN__(16) fp8_e4_16_t {
 struct __CUDA_ALIGN__(32) fp8_e4_32_t {
   fp8_e4_16_t x;
   fp8_e4_16_t y;
-
-  TL_DEVICE fp8_e4_32_t &operator=(const ulonglong4 &rhs) {
-    x.x = *(fp8_e4_8_t *)&rhs.x;
-    x.y = *(fp8_e4_8_t *)&rhs.y;
-    y.x = *(fp8_e4_8_t *)&rhs.z;
-    y.y = *(fp8_e4_8_t *)&rhs.w;
-    return *this;
-  }
 };
 
 struct __CUDA_ALIGN__(2) fp8_e5_2_t {
@@ -80,14 +72,6 @@ struct __CUDA_ALIGN__(16) fp8_e5_16_t {
 struct __CUDA_ALIGN__(32) fp8_e5_32_t {
   fp8_e5_16_t x;
   fp8_e5_16_t y;
-
-  TL_DEVICE fp8_e5_32_t &operator=(const ulonglong4 &rhs) {
-    x.x = *(fp8_e5_8_t *)&rhs.x;
-    x.y = *(fp8_e5_8_t *)&rhs.y;
-    y.x = *(fp8_e5_8_t *)&rhs.z;
-    y.y = *(fp8_e5_8_t *)&rhs.w;
-    return *this;
-  }
 };
 
 struct __CUDA_ALIGN__(2) fp8_e8_2_t {
@@ -115,14 +99,6 @@ struct __CUDA_ALIGN__(16) fp8_e8_16_t {
 struct __CUDA_ALIGN__(32) fp8_e8_32_t {
   fp8_e8_16_t x;
   fp8_e8_16_t y;
-
-  TL_DEVICE fp8_e8_32_t &operator=(const ulonglong4 &rhs) {
-    x.x = *(fp8_e8_8_t *)&rhs.x;
-    x.y = *(fp8_e8_8_t *)&rhs.y;
-    y.x = *(fp8_e8_8_t *)&rhs.z;
-    y.y = *(fp8_e8_8_t *)&rhs.w;
-    return *this;
-  }
 };
 
 // Pack two fp8_e4_t values.

--- a/testing/python/language/test_tilelang_language_vectorize_matrix.py
+++ b/testing/python/language/test_tilelang_language_vectorize_matrix.py
@@ -1,0 +1,191 @@
+"""Compile matrix over dtype x op x vector width for vectorized global
+memory patterns.
+
+Every cell used to be an independent hand-written case in the codegen
+(make_<type> constructors, operator= from ulonglong4, pack helpers), so a
+new dtype or a wider vector width silently created nvcc-only failures:
+fp4 x 64 lanes, int4 x 64 lanes, and fp16 x 16 lanes all broke when 256-bit
+vectorization was enabled on sm_100+. This matrix compiles every
+combination so the next gap fails in CI instead of on a user's machine.
+
+On targets without 256-bit vectorization (< sm_100) the "256" width params
+compile at 128 bits, which keeps the test portable and still covers the
+128-bit half of the matrix.
+"""
+
+import pytest
+import torch
+import tilelang
+import tilelang.testing
+import tilelang.language as T
+
+MATRIX_DTYPES = [
+    "float4_e2m1fn",
+    "float8_e4m3fn",
+    "float8_e5m2",
+    "float8_e8m0fnu",
+    "float16",
+    "bfloat16",
+    "int8",
+    "uint8",
+    "int4",
+    "uint4",
+    "int32",
+    "float32",
+]
+
+# copy: pure vector load/store, no broadcast.
+# pred_copy: loop-invariant predicate materializes a typed vector temporary
+#   (`condval = tl::load_global_...` assignment) and broadcasts the zero
+#   else-value -- the shape that exposed the fp4/fp16/int4 gaps.
+# fill_one: broadcast of a non-zero constant (exercises packed-nibble
+#   constant folding for 4-bit dtypes).
+MATRIX_OPS = ["copy", "pred_copy", "fill_one"]
+
+
+def _matrix_kernel(dtype, op, disable_256):
+    @tilelang.jit(pass_configs={tilelang.PassConfigKey.TL_DISABLE_VECTORIZE_256: disable_256})
+    def factory():
+        @T.prim_func
+        def kern(
+            src: T.Tensor((128, 128), dtype),
+            predicate: T.Tensor((1,), T.int32),
+            dst: T.Tensor((128, 128), dtype),
+        ):
+            with T.Kernel(1, threads=256):
+                for row, col in T.Parallel(128, 128):
+                    if op == "copy":
+                        dst[row, col] = src[row, col]
+                    elif op == "pred_copy":
+                        dst[row, col] = src[row, col] if predicate[0] != 0 else 0
+                    else:
+                        dst[row, col] = 1
+
+        return kern
+
+    return factory()
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", MATRIX_DTYPES)
+@pytest.mark.parametrize("op", MATRIX_OPS)
+@pytest.mark.parametrize("width", ["128", "256"])
+def test_vectorize_matrix_compiles(dtype, op, width):
+    _matrix_kernel(dtype, op, disable_256=(width == "128"))
+
+
+def _pred_copy_kernel(dtype):
+    @tilelang.jit
+    def factory():
+        @T.prim_func
+        def kern(
+            src: T.Tensor((128, 128), dtype),
+            predicate: T.Tensor((1,), T.int32),
+            dst: T.Tensor((128, 128), dtype),
+        ):
+            with T.Kernel(1, threads=256):
+                for row, col in T.Parallel(128, 128):
+                    dst[row, col] = src[row, col] if predicate[0] != 0 else 0
+
+        return kern
+
+    return factory()
+
+
+def _check_pred_copy_packed(kernel):
+    """Run a predicated copy on byte-backed packed storage and check both
+    predicate branches. src/dst are uint8 views so equality is bitwise."""
+    src = torch.randint(0, 256, (128, 64), dtype=torch.uint8, device="cuda")
+    dst = torch.full((128, 64), 0xEE, dtype=torch.uint8, device="cuda")
+    packed = torch.float4_e2m1fn_x2
+    pred1 = torch.tensor([1], dtype=torch.int32, device="cuda")
+    pred0 = torch.tensor([0], dtype=torch.int32, device="cuda")
+
+    kernel(src.view(packed), pred1, dst.view(packed))
+    torch.cuda.synchronize()
+    assert torch.equal(dst, src)
+
+    kernel(src.view(packed), pred0, dst.view(packed))
+    torch.cuda.synchronize()
+    assert (dst == 0).all()
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.skipif(
+    not hasattr(torch, "float4_e2m1fn_x2"),
+    reason="PyTorch float4_e2m1fn_x2 dtype is unavailable",
+)
+def test_pred_copy_fp4_numeric():
+    """fp4 predicated copy: on sm_100+ this vectorizes to 64 lanes (256 bits)
+    and used to fail to compile (undefined make_fp4_e2_64_t, missing
+    ulonglong4 assignment)."""
+    _check_pred_copy_packed(_pred_copy_kernel("float4_e2m1fn"))
+
+
+@tilelang.testing.requires_cuda
+def test_pred_copy_int4_numeric():
+    """int4 predicated copy: on sm_100+ this vectorizes to 64 lanes and used
+    to emit the nonexistent CUDA type `int8` plus a 64-arg make_int8 call."""
+    kernel = _pred_copy_kernel("int4")
+    src = torch.randint(0, 256, (128, 64), dtype=torch.uint8, device="cuda")
+    dst = torch.full((128, 64), 0xEE, dtype=torch.uint8, device="cuda")
+    pred1 = torch.tensor([1], dtype=torch.int32, device="cuda")
+    pred0 = torch.tensor([0], dtype=torch.int32, device="cuda")
+
+    kernel(src, pred1, dst)
+    torch.cuda.synchronize()
+    assert torch.equal(dst, src)
+
+    kernel(src, pred0, dst)
+    torch.cuda.synchronize()
+    assert (dst == 0).all()
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("fill_value", [1, 5])
+def test_fill_int4_nonzero_numeric(fill_value):
+    """int4 constant fill: checks the packed-nibble constant path (every
+    byte of the destination must hold the value in both nibbles)."""
+
+    @tilelang.jit
+    def factory():
+        @T.prim_func
+        def kern(dst: T.Tensor((128, 128), "int4")):
+            with T.Kernel(1, threads=256):
+                for row, col in T.Parallel(128, 128):
+                    dst[row, col] = fill_value
+
+        return kern
+
+    kernel = factory()
+    dst = torch.full((128, 64), 0xEE, dtype=torch.uint8, device="cuda")
+    kernel(dst)
+    torch.cuda.synchronize()
+    expected = (fill_value & 0xF) | ((fill_value & 0xF) << 4)
+    assert (dst == expected).all()
+
+
+@tilelang.testing.requires_cuda
+def test_fill_fp16_numeric():
+    """fp16 constant fill: at 16 lanes (256 bits) the broadcast goes through
+    tl::pack_float16x4, which used to reject cutlass::half_t arguments."""
+
+    @tilelang.jit
+    def factory():
+        @T.prim_func
+        def kern(dst: T.Tensor((128, 128), "float16")):
+            with T.Kernel(1, threads=256):
+                for row, col in T.Parallel(128, 128):
+                    dst[row, col] = 1.5
+
+        return kern
+
+    kernel = factory()
+    dst = torch.zeros((128, 128), dtype=torch.float16, device="cuda")
+    kernel(dst)
+    torch.cuda.synchronize()
+    assert (dst == 1.5).all()
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

256-bit vectorization (sm_100+) failed to compile for several packed dtypes. Minimal repro — an fp4 predicated copy with a loop-invariant predicate:

```python
for row, col in T.Parallel(128, 128):
    dst[row, col] = src[row, col] if predicate[0] != 0 else 0
```

At 64 lanes this materializes a typed vector temporary and a zero broadcast, hitting two gaps: `condval = tl::load_global_256(...)` has no matching `operator=` (the generic overload returned `ulonglong4`, and `fp4_e2_64_t` never got the hand-written assignment operator — it was copy-pasted onto the 128-bit `fp4_e2_32_t` with a broken body), and the broadcast fallback emits `make_fp4_e2_64_t` with 64 args while the constructors stop at 32 lanes.

A compile sweep over dtype × op × width found the same class of bug in two more places:

- **int4/uint4 × 64 lanes**: `PrintType` emitted the nonexistent CUDA type `(u)int8`, and the packed-nibble broadcast only handled 16/32 lanes.
- **fp16 × 16 lanes**: broadcast calls `tl::pack_float16x4(const half ...)`, but codegen prints fp16 scalars as `cutlass::half_t` (the bf16 variant already took `bfloat16_t`, which is why bf16 worked).

## Approach

Rather than adding one more hand-written case per cell, make the contracts generic so new dtypes/widths don't need per-type glue:

- `tl::load_global_256` / `_conditional` generic overloads now return the pointee type (`static_assert(sizeof(T) == 32)`) and bit-cast internally. Assignment then type-checks for any 32-byte vector struct; the `operator=(ulonglong4)` hacks on `fp8_e{4,5,8}_32_t` become dead and are removed, along with the misplaced/broken `fp4_e2_32_t` one. The `T.ldg256` builtin keeps returning `uint32x8` via an explicit `ulonglong4` pointer cast.
- New `tl::broadcast<V>(unit)` replicates a packed unit across any vector width. fp4 broadcast emits one packed fp4x2 byte + `tl::broadcast`, covering every lane count uniformly (and shrinking the generated source).
- `int4x64` maps to `(u)longlong4` (following the `int8x32` precedent); its broadcast packs two 8-nibble 32-bit fields per 64-bit component.
- `pack_float16x4` takes `half_t`, consistent with `__pack_half2` / `pack_bfloat16x4`.

## Testing

- New `testing/python/language/test_tilelang_language_vectorize_matrix.py`: compile matrix of 12 dtypes × {copy, predicated copy, non-zero fill} × {128b, 256b} (72 cells, all previously-failing ones covered), plus bitwise numeric checks for fp4/int4 predicated copies and int4/fp16 fills. On < sm_100 targets the 256b params compile at 128 bits, so the test stays portable.
- Verified on sm_103a: matrix all green; fp4/fp8(e4m3, e5m2)/int4/fp16 predicated copies bitwise-correct for both predicate values; `test_tilelang_language_ldg.py`, `test_tilelang_language_ldst.py`, `test_tilelang_language_vectorize.py`, `test_tilelang_language_vectorized_cast.py` all pass (109 tests) with `TILELANG_DISABLE_CACHE=1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixes 256-bit vectorized code generation for fp4, int4/uint4, and fp16 on sm_100+.
- Makes `load_global_256` generic for 32-byte vector types.
- Adds width-independent packed-value broadcasting.
- Updates int4/uint4 type mapping and broadcasting.
- Aligns `pack_float16x4` with generated fp16 scalar types.
- Removes obsolete vector assignment operators.

## Testing

- Adds a compile matrix for 12 dtypes, three operations, and 128-/256-bit widths.
- Adds numeric checks for fp4, int4, and fp16.
- Tests pass on sm_103a.

## C++ style / lint notes

- The PR changes C++ code and CUDA headers.
- No evidence indicates changes to rules documented in `docs/developer_guide/cpp_style.md`.
- No C++ API Style Audit warning is reported.
- The changes remove obsolete operators and add template checks. No correctness or build issue is identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->