### PR TITLE
[ROCm] Support wave64 Hadamard transforms

### DIFF
--- a/examples/hadamard_transform/example_hadamard.py
+++ b/examples/hadamard_transform/example_hadamard.py
@@ -49,7 +49,13 @@ def hadamard(A, n, dtype):
     threads = [0, 1, 1, 1, 2, 4, 8, 16, 32, 32, 128, 256, 256, 256, 256, 256][logN]
     target = determine_target("auto", return_object=True)
     is_hip = target.kind.name == "hip"
-    hardware_warp_size = int(target.attrs.get("thread_warp_size", 32))
+    if is_hip:
+        target_warp_size = target.attrs.get("thread_warp_size")
+        if target_warp_size is None:
+            raise RuntimeError(f"Cannot determine the HIP wavefront size for target {target}")
+        hardware_warp_size = int(target_warp_size)
+    else:
+        hardware_warp_size = 32
     if is_hip:
         threads = max(threads, hardware_warp_size)
     thread_elem = max(1, n // threads)  # Each active thread is responsible for a chunk of elements

--- a/examples/hadamard_transform/example_hadamard.py
+++ b/examples/hadamard_transform/example_hadamard.py
@@ -5,7 +5,6 @@ from tilelang.cuda.intrinsics import make_mma_swizzle_layout
 import math
 import argparse
 import torch
-import scipy
 
 
 def is_pow_of_2(n):
@@ -44,12 +43,16 @@ def hadamard(A, n, dtype):
 
     logN = int(math.log2(n))
     threads = [0, 1, 1, 1, 2, 4, 8, 16, 32, 32, 128, 256, 256, 256, 256, 256][logN]
-    thread_elem = n // threads  # Each thread is responsible for a chunk of elements
+    is_hip = torch.version.hip is not None
+    hardware_warp_size = 64 if is_hip else 32
+    if is_hip:
+        threads = max(threads, hardware_warp_size)
+    thread_elem = max(1, n // threads)  # Each active thread is responsible for a chunk of elements
     thread_round = int(math.log2(thread_elem))
 
-    warps = 1 if threads <= 32 else threads // 32
-    warp_round = int(math.log2(threads / warps))
-    warp_size = threads // warps
+    warps = 1 if threads <= hardware_warp_size else threads // hardware_warp_size
+    warp_size = n if is_hip and n < hardware_warp_size else threads // warps
+    warp_round = int(math.log2(warp_size))
 
     block_round = int(math.log2(warps))
 
@@ -59,12 +62,20 @@ def hadamard(A, n, dtype):
     with T.Kernel(b, threads=threads) as bx:
         local = T.alloc_local((thread_elem,), dtype)
         shared = T.alloc_shared((threads, thread_elem_in_smem), dtype)
-        T.annotate_layout({shared: make_mma_swizzle_layout(shared)})
+        if is_hip:
+            T.annotate_layout({shared: tilelang.layout.make_swizzled_layout(shared)})
+        else:
+            T.annotate_layout({shared: make_mma_swizzle_layout(shared)})
         tx = T.get_thread_binding(0)
 
         # 1. Load from HBM to register
-        for i in T.vectorized(thread_elem):
-            local[i] = A[bx, tx * thread_elem + i]
+        if is_hip and n < hardware_warp_size:
+            T.fill(local, 0)
+            if tx < n:
+                local[0] = A[bx, tx]
+        else:
+            for i in T.vectorized(thread_elem):
+                local[i] = A[bx, tx * thread_elem + i]
 
         # 2. Hadamard inside thread, n<=8
         for i in T.serial(thread_round):
@@ -114,8 +125,12 @@ def hadamard(A, n, dtype):
                     local[exchange_base + j] = shared[src_tx, j]
 
         # 5. Write back to HBM
-        for i in T.vectorized(thread_elem):
-            B[bx, tx * thread_elem + i] = local[i]
+        if is_hip and n < hardware_warp_size:
+            if tx < n:
+                B[bx, tx] = local[0]
+        else:
+            for i in T.vectorized(thread_elem):
+                B[bx, tx * thread_elem + i] = local[i]
 
     return B
 
@@ -124,13 +139,17 @@ def ref_program(x: torch.Tensor):
     assert x.ndim == 2
     dim = x.shape[-1]
     assert is_pow_of_2(dim)
-    # Compute the reference in float64: an fp32 matmul may run in reduced
-    # precision depending on the environment (e.g. TF32 is enabled by default
-    # in NGC torch builds). For dim=32768 such a reference deviates from the
-    # exact result by ~1e-1, which exceeds the 1e-2 tolerance below and makes
-    # a correct kernel "fail".
-    H = torch.tensor(scipy.linalg.hadamard(dim, dtype=float), dtype=torch.float64, device=x.device)
-    return (x.double() @ H.T).to(x.dtype)
+    # Compute a matrix-free float64 reference. Materializing the 32768-square
+    # Hadamard matrix would require 8 GiB before accounting for the matmul.
+    result = x.double()
+    half = 1
+    while half < dim:
+        pairs = result.reshape(*x.shape[:-1], -1, 2, half)
+        left = pairs[..., 0, :]
+        right = pairs[..., 1, :]
+        result = torch.cat((left + right, left - right), dim=-1)
+        half *= 2
+    return result.reshape_as(x).to(x.dtype)
 
 
 def main(argv=None):

--- a/examples/hadamard_transform/example_hadamard.py
+++ b/examples/hadamard_transform/example_hadamard.py
@@ -1,5 +1,6 @@
 import tilelang
 import tilelang.language as T
+from tilelang.backend.target import determine_target
 from tilelang.cuda.intrinsics import make_mma_swizzle_layout
 
 import math
@@ -8,11 +9,13 @@ import torch
 
 
 def is_pow_of_2(n):
+    """Return whether ``n`` is a positive power of two."""
     return isinstance(n, int) and n > 0 and (n & (n - 1)) == 0
 
 
 @T.macro
 def warp_shfl(local, buf, thread_elem, warp_size, round):
+    """Apply the Hadamard butterfly rounds handled by one hardware warp."""
     tx = T.get_thread_binding(0)
     for i in T.serial(round):
         tx_stride = 1 << i
@@ -31,6 +34,7 @@ def warp_shfl(local, buf, thread_elem, warp_size, round):
 
 @tilelang.jit
 def hadamard(A, n, dtype):
+    """Build a Hadamard transform specialized for the active accelerator."""
     b = T.const("b")
 
     A: T.Tensor((b, n), dtype)
@@ -43,8 +47,9 @@ def hadamard(A, n, dtype):
 
     logN = int(math.log2(n))
     threads = [0, 1, 1, 1, 2, 4, 8, 16, 32, 32, 128, 256, 256, 256, 256, 256][logN]
-    is_hip = torch.version.hip is not None
-    hardware_warp_size = 64 if is_hip else 32
+    target = determine_target("auto", return_object=True)
+    is_hip = target.kind.name == "hip"
+    hardware_warp_size = int(target.attrs.get("thread_warp_size", 32))
     if is_hip:
         threads = max(threads, hardware_warp_size)
     thread_elem = max(1, n // threads)  # Each active thread is responsible for a chunk of elements
@@ -136,6 +141,7 @@ def hadamard(A, n, dtype):
 
 
 def ref_program(x: torch.Tensor):
+    """Compute a matrix-free float64 Hadamard reference."""
     assert x.ndim == 2
     dim = x.shape[-1]
     assert is_pow_of_2(dim)

--- a/examples/hadamard_transform/example_hadamard.py
+++ b/examples/hadamard_transform/example_hadamard.py
@@ -23,12 +23,12 @@ def warp_shfl(local, buf, thread_elem, warp_size, round):
         sign = (tx >> i) & 1  # get i-th lowest bit of tx, which determines the operation type for shared[tx, :]
         for j in T.Pipelined(thread_elem, num_stages=1):
             buf[j] = T.shfl_sync(
-                # CUDA uses this 32-bit active mask. HIP ignores the mask and
-                # emits __shfl(value, src_lane, width).
-                0xFFFFFFFF,
                 local[j],
                 another_tx % warp_size,
                 warp_size,
+                # CUDA uses this 32-bit active mask. HIP ignores the mask and
+                # emits __shfl(value, src_lane, width).
+                0xFFFFFFFF,
             )
             local[j] = T.if_then_else(sign == 0, local[j] + buf[j], buf[j] - local[j])
 

--- a/examples/hadamard_transform/example_hadamard.py
+++ b/examples/hadamard_transform/example_hadamard.py
@@ -23,7 +23,9 @@ def warp_shfl(local, buf, thread_elem, warp_size, round):
         sign = (tx >> i) & 1  # get i-th lowest bit of tx, which determines the operation type for shared[tx, :]
         for j in T.Pipelined(thread_elem, num_stages=1):
             buf[j] = T.tvm_warp_shuffle(
-                0xFFFFFFFF,  # mask of all threads
+                # CUDA uses this 32-bit active mask. HIP lowering discards the
+                # mask and emits __shfl(value, src_lane, width).
+                0xFFFFFFFF,
                 local[j],
                 another_tx % warp_size,
                 warp_size,

--- a/examples/hadamard_transform/example_hadamard.py
+++ b/examples/hadamard_transform/example_hadamard.py
@@ -22,13 +22,12 @@ def warp_shfl(local, buf, thread_elem, warp_size, round):
         another_tx = tx ^ tx_stride
         sign = (tx >> i) & 1  # get i-th lowest bit of tx, which determines the operation type for shared[tx, :]
         for j in T.Pipelined(thread_elem, num_stages=1):
-            buf[j] = T.tvm_warp_shuffle(
-                # CUDA uses this 32-bit active mask. HIP lowering discards the
-                # mask and emits __shfl(value, src_lane, width).
+            buf[j] = T.shfl_sync(
+                # CUDA uses this 32-bit active mask. HIP ignores the mask and
+                # emits __shfl(value, src_lane, width).
                 0xFFFFFFFF,
                 local[j],
                 another_tx % warp_size,
-                warp_size,
                 warp_size,
             )
             local[j] = T.if_then_else(sign == 0, local[j] + buf[j], buf[j] - local[j])

--- a/testing/python/amd/test_tilelang_hip_hadamard.py
+++ b/testing/python/amd/test_tilelang_hip_hadamard.py
@@ -1,7 +1,6 @@
 import sys
 from pathlib import Path
 
-import pytest
 import torch
 
 import tilelang.language as T
@@ -14,14 +13,15 @@ sys.path.insert(0, str(_EXAMPLE_DIR))
 import example_hadamard  # noqa: E402
 
 
-@pytest.mark.parametrize("dim", [16, 256, 1024, 8192, 32768])
 @tilelang.testing.requires_rocm
-def test_hadamard(dim):
+def test_hadamard():
     """Validate sub-wave, wave, and shared-memory exchange paths on gfx942."""
-    torch.manual_seed(0)
-    input_tensor = torch.randn((2, dim), device="cuda", dtype=torch.float32)
+    for dim in [16, 256, 1024, 8192, 32768]:
+        torch.manual_seed(0)
+        input_tensor = torch.randn((2, dim), device="cuda", dtype=torch.float32)
 
-    output = example_hadamard.hadamard(input_tensor, dim, T.float32)
-    reference = example_hadamard.ref_program(input_tensor)
+        output = example_hadamard.hadamard(input_tensor, dim, T.float32)
+        torch.cuda.synchronize()
+        reference = example_hadamard.ref_program(input_tensor)
 
-    torch.testing.assert_close(output, reference, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(output, reference, atol=1e-2, rtol=1e-2, msg=f"dim={dim}")

--- a/testing/python/amd/test_tilelang_hip_hadamard.py
+++ b/testing/python/amd/test_tilelang_hip_hadamard.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+import tilelang.language as T
+import tilelang.testing
+
+
+_EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "hadamard_transform"
+sys.path.insert(0, str(_EXAMPLE_DIR))
+
+import example_hadamard  # noqa: E402
+
+
+@pytest.mark.parametrize("dim", [16, 256, 1024, 8192, 32768])
+@tilelang.testing.requires_rocm
+def test_hadamard(dim):
+    """Validate sub-wave, wave, and shared-memory exchange paths on gfx942."""
+    torch.manual_seed(0)
+    input_tensor = torch.randn((2, dim), device="cuda", dtype=torch.float32)
+
+    output = example_hadamard.hadamard(input_tensor, dim, T.float32)
+    reference = example_hadamard.ref_program(input_tensor)
+
+    torch.testing.assert_close(output, reference, atol=1e-2, rtol=1e-2)

--- a/testing/python/amd/test_tilelang_hip_hadamard.py
+++ b/testing/python/amd/test_tilelang_hip_hadamard.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import pytest
 import torch
 
 import tilelang.language as T
@@ -14,14 +15,20 @@ import example_hadamard  # noqa: E402
 
 
 @tilelang.testing.requires_rocm
-def test_hadamard():
+@pytest.mark.parametrize("dim", [16, 256, 1024, 8192, 32768])
+def test_hadamard(dim):
     """Validate sub-wave, wave, and shared-memory exchange paths on gfx942."""
-    for dim in [16, 256, 1024, 8192, 32768]:
-        torch.manual_seed(0)
-        input_tensor = torch.randn((2, dim), device="cuda", dtype=torch.float32)
+    torch.manual_seed(0)
+    input_tensor = torch.randn((2, dim), device="cuda", dtype=torch.float32)
 
-        output = example_hadamard.hadamard(input_tensor, dim, T.float32)
-        torch.cuda.synchronize()
-        reference = example_hadamard.ref_program(input_tensor)
+    output = example_hadamard.hadamard(input_tensor, dim, T.float32)
+    torch.cuda.synchronize()
+    reference = example_hadamard.ref_program(input_tensor)
 
-        torch.testing.assert_close(output, reference, atol=1e-2, rtol=1e-2, msg=f"dim={dim}")
+    torch.testing.assert_close(
+        output,
+        reference,
+        atol=1e-2,
+        rtol=1e-2,
+        msg=lambda details: f"dim={dim}: {details}",
+    )


### PR DESCRIPTION
## Summary

- adapt the Hadamard transform to the target-reported HIP wavefront size while preserving the existing CUDA launch behavior
- use the public cross-backend `T.shfl_sync` intrinsic and the backend-neutral shared-memory swizzle on HIP
- support small transforms with a full HIP wave and guarded active lanes
- replace the dense float64 Hadamard reference with a bounded matrix-free transform
- add independent gfx942 correctness coverage across sub-wave, wave, and shared-memory exchange paths

## Why

The example assumed a 32-lane CUDA warp and selected blocks smaller than one gfx942 wavefront. Its newly added CUDA test also materialized a 32768 by 32768 float64 matrix, requiring approximately 8 GiB before the matrix multiplication.

The HIP path now launches at least one target-reported wavefront, computes shuffle groups using that native wave size, and keeps the existing CUDA choices unchanged. The portable shuffle intrinsic retains masked CUDA lowering and emits native HIP `__shfl`. TileLang target normalization supplies wave64 for CDNA/gfx9 and wave32 for RDNA gfx10/gfx11/gfx12. The reference retains float64 accuracy with O(batch times dimension) storage.

## Test coverage

- dimensions 16, 256, 1024, 8192, and 32768 as independent cases
- sub-wave active-lane path
- single-wave shuffle path
- one-round and multi-round shared-memory exchange paths
- direct comparison against the matrix-free float64 reference

## Validation

- exact head: `e28c88cf` on `main` at `021592f4`
- changed-file pre-commit hooks: passed
- Python syntax compilation: passed
- matrix-free reference matched an explicit Sylvester Hadamard matrix for dimensions 2 through 64
- gfx942 job [`100559436388`](https://github.com/tile-ai/tilelang/actions/runs/33727328591/job/100559436388): passed
  - all five focused dimensions passed
  - full suite: 2244 passed, 1574 skipped
- Metal: passed
- CodeRabbit: passed with no unresolved review threads
- CUDA: pending

Local runtime validation is unavailable because the macOS environment does not provide a GPU-enabled PyTorch runtime.
