### PR TITLE
[ROCm] Validate generic Top-K kernel

### DIFF
--- a/testing/python/amd/test_tilelang_hip_topk.py
+++ b/testing/python/amd/test_tilelang_hip_topk.py
@@ -14,12 +14,14 @@ import example_topk  # noqa: E402
 
 @tilelang.testing.requires_rocm
 def test_topk():
-    """Validate the generic Top-K kernel and its autotuned launch on gfx942."""
+    """Validate every generic Top-K thread candidate on gfx942."""
     torch.manual_seed(0)
     logits = torch.rand((64, 64), device="cuda", dtype=torch.float32)
 
-    actual_values, actual_indices = example_topk.tl_topk(logits, 4, blk_m=64)
     expected_values, expected_indices = example_topk.ref_program(logits, 4)
 
-    torch.testing.assert_close(actual_values, expected_values)
-    torch.testing.assert_close(actual_indices, expected_indices)
+    for threads in (128, 256, 512):
+        actual_values, actual_indices = example_topk.tl_topk(logits, 4, blk_m=64, threads=threads)
+
+        torch.testing.assert_close(actual_values, expected_values)
+        torch.testing.assert_close(actual_indices, expected_indices)

--- a/testing/python/amd/test_tilelang_hip_topk.py
+++ b/testing/python/amd/test_tilelang_hip_topk.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+import torch
+
+import tilelang.testing
+
+
+_EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "topk"
+sys.path.insert(0, str(_EXAMPLE_DIR))
+
+import example_topk  # noqa: E402
+
+
+@tilelang.testing.requires_rocm
+def test_topk():
+    """Validate the generic Top-K kernel and its autotuned launch on gfx942."""
+    torch.manual_seed(0)
+    logits = torch.rand((64, 64), device="cuda", dtype=torch.float32)
+
+    actual_values, actual_indices = example_topk.tl_topk(logits, 4, blk_m=64)
+    expected_values, expected_indices = example_topk.ref_program(logits, 4)
+
+    torch.testing.assert_close(actual_values, expected_values)
+    torch.testing.assert_close(actual_indices, expected_indices)


### PR DESCRIPTION
## Summary

- add focused gfx942 correctness coverage for the backend-neutral generic Top-K example
- exercise its configured 128, 256, and 512-thread launch candidates directly
- compare both selected values and indices against `torch.topk`

## Why

The generic Top-K kernel uses TileLang copies, fragment reductions, and parallel loops without PTX, TMA, or CUDA-specific intrinsics, but its example test is CUDA-only. This adds direct ROCm runtime coverage without changing the kernel or CUDA behavior.

## Test coverage

- 64 rows by 64 candidates
- top 4 values and indices
- FP32 inputs
- deterministic comparison against PyTorch

## Validation

- exact head: `0eb5e435` on `main` at `021592f4`
- changed-file pre-commit hooks: passed
- Python syntax compilation: passed
- explicit 128/256/512-thread review coverage: passed changed-file hooks
- gfx942 job [`100546866201`](https://github.com/tile-ai/tilelang/actions/runs/33723158041/job/100546866201): passed
  - focused Top-K test: passed in 6.96s
  - full suite: 2240 passed, 1574 skipped
- CUDA and Metal: passed
- CodeRabbit: passed with no unresolved review threads
- CuTeDSL CUDA examples: pending

Local runtime validation is unavailable because the macOS environment does not provide a GPU-enabled PyTorch runtime.
