### PR TITLE
[ROCm] Support DeepSeek mHC pre and post kernels

### DIFF
--- a/examples/deepseek_mhc/example_mhc_pre.py
+++ b/examples/deepseek_mhc/example_mhc_pre.py
@@ -171,6 +171,17 @@ def mhc_pre_gemm_sqrsum_tilelang(
     with T.Kernel(T.ceildiv(num_tokens, token_block)) as px:
         out_frag = T.alloc_fragment((token_block, 32), T.float32)
         sqrsum_part = T.alloc_fragment((token_block, 4), T.float32)
+        if is_hip:
+            # The MFMA A fragment is replicated across the two output waves,
+            # so it cannot uniquely determine ownership for sqrsum_part.
+            T.annotate_layout(
+                {
+                    sqrsum_part: T.Fragment(
+                        sqrsum_part.shape,
+                        forward_fn=lambda i, j: (i * 4 + j, 0),
+                    )
+                }
+            )
         T.clear(out_frag)
         T.clear(sqrsum_part)
         for pz in T.Pipelined(hc_hidden_size // hidden_block, num_stages=2):
@@ -189,7 +200,11 @@ def mhc_pre_gemm_sqrsum_tilelang(
 
             for jj in T.serial(hidden_block // 4):
                 for i, j in T.Parallel(token_block, 4):
-                    sqrsum_part[i, j] += x_frag[i, jj * 4 + j] * x_frag[i, jj * 4 + j]
+                    if is_hip:
+                        x_value = T.cast(x_smem_16[i, jj * 4 + j], T.float32)
+                    else:
+                        x_value = x_frag[i, jj * 4 + j]
+                    sqrsum_part[i, j] += x_value * x_value
 
             # should be TF32 gemm
             T.gemm(

--- a/examples/deepseek_mhc/example_mhc_pre.py
+++ b/examples/deepseek_mhc/example_mhc_pre.py
@@ -3,6 +3,7 @@ import math
 import tilelang
 import tilelang.language as T
 import torch
+from tilelang.backend.target import determine_target
 
 
 @tilelang.jit(
@@ -30,6 +31,17 @@ def mhc_pre_big_fuse_tilelang(
     num_tokens = T.dynamic("num_tokens")
     hc_mult3 = hc_mult * (2 + hc_mult)
     hidden_block = math.gcd(512, hidden_size)
+    target = determine_target("auto", return_object=True)
+    is_hip = target.kind.name == "hip"
+    if is_hip:
+        target_warp_size = target.attrs.get("thread_warp_size")
+        if target_warp_size is None:
+            raise RuntimeError(f"Cannot determine the HIP wavefront size for target {target}")
+        role_threads = int(target_warp_size)
+        kernel_threads = role_threads * 2
+    else:
+        role_threads = 32
+        kernel_threads = 96
 
     gemm_out_mul: T.Tensor[[n_splits, num_tokens, hc_mult3], T.float32]
     gemm_out_sqrsum: T.Tensor[[n_splits, num_tokens], T.float32]
@@ -41,7 +53,7 @@ def mhc_pre_big_fuse_tilelang(
     comb_mix: T.Tensor[[num_tokens, hc_mult * hc_mult], T.float32]
     layer_input: T.Tensor[[num_tokens, hidden_size], T.bfloat16]
 
-    with T.Kernel(num_tokens, threads=96) as i:
+    with T.Kernel(num_tokens, threads=kernel_threads) as i:
         ##################################################################
         # _pre_norm_fn_fwd_norm
         rms = T.alloc_fragment(1, T.float32)
@@ -59,7 +71,7 @@ def mhc_pre_big_fuse_tilelang(
         mixes_shared = T.alloc_shared(hc_mult3, T.float32)
         T.copy(mixes, mixes_shared)
 
-        if T.get_thread_binding() < 32:
+        if T.get_thread_binding() < role_threads:
             ##################################################################
             # _pre_split_mixes_fwd (post & comb)
             cm = T.alloc_fragment((hc_mult, hc_mult), T.float32)
@@ -146,9 +158,13 @@ def mhc_pre_gemm_sqrsum_tilelang(
     assert hc_mult3 <= 32  # should be 24 usually
     num_tokens = T.dynamic("num_tokens")
     assert hc_hidden_size % hidden_block == 0
+    target = determine_target("auto", return_object=True)
+    is_hip = target.kind.name == "hip"
+    fn_dtype = T.float32 if is_hip else T.tfloat32
+    gemm_dtype = T.bfloat16 if is_hip else T.tfloat32
 
     x: T.Tensor((num_tokens, hc_hidden_size), T.bfloat16)
-    fn: T.Tensor((hc_mult3, hc_hidden_size), T.tfloat32)
+    fn: T.Tensor((hc_mult3, hc_hidden_size), fn_dtype)
     out: T.Tensor((num_tokens, hc_mult3), T.float32)
     sqrsum: T.Tensor((num_tokens), T.float32)
 
@@ -159,7 +175,7 @@ def mhc_pre_gemm_sqrsum_tilelang(
         T.clear(sqrsum_part)
         for pz in T.Pipelined(hc_hidden_size // hidden_block, num_stages=2):
             x_smem_16 = T.alloc_shared((token_block, hidden_block), T.bfloat16)
-            fn_smem = T.alloc_shared((32, hidden_block), T.tfloat32)
+            fn_smem = T.alloc_shared((32, hidden_block), gemm_dtype)
 
             T.annotate_layout({x_smem_16: tilelang.layout.make_swizzled_layout(x_smem_16)})
 
@@ -168,7 +184,7 @@ def mhc_pre_gemm_sqrsum_tilelang(
 
             x_frag_16 = T.alloc_fragment((token_block, hidden_block), T.bfloat16)
             T.copy(x_smem_16, x_frag_16)
-            x_frag = T.alloc_fragment((token_block, hidden_block), T.tfloat32)
+            x_frag = T.alloc_fragment((token_block, hidden_block), gemm_dtype)
             T.copy(x_frag_16, x_frag)
 
             for jj in T.serial(hidden_block // 4):

--- a/testing/python/amd/test_tilelang_hip_deepseek_mhc.py
+++ b/testing/python/amd/test_tilelang_hip_deepseek_mhc.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+import torch
+
+import tilelang.testing
+
+
+_EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "deepseek_mhc"
+sys.path.insert(0, str(_EXAMPLE_DIR))
+
+import example_mhc_post  # noqa: E402
+import example_mhc_pre  # noqa: E402
+
+
+@tilelang.testing.requires_rocm
+def test_mhc_pre():
+    """Validate the wave-aware BF16 mHC pre path on ROCm."""
+    test_data = example_mhc_pre.generate_test_data(n=32, hc_mult=4, hidden_size=256)
+
+    actual = example_mhc_pre.mhc_pre(**test_data)
+    expected = example_mhc_pre.mhc_pre_ref(**test_data)
+
+    for actual_tensor, expected_tensor in zip(actual, expected):
+        torch.testing.assert_close(actual_tensor, expected_tensor, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_rocm
+def test_mhc_post():
+    """Validate the backend-neutral mHC post path on ROCm."""
+    test_data = example_mhc_post.generate_test_data(n=8, h=256, hc_mult=4)
+    output = torch.empty_like(test_data["residual"])
+
+    example_mhc_post.mhc_post_tilelang(
+        test_data["comb_res_mix"],
+        test_data["residual"],
+        test_data["post_layer_mix"].squeeze(-1),
+        test_data["x"],
+        output,
+        test_data["residual"].shape[-2],
+        test_data["residual"].shape[-1],
+    )
+    expected = example_mhc_post.mhc_post_ref(**test_data)
+
+    torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)

--- a/testing/python/amd/test_tilelang_hip_deepseek_mhc.py
+++ b/testing/python/amd/test_tilelang_hip_deepseek_mhc.py
@@ -21,6 +21,7 @@ def test_mhc_pre():
     actual = example_mhc_pre.mhc_pre(**test_data)
     expected = example_mhc_pre.mhc_pre_ref(**test_data)
 
+    assert len(actual) == len(expected) == 3
     for actual_tensor, expected_tensor in zip(actual, expected):
         torch.testing.assert_close(actual_tensor, expected_tensor, rtol=1e-2, atol=1e-2)
 


### PR DESCRIPTION
## Summary

- run the mHC pre split roles on complete target-sized HIP wavefronts while preserving the existing CUDA 96-thread layout
- use BF16 MFMA inputs for the HIP pre GEMM while retaining the existing CUDA TF32 path
- add focused gfx942 correctness coverage for both mHC pre and post kernels

## Why

The CUDA mHC pre path assigns work at a 32-thread boundary inside a 96-thread block and uses `T.tfloat32` GEMM inputs. On CDNA, that splits a native 64-lane wavefront across divergent roles, and TF32 is not an MFMA input type.

The HIP path now uses two complete target-reported wavefronts and converts the FP32 mixing weights to BF16 in shared memory for the MFMA computation. CUDA continues to use the original 96 threads, 32-thread role boundary, and TF32 GEMM inputs.

## Test coverage

- mHC pre with 32 tokens, hidden size 256, and expansion factor 4
- mHC post with 8 tokens, hidden size 256, and expansion factor 4
- comparison against the existing PyTorch references

## Validation

- exact head: `afbf6728` on `main` at `021592f4`
- changed-file pre-commit hooks: passed
- Python syntax compilation: passed
- review-requested output-count assertion: passed changed-file hooks
- gfx942 job [`100553564311`](https://github.com/tile-ai/tilelang/actions/runs/33725376184/job/100553564311): passed
  - mHC pre: passed in 6.29s
  - mHC post: passed in 2.17s
  - full suite: 2241 passed, 1574 skipped
- Metal: passed
- CodeRabbit: passed with no unresolved review threads
- CUDA: pending

Local runtime validation is unavailable because the macOS environment does not provide a GPU-enabled PyTorch runtime.
