### PR TITLE
[ROCm] Validate DeepSeek-V3.2 sparse MLA forward

### DIFF
--- a/testing/python/amd/test_tilelang_hip_deepseek_v32_sparse_mla.py
+++ b/testing/python/amd/test_tilelang_hip_deepseek_v32_sparse_mla.py
@@ -9,12 +9,12 @@ import tilelang.testing
 _EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "deepseek_v32"
 sys.path.insert(0, str(_EXAMPLE_DIR))
 
-import sparse_mla_fwd  # noqa: E402
-
 
 @tilelang.testing.requires_rocm
 def test_deepseek_v32_sparse_mla_forward():
     """Validate the portable sparse MLA forward kernel on CDNA."""
+    import sparse_mla_fwd
+
     torch.manual_seed(0)
     batch, sequence_length, heads, kv_heads = 1, 32, 16, 1
     query_key_dim, value_dim, topk = 576, 512, 32
@@ -49,7 +49,7 @@ def test_deepseek_v32_sparse_mla_forward():
         d_v=value_dim,
         block_I=32,
         num_stages=2,
-        threads=256,
+        threads=64,
     )
     reference = sparse_mla_fwd.ref_sparse_mla_fwd_interface(query, key_value, indices)
 

--- a/testing/python/amd/test_tilelang_hip_deepseek_v32_sparse_mla.py
+++ b/testing/python/amd/test_tilelang_hip_deepseek_v32_sparse_mla.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+
+import torch
+
+import tilelang.testing
+
+
+_EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "deepseek_v32"
+sys.path.insert(0, str(_EXAMPLE_DIR))
+
+import sparse_mla_fwd  # noqa: E402
+
+
+@tilelang.testing.requires_rocm
+def test_deepseek_v32_sparse_mla_forward():
+    """Validate the portable sparse MLA forward kernel on CDNA."""
+    torch.manual_seed(0)
+    batch, sequence_length, heads, kv_heads = 1, 32, 16, 1
+    query_key_dim, value_dim, topk = 576, 512, 32
+
+    query = torch.randn(
+        batch,
+        sequence_length,
+        heads,
+        query_key_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    key_value = torch.randn(
+        batch,
+        sequence_length,
+        kv_heads,
+        query_key_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    indices = (
+        torch.arange(sequence_length, device="cuda", dtype=torch.int32)
+        .reshape(1, 1, 1, sequence_length)
+        .expand(batch, sequence_length, kv_heads, topk)
+        .contiguous()
+    )
+
+    output, _ = sparse_mla_fwd.sparse_mla_fwd_interface(
+        query,
+        key_value,
+        indices,
+        d_v=value_dim,
+        block_I=32,
+        num_stages=2,
+        threads=256,
+    )
+    reference = sparse_mla_fwd.ref_sparse_mla_fwd_interface(query, key_value, indices)
+
+    torch.testing.assert_close(output, reference, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
## Summary

- add focused gfx942 correctness coverage for the portable DeepSeek-V3.2 sparse MLA forward kernel
- use a 32-entry sparse tile and one 64-lane wave to fit the CDNA LDS budget and MFMA layout while exercising BF16 GEMMs, online softmax, and indexed KV loads
- compare the TileLang output with the existing PyTorch reference

## Why

ROCm support for the DeepSeek-V3.2 Top-K selector landed in #3147. This follow-up validates the next kernel in that model path: the non-pipelined sparse MLA forward implementation.

The selected implementation already disables TMA lowering and warp specialization and uses portable `T.copy`, `T.gemm`, and reduction operations. The Hopper-specific pipelined and seesaw variants use `T.tma_copy`, `T.wgmma_gemm`, and `T.ptx_cp_async`, so they are intentionally outside this PR.

## Test coverage

- BF16 sparse MLA forward with 16 query heads and one KV head
- causal indexed attention over 32 query/KV positions
- 32-entry sparse tile on one native 64-lane wave
- comparison against `ref_sparse_mla_fwd_interface` at `rtol=1e-2`, `atol=1e-2`

## Validation

- exact head: `b70acc7451a686e35cd0aff8f6e7cbcb2e9e9618`
- changed-file pre-commit hooks: passed
- Python syntax compilation: passed
- `git diff --check`: passed
- gfx942 job [`100570568816`](https://github.com/tile-ai/tilelang/actions/runs/33730893957/job/100570568816): passed
  - focused sparse MLA forward test: passed in 4.05s
  - full suite: 2244 passed, 1574 skipped
- CUDA job [`100570568798`](https://github.com/tile-ai/tilelang/actions/runs/33730893957/job/100570568798): passed
  - examples suite: 75 passed, 9 skipped
  - CUDA test suite: 3371 passed, 450 skipped
- CuTeDSL CUDA job [`100625922531`](https://github.com/tile-ai/tilelang/actions/runs/33730893957/job/100625922531): passed
  - examples suite: 74 passed, 11 skipped, 2 xpassed
- Metal, Quick Lint, pre-commit.ci, and CodeRabbit: passed

The first gfx942 attempt used four waves for the small 16-by-32 MFMA output tile and failed during layout inference. Matching the test tile to one native wave resolves that invalid partition without changing production kernel code.

Local runtime validation is unavailable because the macOS environment does not provide a GPU-enabled PyTorch runtime.