### PR TITLE
[ROCm] Validate sparse MLA backward with configurable launch tiles

### DIFF
--- a/examples/deepseek_v32/sparse_mla_bwd.py
+++ b/examples/deepseek_v32/sparse_mla_bwd.py
@@ -248,7 +248,20 @@ def bwd(
     return dQ
 
 
-def sparse_mla_bwd(q, kv, o, do, indices, lse, sm_scale=None, is_casual=True, return_kernel=False, delta=None):
+def sparse_mla_bwd(
+    q,
+    kv,
+    o,
+    do,
+    indices,
+    lse,
+    sm_scale=None,
+    is_casual=True,
+    return_kernel=False,
+    delta=None,
+    block_size=32,
+    threads=None,
+):
     assert q.is_contiguous()
     assert kv.is_contiguous()
     assert indices.is_contiguous()
@@ -268,7 +281,24 @@ def sparse_mla_bwd(q, kv, o, do, indices, lse, sm_scale=None, is_casual=True, re
     if delta is None:
         delta = preprocess(o, do)
     dkv = torch.zeros_like(kv, dtype=torch.float32)
-    dq = bwd(q, kv, do, indices, lse, delta, dkv, H, D, D_tail, topk, kv_group, sm_scale, is_casual)
+    dq = bwd(
+        q,
+        kv,
+        do,
+        indices,
+        lse,
+        delta,
+        dkv,
+        H,
+        D,
+        D_tail,
+        topk,
+        kv_group,
+        sm_scale,
+        is_casual,
+        block_size=block_size,
+        threads=threads,
+    )
     dkv = postprocess(dkv, D, D_tail, kv_group)
 
     return dq, dkv

--- a/examples/deepseek_v32/sparse_mla_bwd.py
+++ b/examples/deepseek_v32/sparse_mla_bwd.py
@@ -262,6 +262,10 @@ def sparse_mla_bwd(
     block_size=32,
     threads=None,
 ):
+    """Run sparse MLA backward with a block size compatible with split dKV stores."""
+    if block_size <= 0 or block_size % 2 != 0:
+        raise ValueError("block_size must be a positive even integer")
+
     assert q.is_contiguous()
     assert kv.is_contiguous()
     assert indices.is_contiguous()

--- a/testing/python/amd/test_tilelang_hip_deepseek_v32_sparse_mla_bwd.py
+++ b/testing/python/amd/test_tilelang_hip_deepseek_v32_sparse_mla_bwd.py
@@ -73,6 +73,8 @@ def test_deepseek_v32_sparse_mla_backward():
         output_gradient,
         indices,
         logsumexp,
+        block_size=16,
+        threads=64,
     )
     expected_dq, expected_dkv = sparse_mla_bwd.ref_sparse_mla_bwd_interface(
         query,

--- a/testing/python/amd/test_tilelang_hip_deepseek_v32_sparse_mla_bwd.py
+++ b/testing/python/amd/test_tilelang_hip_deepseek_v32_sparse_mla_bwd.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import pytest
 import torch
 
 import tilelang.testing
@@ -87,3 +88,15 @@ def test_deepseek_v32_sparse_mla_backward():
 
     sparse_mla_bwd.assert_tensors_similar(actual_dq, expected_dq, eps=1e-4, name="dq")
     sparse_mla_bwd.assert_tensors_similar(actual_dkv, expected_dkv, eps=1e-4, name="dkv")
+
+    with pytest.raises(ValueError, match="positive even integer"):
+        sparse_mla_bwd.sparse_mla_bwd(
+            query,
+            key_value,
+            output,
+            output_gradient,
+            indices,
+            logsumexp,
+            block_size=15,
+            threads=64,
+        )

--- a/testing/python/amd/test_tilelang_hip_deepseek_v32_sparse_mla_bwd.py
+++ b/testing/python/amd/test_tilelang_hip_deepseek_v32_sparse_mla_bwd.py
@@ -1,0 +1,87 @@
+import sys
+from pathlib import Path
+
+import torch
+
+import tilelang.testing
+
+
+_EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "deepseek_v32"
+sys.path.insert(0, str(_EXAMPLE_DIR))
+
+
+@tilelang.testing.requires_rocm
+def test_deepseek_v32_sparse_mla_backward():
+    """Validate sparse MLA gradients, including colliding dKV atomics, on CDNA."""
+    import sparse_mla_bwd
+    import sparse_mla_fwd
+
+    torch.manual_seed(0)
+    batch, sequence_length, heads, kv_heads = 1, 32, 16, 1
+    query_key_dim, value_dim, topk = 576, 512, 32
+
+    query = torch.randn(
+        batch,
+        sequence_length,
+        heads,
+        query_key_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+        requires_grad=True,
+    )
+    key_value = torch.randn(
+        batch,
+        sequence_length,
+        kv_heads,
+        query_key_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+        requires_grad=True,
+    )
+    output_gradient = torch.randn(
+        batch,
+        sequence_length,
+        heads,
+        value_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+
+    # Every query visits the same KV positions. The causal mask makes the prefix
+    # valid while still forcing different query blocks to accumulate into the
+    # same dKV elements through T.atomic_addx4.
+    indices = (
+        torch.arange(topk, device="cuda", dtype=torch.int32)
+        .reshape(1, 1, 1, topk)
+        .expand(batch, sequence_length, kv_heads, topk)
+        .contiguous()
+    )
+
+    output, logsumexp = sparse_mla_fwd.sparse_mla_fwd_interface(
+        query,
+        key_value,
+        indices,
+        d_v=value_dim,
+        block_I=32,
+        num_stages=2,
+        threads=64,
+    )
+    actual_dq, actual_dkv = sparse_mla_bwd.sparse_mla_bwd(
+        query,
+        key_value,
+        output,
+        output_gradient,
+        indices,
+        logsumexp,
+    )
+    expected_dq, expected_dkv = sparse_mla_bwd.ref_sparse_mla_bwd_interface(
+        query,
+        key_value,
+        output,
+        output_gradient,
+        indices,
+        logsumexp,
+    )
+
+    sparse_mla_bwd.assert_tensors_similar(actual_dq, expected_dq, eps=1e-4, name="dq")
+    sparse_mla_bwd.assert_tensors_similar(actual_dkv, expected_dkv, eps=1e-4, name="dkv")


### PR DESCRIPTION
## Summary

- add a ROCm-only correctness test for the non-pipelined DeepSeek-V3.2 sparse MLA backward kernel
- compare both `dQ` and `dKV` against the PyTorch autograd reference
- reuse shared causal KV prefixes so multiple query blocks exercise colliding `T.atomic_addx4` updates
- expose optional `block_size` and `threads` wrapper arguments while preserving all existing CUDA defaults
- use a 16-wide, one-wavefront backward tile on ROCm to keep the dynamic shared-memory requirement launchable on gfx942
- reject non-positive or odd block sizes before the split `dKV` store layout can silently omit elements

The test keeps `topk=32`, so the smaller tile executes two sparse blocks and preserves the intended colliding atomic updates. Companion to #3157, which covers the corresponding sparse MLA forward path.

## Validation

- exact head: `b60bebfc6e0ca81446d595025c4da6d834a65d1e`
- `python3 -m py_compile examples/deepseek_v32/sparse_mla_bwd.py testing/python/amd/test_tilelang_hip_deepseek_v32_sparse_mla_bwd.py`
- `/usr/local/bin/pre-commit run --files examples/deepseek_v32/sparse_mla_bwd.py testing/python/amd/test_tilelang_hip_deepseek_v32_sparse_mla_bwd.py`
- `git diff --check`
- gfx942 job [`100585744708`](https://github.com/tile-ai/tilelang/actions/runs/33735529672/job/100585744708): passed
  - focused sparse MLA backward test: passed in 13.72s
  - full suite: 2244 passed, 1574 skipped
- CUDA job [`100585744744`](https://github.com/tile-ai/tilelang/actions/runs/33735529672/job/100585744744): passed
  - examples suite: 75 passed, 9 skipped
  - CUDA test suite: 3371 passed, 450 skipped
- CuTeDSL CUDA job [`100635046075`](https://github.com/tile-ai/tilelang/actions/runs/33735529672/job/100635046075): passed
  - examples suite: 74 passed, 11 skipped, 2 xpassed
- Metal, Quick Lint, pre-commit.ci, and CodeRabbit: passed

ROCm runtime validation is delegated to the repository's gfx942 CI because the local macOS environment has no ROCm device.