### PR TITLE
[Language] Cache dtype.as_torch and demote storage-dtype fallback logs to debug

### DIFF
--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -184,10 +184,6 @@ def __dtype_call__(self: dtype, *args, is_size_var: bool = False) -> tirx.Var:
 
 
 @functools.cache
-def _log_storage_dtype_fallback_once(msg: str) -> None:
-    logger.debug(msg)
-
-
 def __dtype_as_torch__(self: dtype) -> torch.dtype:
     """Convert TileLang dtype to PyTorch dtype."""
     dtype_str = str(self)
@@ -225,15 +221,15 @@ def __dtype_as_torch__(self: dtype) -> torch.dtype:
         )
         return torch.float4_e2m1fn_x2
     elif dtype_str == "float4_e2m1fn":
-        _log_storage_dtype_fallback_once("torch doesn't support float4_e2m1fn, using float4_e2m1fnx2 as storage dtype.")
+        logger.debug("torch doesn't support float4_e2m1fn, using float4_e2m1fnx2 as storage dtype.")
         return torch.float4_e2m1fn_x2 if hasattr(torch, "float4_e2m1fn_x2") else torch.int8
     elif dtype_str == "custom[tfloat32]":
         return torch.float32
     elif dtype_str == "int4":
-        _log_storage_dtype_fallback_once("torch doesn't support int4, using int8 as storage dtype.")
+        logger.debug("torch doesn't support int4, using int8 as storage dtype.")
         return torch.int8
     elif dtype_str == "uint4":
-        _log_storage_dtype_fallback_once("torch doesn't support uint4, using uint8 as storage dtype.")
+        logger.debug("torch doesn't support uint4, using uint8 as storage dtype.")
         return torch.uint8
     elif dtype_str == "handle":
         return None

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -183,7 +183,7 @@ def __dtype_call__(self: dtype, *args, is_size_var: bool = False) -> tirx.Var:
     return call(expr, is_size_var)
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _log_storage_dtype_fallback_once(msg: str) -> None:
     logger.debug(msg)
 

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -1,5 +1,6 @@
 from tilelang import tvm
 from tvm import ir
+import functools
 import torch
 import tvm_ffi
 from typing import Generic, TypeVar, TYPE_CHECKING
@@ -182,6 +183,11 @@ def __dtype_call__(self: dtype, *args, is_size_var: bool = False) -> tirx.Var:
     return call(expr, is_size_var)
 
 
+@functools.cache
+def _log_storage_dtype_fallback_once(msg: str) -> None:
+    logger.debug(msg)
+
+
 def __dtype_as_torch__(self: dtype) -> torch.dtype:
     """Convert TileLang dtype to PyTorch dtype."""
     dtype_str = str(self)
@@ -219,15 +225,15 @@ def __dtype_as_torch__(self: dtype) -> torch.dtype:
         )
         return torch.float4_e2m1fn_x2
     elif dtype_str == "float4_e2m1fn":
-        logger.debug("torch doesn't support float4_e2m1fn, using float4_e2m1fnx2 as storage dtype.")
+        _log_storage_dtype_fallback_once("torch doesn't support float4_e2m1fn, using float4_e2m1fnx2 as storage dtype.")
         return torch.float4_e2m1fn_x2 if hasattr(torch, "float4_e2m1fn_x2") else torch.int8
     elif dtype_str == "custom[tfloat32]":
         return torch.float32
     elif dtype_str == "int4":
-        logger.debug("torch doesn't support int4, using int8 as storage dtype.")
+        _log_storage_dtype_fallback_once("torch doesn't support int4, using int8 as storage dtype.")
         return torch.int8
     elif dtype_str == "uint4":
-        logger.debug("torch doesn't support uint4, using uint8 as storage dtype.")
+        _log_storage_dtype_fallback_once("torch doesn't support uint4, using uint8 as storage dtype.")
         return torch.uint8
     elif dtype_str == "handle":
         return None

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -1,6 +1,5 @@
 from tilelang import tvm
 from tvm import ir
-import functools
 import torch
 import tvm_ffi
 from typing import Generic, TypeVar, TYPE_CHECKING
@@ -183,11 +182,6 @@ def __dtype_call__(self: dtype, *args, is_size_var: bool = False) -> tirx.Var:
     return call(expr, is_size_var)
 
 
-@functools.cache
-def _log_storage_dtype_fallback_once(msg: str) -> None:
-    logger.debug(msg)
-
-
 def __dtype_as_torch__(self: dtype) -> torch.dtype:
     """Convert TileLang dtype to PyTorch dtype."""
     dtype_str = str(self)
@@ -225,15 +219,15 @@ def __dtype_as_torch__(self: dtype) -> torch.dtype:
         )
         return torch.float4_e2m1fn_x2
     elif dtype_str == "float4_e2m1fn":
-        _log_storage_dtype_fallback_once("torch doesn't support float4_e2m1fn, using float4_e2m1fnx2 as storage dtype.")
+        logger.debug("torch doesn't support float4_e2m1fn, using float4_e2m1fnx2 as storage dtype.")
         return torch.float4_e2m1fn_x2 if hasattr(torch, "float4_e2m1fn_x2") else torch.int8
     elif dtype_str == "custom[tfloat32]":
         return torch.float32
     elif dtype_str == "int4":
-        _log_storage_dtype_fallback_once("torch doesn't support int4, using int8 as storage dtype.")
+        logger.debug("torch doesn't support int4, using int8 as storage dtype.")
         return torch.int8
     elif dtype_str == "uint4":
-        _log_storage_dtype_fallback_once("torch doesn't support uint4, using uint8 as storage dtype.")
+        logger.debug("torch doesn't support uint4, using uint8 as storage dtype.")
         return torch.uint8
     elif dtype_str == "handle":
         return None

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -1,5 +1,6 @@
 from tilelang import tvm
 from tvm import ir
+import functools
 import torch
 import tvm_ffi
 from typing import Generic, TypeVar, TYPE_CHECKING
@@ -182,6 +183,11 @@ def __dtype_call__(self: dtype, *args, is_size_var: bool = False) -> tirx.Var:
     return call(expr, is_size_var)
 
 
+@functools.lru_cache(maxsize=None)
+def _log_storage_dtype_fallback_once(msg: str) -> None:
+    logger.debug(msg)
+
+
 def __dtype_as_torch__(self: dtype) -> torch.dtype:
     """Convert TileLang dtype to PyTorch dtype."""
     dtype_str = str(self)
@@ -219,15 +225,15 @@ def __dtype_as_torch__(self: dtype) -> torch.dtype:
         )
         return torch.float4_e2m1fn_x2
     elif dtype_str == "float4_e2m1fn":
-        logger.info("torch doesn't support float4_e2m1fn, using float4_e2m1fnx2 as storage dtype.")
+        _log_storage_dtype_fallback_once("torch doesn't support float4_e2m1fn, using float4_e2m1fnx2 as storage dtype.")
         return torch.float4_e2m1fn_x2 if hasattr(torch, "float4_e2m1fn_x2") else torch.int8
     elif dtype_str == "custom[tfloat32]":
         return torch.float32
     elif dtype_str == "int4":
-        logger.info("torch doesn't support int4, using int8 as storage dtype.")
+        _log_storage_dtype_fallback_once("torch doesn't support int4, using int8 as storage dtype.")
         return torch.int8
     elif dtype_str == "uint4":
-        logger.info("torch doesn't support uint4, using uint8 as storage dtype.")
+        _log_storage_dtype_fallback_once("torch doesn't support uint4, using uint8 as storage dtype.")
         return torch.uint8
     elif dtype_str == "handle":
         return None


### PR DESCRIPTION
## Summary

Every fp4/int4/uint4 dtype-to-torch conversion emitted an info-level log (e.g. `torch doesn't support float4_e2m1fn, using float4_e2m1fnx2 as storage dtype`). Frameworks that query the torch dtype once per tensor end up spamming the console with the same message.

This PR caches `__dtype_as_torch__` itself with `functools.cache` (tvm `DataType` is a value-hashable str subclass, so it is a valid cache key) and lowers the three storage-dtype fallback messages (`float4_e2m1fn`, `int4`, `uint4`) from `info` to `debug`. Caching the conversion means each fallback message is emitted at most once per process even with debug logging enabled, and repeated `as_torch()` calls become a dict lookup.

## Testing

Verified locally that with debug logging enabled, six `dtype('float4_e2m1fn').as_torch()` calls (including a fresh `dtype` instance with the same value) emit the message exactly once and return `torch.float4_e2m1fn_x2`; `int4`/`uint4`/`float16`/`handle` conversions are unchanged; unsupported dtypes (e.g. `float16x2`) still raise `ValueError` on every call since exceptions are not cached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Cache `__dtype_as_torch__` results with `functools.cache`.
- Change fallback messages for `float4_e2m1fn`, `int4`, and `uint4` from `info` to `debug`.
- Preserve fallback dtypes and unsupported-dtype errors.
- Emit each fallback conversion message at most once per process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->