### PR TITLE
[Misc] Expose .agents skills to Claude Code via .claude/skills symlinks

### DIFF
--- a/.claude/skills/tilelang-backend
+++ b/.claude/skills/tilelang-backend
@@ -1,0 +1,1 @@
+../../.agents/skills/tilelang-backend

--- a/.claude/skills/tilelang-build
+++ b/.claude/skills/tilelang-build
@@ -1,0 +1,1 @@
+../../.agents/skills/tilelang-build

--- a/.claude/skills/tilelang-cpp-style
+++ b/.claude/skills/tilelang-cpp-style
@@ -1,0 +1,1 @@
+../../.agents/skills/tilelang-cpp-style

--- a/.claude/skills/tilelang-layout
+++ b/.claude/skills/tilelang-layout
@@ -1,0 +1,1 @@
+../../.agents/skills/tilelang-layout

--- a/.claude/skills/tilelang-semantic
+++ b/.claude/skills/tilelang-semantic
@@ -1,0 +1,1 @@
+../../.agents/skills/tilelang-semantic

--- a/.claude/skills/tilelang-simplification
+++ b/.claude/skills/tilelang-simplification
@@ -1,0 +1,1 @@
+../../.agents/skills/tilelang-simplification

--- a/.claude/skills/tilelang-submit-pr
+++ b/.claude/skills/tilelang-submit-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/tilelang-submit-pr

--- a/.claude/skills/tilelang-tvm-ir
+++ b/.claude/skills/tilelang-tvm-ir
@@ -1,0 +1,1 @@
+../../.agents/skills/tilelang-tvm-ir

--- a/.gitignore
+++ b/.gitignore
@@ -96,8 +96,11 @@ tilelang/jit/adapter/cython/.cycache
 # cache directory for clangd
 .cache/
 
-# claude
+# claude (keep local settings ignored, but track the skills symlinks)
 **/.claude
+!/.claude
+/.claude/*
+!/.claude/skills
 
 # CMake
 cmake-build/


### PR DESCRIPTION
## Summary

The repository keeps its agent skills in the cross-tool `.agents/skills/` directory, but Claude Code only discovers project skills under `.claude/skills/`. This PR adds a per-skill relative symlink in `.claude/skills/` for each of the eight `.agents/skills/` entries, so both conventions share the same `SKILL.md` sources with no duplication.

It also narrows the `.gitignore` rule for `.claude`: the `skills/` subdirectory is now tracked, while local files such as `.claude/settings.local.json` remain ignored.

## Changes

- `.claude/skills/<name>` -> `../../.agents/skills/<name>` symlinks for: tilelang-backend, tilelang-build, tilelang-cpp-style, tilelang-layout, tilelang-semantic, tilelang-simplification, tilelang-submit-pr, tilelang-tvm-ir
- `.gitignore`: re-include `/.claude/skills` while keeping everything else under `.claude/` ignored

## Testing

- `git check-ignore` confirms `.claude/settings.local.json` stays ignored and the skill symlinks are tracked
- Pre-commit passes, including the broken/destroyed symlink checks
- Verified Claude Code picks up the skills from the symlinked directories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added relative symlinks for all eight skills under `.claude/skills/`.
- Reused the existing sources in `.agents/skills/` without duplication.
- Updated `.gitignore` to track `/.claude/skills` while ignoring local Claude settings.

## Testing

- Verified ignore rules.
- Ran pre-commit checks.
- Confirmed Claude Code discovers the symlinked skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->