### PR TITLE
[CUDA] Add 16-bit hpow and hfmod bridges

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -272,6 +272,22 @@ TL_PATCH TL_DEVICE bfloat16_t hnearbyint(const bfloat16_t x) {
   return bfloat16_t(nearbyintf(float(x)));
 }
 
+TL_PATCH TL_DEVICE half_t hpow(const half_t x, const half_t y) {
+  return half_t(powf(float(x), float(y)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hpow(const bfloat16_t x, const bfloat16_t y) {
+  return bfloat16_t(powf(float(x), float(y)));
+}
+
+TL_PATCH TL_DEVICE half_t hfmod(const half_t x, const half_t y) {
+  return half_t(fmodf(float(x), float(y)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hfmod(const bfloat16_t x, const bfloat16_t y) {
+  return bfloat16_t(fmodf(float(x), float(y)));
+}
+
 // TVM lowers 16-bit math ops to CUDA's half-style names (hexp, hlog, ...).
 // TileLang emits cutlass::half_t / bfloat16_t for scalar 16-bit values, while
 // CUDA overloads those names only for native __half / __nv_bfloat16. Kept here

--- a/src/tl_templates/cuda/math.h
+++ b/src/tl_templates/cuda/math.h
@@ -10,7 +10,6 @@
 #define hsin cutlass::fast_sin
 #define hcos cutlass::fast_cos
 #define htanh cutlass::fast_tanh
-#define hpow powf
 
 namespace cutlass {
 // CUTLASS lacks 16-bit overloads for these functions except fast_exp and

--- a/testing/python/language/test_tilelang_language_intrinsics_codegen.py
+++ b/testing/python/language/test_tilelang_language_intrinsics_codegen.py
@@ -155,5 +155,69 @@ def test_half_math_intrinsics(dtype):
         )
 
 
+# (op, lowered h* intrinsic, torch reference, dtypes it can reach codegen on).
+# bfloat16 T.pow is rejected before codegen by an upstream dtype check, so its
+# bridge is not reachable yet (tile-ai/tilelang#2571).
+BINARY_MATH_OPS = (
+    ("fmod", "hfmod", torch.fmod, (T.float16, T.bfloat16)),
+    ("pow", "hpow", torch.pow, (T.float16,)),
+)
+
+
+def binary_math_kernel(op, dtype, N):
+    fn = getattr(T, op)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        C: T.Tensor((N,), dtype),
+        B: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(1, threads=N):
+            i = T.get_thread_binding()
+            # Keep the temporary: it copy-initializes, a store only assigns.
+            value = fn(A[i], C[i])
+            B[i] = value
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    "name, intrinsic, ref_fn, dtype",
+    [(n, h, f, d) for n, h, f, dtypes in BINARY_MATH_OPS for d in dtypes],
+)
+def test_binary_math_intrinsics(name, intrinsic, ref_fn, dtype):
+    N = 128
+    kernel = tilelang.compile(binary_math_kernel(name, dtype, N), target="cuda")
+    body = kernel.get_kernel_source()
+    body = body[body.rindex("__global__") :]
+    assert body.count(f"{intrinsic}(") == 1
+
+    torch_dtype = dtype.as_torch()
+    idx = torch.arange(N, device="cuda", dtype=torch.float32)
+    if name == "fmod":
+        # Both operands take both signs and |A| usually exceeds |C|, so the
+        # remainder is non-trivial and the dividend's sign is exercised. Every
+        # value is exact in float16 and bfloat16.
+        a = ((idx - 64) * 0.25).to(torch_dtype)
+        c = (((idx % 5) - 2.5) * 1.5).to(torch_dtype)
+    else:
+        # [0.5, 1.5) base and [0.5, 2.5) exponent keep pow finite in float16.
+        a = (idx * 0.0078125 + 0.5).to(torch_dtype)
+        c = (idx * 0.015625 + 0.5).to(torch_dtype)
+    b = torch.empty(N, device="cuda", dtype=torch_dtype)
+    kernel(a, c, b)
+
+    ref = ref_fn(a.float(), c.float()).to(torch_dtype)
+    torch.testing.assert_close(
+        b.float(),
+        ref.float(),
+        atol=2e-2,
+        rtol=2e-2,
+        msg=lambda base: f"T.{name} mismatch\n{base}",
+    )
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

`T.fmod` on `float16`/`bfloat16` and variable-exponent `T.pow` on `float16` fail during CUDA compilation:

```text
identifier "hfmod" is undefined
identifier "hpow" is undefined
```

CUDA lowering emits the half-style `hfmod` and `hpow` names for 16-bit operands, and no CUDA toolkit declares either one. Integer-exponent `pow` is unaffected: TileLang expands it into repeated multiplication before lowering.

This is the binary counterpart to #3132, which completed the corresponding unary math bridges.

## Fix

Add `half_t` and `bfloat16_t` overloads for `hpow` and `hfmod`. Each evaluates through `powf` or `fmodf` in float32 and converts the result back, following the existing 16-bit bridge pattern.

Remove `#define hpow powf` from `math.h`: it shadows the new overload at the call site, and compiles only where the result is assigned directly, not where it is materialized.

The `bfloat16_t` `hpow` overload is included for backend completeness. `T.pow` on `bfloat16` remains rejected by an upstream TVM dtype check tracked in #2571; this PR does not change that frontend restriction, so that overload is not yet reachable.

## Tests

Added `T.fmod` on `float16`/`bfloat16` and variable-exponent `T.pow` on `float16` to the 16-bit intrinsics tests. The `fmod` operands take both signs and mostly satisfy `|A| > |C|`, so the remainder is non-trivial.

Verified locally on sm_75 / CUDA 12.4:

* Touched test file: 8 passed.
* Negative control (bridges reverted): all 3 new cases fail with the expected undefined identifiers.
* Related fast-math suites: 125 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added CUDA `hpow` and `hfmod` overloads for `half_t` and `bfloat16_t`.
- Compute through `powf` and `fmodf` in `float32`, then convert results back.
- Removed the conflicting `hpow` macro from `math.h`.
- Added code-generation and numerical tests for supported 16-bit operations.
- Kept `bfloat16` `pow` unavailable at the frontend because of an upstream TVM dtype restriction.

## C++ style / lint notes

- The PR touches CUDA template code covered by the generated-kernel and CUDA-runtime guidance in `cpp_style.md`.
- No documented style rules were changed.
- The “C++ API Style Audit (warning only)” CI step remains relevant.
- No correctness or build issue is identified from the available changes. Any TLCPP003/TLCPP004 findings are advisory unless they indicate an API or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->