### PR TITLE
[BugFix][ROCm] Resolve hipcc robustly instead of trusting bare PATH lookup

### DIFF
--- a/tilelang/contrib/hipcc.py
+++ b/tilelang/contrib/hipcc.py
@@ -15,7 +15,8 @@ from tilelang import tvm as tvm
 from tilelang.env import env
 from tvm.contrib import utils
 from tvm.base import py_str
-from tvm.contrib.rocm import get_rocm_arch, find_rocm_path
+
+from .rocm import find_hipcc, find_rocm_path, get_rocm_arch
 
 from .hip_resource_info import filter_and_record, hipcc_remark_flag
 
@@ -73,7 +74,7 @@ def compile_hip(code, target_format="hsaco", arch=None, options=None, path_targe
         out_file.write(code)
 
     file_target = path_target if path_target else temp_target
-    cmd = ["hipcc"]
+    cmd = [find_hipcc()]
     cmd += ["-O3", "-c"]
     # Always include line info for better profiling and mapping
     cmd += ["-gline-tables-only"]

--- a/tilelang/contrib/rocm.py
+++ b/tilelang/contrib/rocm.py
@@ -17,7 +17,9 @@
 """Utility for ROCm backend"""
 
 # ruff: noqa
+import logging
 import re
+import shutil
 import subprocess
 import os
 from os.path import join, exists
@@ -28,6 +30,8 @@ import tvm.runtime
 import tvm.target
 
 from tvm.contrib import utils
+
+logger = logging.getLogger(__name__)
 
 
 def find_lld(required=True):
@@ -264,6 +268,81 @@ def get_rocm_arch(rocm_path="/opt/rocm"):
         return gpu_arch
 
 
+# Well-known ROCm install prefix used as the last-resort hipcc candidate.
+# Module-level so tests can point it at a scratch toolchain.
+DEFAULT_ROCM_PATH = "/opt/rocm"
+
+
+def _hipcc_toolchain_prefix(hipcc_path):
+    """Return the toolchain prefix a hipcc binary belongs to ({prefix}/bin/hipcc)."""
+    return os.path.dirname(os.path.dirname(os.path.realpath(hipcc_path)))
+
+
+def _hip_headers_exist(prefix):
+    """Whether a toolchain prefix carries the public HIP headers."""
+    return exists(join(prefix, "include", "hip", "hip_runtime.h"))
+
+
+def _which_all(cmd):
+    """All resolutions of ``cmd`` across PATH entries, in PATH order."""
+    results = []
+    for path_dir in os.environ.get("PATH", "").split(os.pathsep):
+        if not path_dir:
+            continue
+        found = shutil.which(cmd, path=path_dir)
+        if found:
+            results.append(found)
+    return results
+
+
+_warned_incomplete_hipcc = set()
+
+
+def find_hipcc():
+    """Resolve the hipcc executable to invoke for JIT compilation.
+
+    Resolution order:
+        1. ``$ROCM_PATH/bin/hipcc`` -- an explicit ROCM_PATH is honored as-is.
+        2. every ``hipcc`` on PATH, in PATH order.
+        3. ``/opt/rocm/bin/hipcc``.
+
+    Candidates from 2 and 3 are only accepted when their toolchain prefix
+    carries the public HIP headers (``include/hip/hip_runtime.h``). Partial
+    toolchains without headers exist in the wild (e.g. the preview compiler
+    that some ROCm 7 installs prepend to PATH) and fail on any TileLang
+    kernel; skipping them lets a complete sibling install win. If no
+    candidate validates, the first existing one is returned so the compiler
+    can report its own error.
+
+    Returns
+    -------
+    path : str
+        Path to the hipcc executable.
+    """
+    rocm_path = os.environ.get("ROCM_PATH")
+    if rocm_path:
+        explicit = join(rocm_path, "bin", "hipcc")
+        if exists(explicit):
+            return explicit
+
+    candidates = _which_all("hipcc") + [join(DEFAULT_ROCM_PATH, "bin", "hipcc")]
+    candidates = [c for c in dict.fromkeys(candidates) if exists(c)]
+    for candidate in candidates:
+        prefix = _hipcc_toolchain_prefix(candidate)
+        if _hip_headers_exist(prefix):
+            return candidate
+        if candidate not in _warned_incomplete_hipcc:
+            _warned_incomplete_hipcc.add(candidate)
+            logger.warning(
+                "Skipping hipcc at %s: no HIP headers under %s (incomplete HIP toolchain); trying the next candidate. Set ROCM_PATH to override.",
+                candidate,
+                prefix,
+            )
+    if candidates:
+        return candidates[0]
+    raise RuntimeError("Cannot find hipcc. Install ROCm or set ROCM_PATH to a ROCm SDK containing bin/hipcc.")
+
+
 def find_rocm_path():
     """Utility function to find ROCm path
 
@@ -274,13 +353,12 @@ def find_rocm_path():
     """
     if "ROCM_PATH" in os.environ:
         return os.environ["ROCM_PATH"]
-    cmd = ["which", "hipcc"]
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    (out, _) = proc.communicate()
-    out = out.decode("utf-8").strip()
-    if proc.returncode == 0:
-        return os.path.realpath(os.path.join(out, "../.."))
-    rocm_path = "/opt/rocm"
-    if os.path.exists(os.path.join(rocm_path, "bin/hipcc")):
-        return rocm_path
+    try:
+        hipcc = find_hipcc()
+    except RuntimeError:
+        hipcc = None
+    if hipcc is not None:
+        return _hipcc_toolchain_prefix(hipcc)
+    if os.path.exists(os.path.join(DEFAULT_ROCM_PATH, "bin/hipcc")):
+        return DEFAULT_ROCM_PATH
     raise RuntimeError("Cannot find ROCm path")

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -194,8 +194,13 @@ def _find_rocm_home() -> str:
     if rocm_home is None:
         rocmcc_path = shutil.which("hipcc")
         if rocmcc_path is not None:
-            rocm_home = os.path.dirname(os.path.dirname(rocmcc_path))
-        else:
+            candidate = os.path.dirname(os.path.dirname(os.path.realpath(rocmcc_path)))
+            # Only trust a PATH-derived prefix when it carries the public HIP
+            # headers; partial toolchains without them exist in the wild (e.g.
+            # the preview compiler some ROCm 7 installs prepend to PATH).
+            if os.path.exists(os.path.join(candidate, "include", "hip", "hip_runtime.h")):
+                rocm_home = candidate
+        if rocm_home is None:
             rocm_home = "/opt/rocm"
             if not os.path.exists(rocm_home):
                 rocm_home = None

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -17,7 +17,7 @@ from tilelang.contrib.nvcc import (
     get_nvcc_compiler,
     get_target_arch_and_code,
 )
-from tilelang.contrib.rocm import find_rocm_path, get_rocm_arch
+from tilelang.contrib.rocm import find_hipcc, find_rocm_path, get_rocm_arch
 from tilelang.env import TILELANG_TEMPLATE_PATH
 from tilelang.contrib.hip_resource_info import filter_and_record
 
@@ -128,7 +128,7 @@ class LibraryGenerator:
             rocm_path = find_rocm_path()
             arch = target_get_mcpu(target) or get_rocm_arch(rocm_path)
             command = [
-                "hipcc",
+                find_hipcc(),
                 "-std=c++17",
                 "-fPIC",
                 f"--offload-arch={arch}",

--- a/tilelang/rocm/target.py
+++ b/tilelang/rocm/target.py
@@ -87,7 +87,7 @@ def check_hip_availability() -> bool:
         bool: True if HIP is available, False otherwise.
     """
     try:
-        from tvm.contrib import rocm
+        from tilelang.contrib import rocm
 
         rocm.find_rocm_path()
         return True


### PR DESCRIPTION
## Summary

TileLang invokes `hipcc` straight from PATH (`compile_hip` and the JIT library generator), and `find_rocm_path()` derives the ROCm root from `which hipcc`. Partial HIP toolchains without the public headers exist in the wild — e.g. the preview compiler that some ROCm 7 installs prepend to PATH via `/etc/profile.d/rocm.sh` (`/opt/rocm/core-7.14/bin/hipcc`, whose clang only searches `core-7.14/include`, which has no `hip/` subtree). On such hosts every TileLang kernel fails with:

```
fatal error: 'hip/hip_runtime.h' file not found
```

even though a complete install sits right there at `/opt/rocm`. Since the Linux wheel is a fat CUDA+ROCm wheel, this is the first thing a ROCm user can hit after `pip install tilelang`. Our own CI already works around it by prepending `/opt/rocm/bin` to PATH.

## Fix

Add `find_hipcc()` to `tilelang.contrib.rocm` with the following resolution order:

1. `$ROCM_PATH/bin/hipcc` — an explicit `ROCM_PATH` is honored as-is;
2. every `hipcc` on PATH, in PATH order;
3. `/opt/rocm/bin/hipcc`.

Candidates from 2 and 3 are accepted only when their toolchain prefix carries the public HIP headers (`include/hip/hip_runtime.h`), following symlinks so versioned installs (`/opt/rocm -> /opt/rocm-x.y`) validate against the real prefix. Skipped candidates log a one-shot warning. If no candidate validates, the first existing one is returned so the compiler reports its own error (legacy behavior preserved).

`compile_hip` and `LibraryGenerator` now invoke the resolved executable, and `find_rocm_path()`, `env.ROCM_HOME`, and `check_hip_availability()` share the same validated resolution (`tilelang/contrib/hipcc.py` also switches from `tvm.contrib.rocm` to the hardened tilelang helpers).

## Testing

- MI350X (gfx950, ROCm 7.0.2) host with the broken preview toolchain first on PATH: GEMM JIT + correctness now pass with the stock environment (previously required PATH surgery); `ROCM_PATH` override and clean-PATH runs unchanged.
- H100 (CUDA) regression: unaffected.