### PR TITLE
[CI] Validate built wheels on GPU runners in the Dist workflow

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -19,6 +19,8 @@ on:
       - VERSION
       - version_provider.py
       - .github/workflows/dist.yml
+      # Exercised by the GPU wheel-test job below.
+      - maint/scripts/smoke_test_wheel.py
       # Type aliases can affect package import/build behavior.
       - tilelang/_typing.py
   release:
@@ -357,6 +359,153 @@ jobs:
           name: wheels-${{ matrix.target.python_version }}-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target.toolkit }}
           path: wheelhouse/*.whl
           if-no-files-found: error
+
+  test-wheels-gpu:
+    name: Test built wheels with ${{ matrix.target.toolkit }} (on ${{ matrix.target.name }})
+    # The build runners have no GPU, so nothing above proves the built wheels
+    # actually launch kernels: the Linux wheels are fat CUDA+ROCm builds and
+    # neither half was ever executed. This job installs the built wheel on
+    # self-hosted GPU runners and runs a real kernel on each backend. Wheel
+    # artifacts are only uploaded outside PRs (or for [Release] PRs), so gate
+    # this job the same way as the "Upload wheels" step. It is deliberately
+    # not in the needs-chain of publish-pypi: an offline self-hosted runner
+    # must not be able to block a release.
+    if: |
+      github.repository_owner == 'tile-ai' &&
+      (github.event_name != 'pull_request' || contains(github.event.pull_request.title, '[Release]'))
+    needs: [build-wheels]
+    strategy:
+      matrix:
+        target:
+          # Both consume the Linux x86_64 wheel built by the CUDA-13.0 leg above.
+          - { tags: [self-hosted, nvidia], name: self-hosted-nvidia, toolkit: CUDA-13.0, python_version: "3.12" }
+          - { tags: [self-hosted, amd, gfx942], name: self-hosted-amd-gfx942, toolkit: ROCm-7.2, python_version: "3.12" }
+      fail-fast: false
+    timeout-minutes: 60
+    runs-on: ${{ matrix.target.tags }}
+
+    steps:
+      - name: Checkout repository
+        # Only needed for maint/scripts/smoke_test_wheel.py; the wheel under
+        # test comes from the build-wheels artifact.
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Set environment (self-hosted runners)
+        run: |
+          # Hide sensitive data in logs for self-hosted runners
+          if [[ -n "${{ secrets.SECRET_PATH_PREFIXES }}" ]]; then
+            echo "::add-mask::${{ secrets.SECRET_PATH_PREFIXES }}"
+            # Colon separated list of secrets to mask
+            for secret in $(echo "${{ secrets.SECRET_PATH_PREFIXES }}" | tr ':' '\n'); do
+              echo "::add-mask::${secret}"
+            done
+          fi
+
+      - name: Set environment (CUDA)
+        if: contains(matrix.target.toolkit, 'CUDA')
+        run: |
+          TOOLKIT="${{ matrix.target.toolkit }}"
+          CUDA_VERSION="${TOOLKIT##*-}"
+          CUDA_VERSION_MAJMIN="$(echo "${CUDA_VERSION}" | cut -d '.' -f-2)"
+          CUDA_VERSION_MAJMIN_NODOT="${CUDA_VERSION_MAJMIN//./}"
+          if [[ "${TOOLKIT}" == "Nightly-"* ]]; then
+            # Use torch nightly builds
+            TORCH_INDEX_URL="https://download.pytorch.org/whl/nightly/cu${CUDA_VERSION_MAJMIN_NODOT}"
+          else
+            TORCH_INDEX_URL="https://download.pytorch.org/whl/cu${CUDA_VERSION_MAJMIN_NODOT}"
+          fi
+          echo "TORCH_INDEX_URL=${TORCH_INDEX_URL}" | tee -a "${GITHUB_ENV}"
+
+          # The wheel JIT-compiles kernels with the host nvcc at runtime.
+          if [[ -x "$(command -v nvcc)" ]]; then
+            echo "\$ $(command -v nvcc) --version" && nvcc --version
+            NVCC_VERSION="$(nvcc --version | sed -n 's/.*release \([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' | head -n1)"
+            if [[ -n "${NVCC_VERSION}" && "${NVCC_VERSION%%.*}" != "${CUDA_VERSION%%.*}" ]]; then
+              echo "::warning::nvcc CUDA ${NVCC_VERSION} does not match requested ${TOOLKIT}."
+            fi
+          else
+            echo "::warning::nvcc not found in PATH!"
+          fi
+
+      - name: Set environment (ROCm)
+        if: contains(matrix.target.toolkit, 'ROCm')
+        run: |
+          TOOLKIT="${{ matrix.target.toolkit }}"
+          ROCM_VERSION="${TOOLKIT##*-}"
+          ROCM_VERSION_MAJMIN="$(echo "${ROCM_VERSION}" | cut -d '.' -f-2)"
+          if [[ "${TOOLKIT}" == "Nightly-"* ]]; then
+            # Use torch nightly builds
+            TORCH_INDEX_URL="https://download.pytorch.org/whl/nightly/rocm${ROCM_VERSION_MAJMIN}"
+          else
+            TORCH_INDEX_URL="https://download.pytorch.org/whl/rocm${ROCM_VERSION_MAJMIN}"
+          fi
+          echo "TORCH_INDEX_URL=${TORCH_INDEX_URL}" | tee -a "${GITHUB_ENV}"
+
+          if [[ ! -x "$(command -v hipcc)" ]]; then
+            export PATH="/opt/rocm/bin:${PATH}"
+            export LD_LIBRARY_PATH="/opt/rocm/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+            echo "PATH=${PATH}" | tee -a "${GITHUB_ENV}"
+            echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" | tee -a "${GITHUB_ENV}"
+          fi
+          if [[ -x "$(command -v hipcc)" ]]; then
+            echo "\$ $(command -v hipcc) --version" && hipcc --version
+          else
+            echo "::warning::hipcc not found in PATH!"
+          fi
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.target.python_version }}
+          activate-environment: true
+          # Do not use cache upload/download for self-hosted runners, as it is
+          # slow; the local cache directory persists on the runner instead.
+          enable-cache: false
+          prune-cache: false
+          cache-local-path: ${{ env.UV_CACHE_DIR }}
+          ignore-nothing-to-cache: true
+
+      - name: Download built wheels
+        uses: actions/download-artifact@v8
+        with:
+          # Matches the wheels built for this runner's os/arch (Linux-X64).
+          pattern: wheels-*-${{ runner.os }}-${{ runner.arch }}-*
+          path: wheelhouse
+          merge-multiple: true
+
+      - name: Test built wheels on GPU
+        run: |
+          # Always exercise real kernel compilation: a warm kernel cache on a
+          # persistent self-hosted runner must not mask a broken wheel.
+          export TILELANG_DISABLE_CACHE=1
+
+          ls -lh wheelhouse/
+          for WHEEL in wheelhouse/*.whl; do
+            echo "Testing wheel: ${WHEEL}"
+            (
+              set -e
+              uv venv test-venv
+              source test-venv/bin/activate
+
+              # Install torch from the toolkit-matched channel only, before the
+              # wheel, so the resolver cannot substitute a mismatched build
+              # from PyPI (e.g. the CUDA torch on a ROCm host).
+              uv pip install -v --index-url "${TORCH_INDEX_URL}" torch
+              uv pip install -v "${WHEEL}"
+              # Run from RUNNER_TEMP so `import tilelang` resolves to the
+              # installed wheel rather than the repository source tree.
+              cp maint/scripts/smoke_test_wheel.py "${RUNNER_TEMP}/"
+              (
+                set -e
+                cd "${RUNNER_TEMP}"
+                uv run --no-project -- python smoke_test_wheel.py
+              )
+              deactivate
+              rm -rf test-venv
+            )
+          done
 
   list-artifacts:
     name: List artifacts

--- a/maint/scripts/smoke_test_wheel.py
+++ b/maint/scripts/smoke_test_wheel.py
@@ -1,0 +1,78 @@
+"""GPU smoke test for built tilelang wheels.
+
+Runs against an *installed* tilelang (wheel), not the source tree: copy this
+file somewhere outside the repository before running it, or run it with the
+repository root absent from ``sys.path``, so ``import tilelang`` resolves to
+site-packages. It compiles and launches a small fp16 GEMM on the detected
+backend (CUDA or ROCm) and checks the result against torch.
+
+Exits non-zero on any failure.
+"""
+
+import sys
+
+import torch
+
+import tilelang
+import tilelang.language as T
+
+
+def report_environment() -> None:
+    print("=" * 60)
+    print("python:", sys.version.split()[0])
+    print("torch:", torch.__version__, "| cuda:", torch.version.cuda, "| hip:", getattr(torch.version, "hip", None))
+    assert torch.cuda.is_available(), "torch reports no GPU; a GPU is required for the wheel smoke test"
+    print("gpu:", torch.cuda.get_device_name(0))
+    print("tilelang:", tilelang.__version__)
+
+    from tilelang.backend.target import determine_target
+
+    print("detected target:", determine_target(return_object=True))
+    print("=" * 60)
+
+
+@tilelang.jit
+def matmul(A, B, block_M, block_N, block_K, dtype=T.float16, accum_dtype=T.float32):
+    M, N, K = T.const("M, N, K")
+
+    A: T.Tensor((M, K), dtype)
+    B: T.Tensor((K, N), dtype)
+    C = T.empty((M, N), dtype)
+
+    with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+        A_shared = T.alloc_shared((block_M, block_K), dtype)
+        B_shared = T.alloc_shared((block_K, block_N), dtype)
+        C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+        T.clear(C_local)
+        for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=3):
+            T.copy(A[by * block_M, k * block_K], A_shared)
+            T.copy(B[k * block_K, bx * block_N], B_shared)
+            T.gemm(A_shared, B_shared, C_local)
+
+        T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return C
+
+
+def main() -> None:
+    report_environment()
+
+    kernel = matmul.compile(M=1024, N=1024, K=1024, block_M=128, block_N=128, block_K=32)
+
+    a = torch.randn(1024, 1024).cuda().half()
+    b = torch.randn(1024, 1024).cuda().half()
+
+    c = kernel(a, b)
+    ref_c = a @ b
+
+    torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+    print("correctness: PASS")
+
+    latency = kernel.get_profiler().do_bench()
+    print(f"latency: {latency:.4f} ms")
+    print("WHEEL SMOKE TEST: ALL PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The build runners have no GPU, so the Dist workflow never launches a kernel from a built wheel: the Linux wheels are fat CUDA+ROCm builds (#2195) and neither half is ever executed before publishing — the CUDA legs only test `import tilelang`, and the ROCm half ships fully untested on AMD hardware (`ci.yml`'s self-hosted runners cover source builds only).

## Changes

- **New `test-wheels-gpu` job in `dist.yml`** with two legs, `self-hosted-nvidia` (CUDA-13.0) and `self-hosted-amd-gfx942` (ROCm-7.2), both consuming the Linux x86_64 wheel artifact:
  - torch is installed with `--index-url` pinned to the toolkit-matched channel (`whl/cu130` / `whl/rocm7.2`) *before* the wheel, so the resolver cannot substitute a mismatched build from PyPI (e.g. the CUDA torch on a ROCm host).
  - `TILELANG_DISABLE_CACHE=1` so a warm kernel cache on a persistent runner cannot mask a broken wheel.
  - The smoke script runs from `RUNNER_TEMP` so `import tilelang` resolves to the installed wheel, not the repository source tree.
  - Toolkit/torch-channel parsing mirrors `ci.yml` (including `Nightly-` prefix support) and the matrix entry format matches, so future runners (e.g. gfx950) are a one-line addition.
- **New `maint/scripts/smoke_test_wheel.py`**: self-contained, backend-agnostic GEMM correctness + latency smoke test (asserts a GPU is present, prints the detected target).

## Gating / release safety

- The job is gated exactly like the `Upload wheels` step (non-PR runs and `[Release]` PRs), since that is when the artifact exists — it runs on the nightly schedule, `workflow_dispatch`, and releases.
- It is deliberately **not** in `publish-pypi`'s needs-chain: an offline self-hosted runner cannot block a release. It is a signal, not a gate; it can be tightened later if desired.

## Testing

- The exact job flow (fresh venv → channel-pinned torch → wheel file install → smoke script from a temp dir) was run end-to-end outside CI on both backends, using the PyPI 0.1.14 wheel as a stand-in artifact:
  - MI350X (gfx950, ROCm 7.0.2): GEMM correctness passes.
  - H100 (CUDA 13, torch 2.14.0+cu130): GEMM correctness passes.
- `actionlint` reports no issues for the new job (only pre-existing findings on an untouched step remain).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add ROCm wheel validation to the Dist workflow.
- Run validation on a self-hosted `gfx942` AMD runner with matching ROCm PyTorch.
- Test the installed Linux x86_64 wheel in a fresh virtual environment.
- Disable kernel caching and run a GEMM smoke test from a temporary directory.
- Keep the job outside the `publish-pypi` dependency chain so unavailable runners do not block releases.
- Add `maint/scripts/smoke_test_wheel.py` to validate GPU availability, GEMM correctness, and latency on CUDA or ROCm.

## C++ style / lint notes

- The PR changes CI but does not modify C++ code or `docs/developer_guide/cpp_style.md`.
- It does not add or modify the “C++ API Style Audit (warning only)” step.
- No C++ correctness, build, or style warnings were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->