### PR TITLE
[Doc] Document pip installation on AMD GPUs (ROCm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Nightly wheels provide recent features and fixes before the next stable release:
 pip install tilelang --find-links https://tile-ai.github.io/whl/nightly
 ```
 
+On AMD GPUs the same Linux wheels work out of the box: install a ROCm build of PyTorch first (e.g. `pip install torch --index-url https://download.pytorch.org/whl/rocm7.0`), then `pip install tilelang`. A host ROCm installation is required at runtime; see the [ROCm notes](https://tilelang.com/get_started/Installation.html#installing-on-amd-gpus-rocm) in the installation guide.
+
 Nightly builds may be less stable than official releases. For source builds, editable installs, Docker, ROCm setup, pip-provided CUDA toolchains, or a custom TVM checkout, follow the complete [installation guide](https://tilelang.com/get_started/Installation.html).
 
 ## Quick Start

--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -6,7 +6,8 @@
 
 - **glibc**: 2.28 (Ubuntu 20.04 or later)
 - **Python Version**: >= 3.10
-- **CUDA Version**: >= 10.0 (host installation), or pip-provided CUDA toolchain (>= 13.0)
+- **NVIDIA GPUs — CUDA Version**: >= 10.0 (host installation), or pip-provided CUDA toolchain (>= 13.0)
+- **AMD GPUs — ROCm**: a host ROCm installation providing `hipcc` (see [Installing on AMD GPUs (ROCm)](#installing-on-amd-gpus-rocm))
 
 The easiest way to install tilelang is directly from PyPI using pip. To install the latest version, run the following command in your terminal:
 
@@ -31,6 +32,40 @@ After installing tilelang, you can verify the installation by running:
 ```bash
 python -c "import tilelang; print(tilelang.__version__)"
 ```
+
+### Installing on AMD GPUs (ROCm)
+
+The Linux x86_64 wheels on PyPI are fat CUDA+ROCm builds: the same `pip install tilelang` works on AMD GPUs, and no source build or separate package index is required. Two things differ from the CUDA flow:
+
+1. **A host ROCm installation is required at runtime.** Kernels are JIT-compiled with the host `hipcc` (there is no pip-provided ROCm toolchain, unlike the CUDA `nvcc` extra).
+2. **Install a ROCm build of PyTorch first.** A plain `pip install tilelang` resolves the default (CUDA) `torch` from PyPI, which cannot detect AMD GPUs. Install torch from the ROCm channel matching your ROCm version before (or when) installing tilelang:
+
+```bash
+# 1) Install a ROCm build of PyTorch (pick the channel matching your ROCm version)
+pip install torch --index-url https://download.pytorch.org/whl/rocm7.0
+
+# 2) Install tilelang; the already-installed torch is reused
+pip install tilelang
+```
+
+Verify that the ROCm target is detected:
+
+```bash
+python -c "import tilelang; from tilelang.backend.target import determine_target; print(tilelang.__version__, determine_target(return_object=True))"
+```
+
+This should print a `hip` target with your GPU architecture (e.g. `mcpu=gfx942`).
+
+If ROCm is installed outside `/opt/rocm`, or several HIP toolchains are visible on `PATH`, set `ROCM_PATH` to pin the installation TileLang should use:
+
+```bash
+export ROCM_PATH=/opt/rocm  # or your custom ROCm prefix
+```
+
+Notes:
+
+- The `tilelang[nvcc]` extra is CUDA-only; do not install it on ROCm hosts.
+- Windows and macOS wheels do not include the ROCm backend (Linux only).
 
 ## Building from Source
 
@@ -198,6 +233,12 @@ python -c "import tilelang; print(tilelang.__version__)"
 ```
 
 ### ROCm container build (gfx942/gfx950)
+
+A source build is **not** required just to run TileLang on AMD GPUs — the PyPI
+wheels already include the ROCm backend (see
+[Installing on AMD GPUs (ROCm)](#installing-on-amd-gpus-rocm)). Use the
+container/source flow below when developing TileLang itself or when you need a
+custom build.
 
 If you want a ready-to-use ROCm image that builds TileLang from source, use
 `docker/Dockerfile.rocm`. This is the recommended path for a clean, reproducible


### PR DESCRIPTION
## Summary

The Linux wheels have been fat CUDA+ROCm builds since #2195, but the installation guide never says so: the pip section lists CUDA-only prerequisites, and ROCm users are funneled to the docker/source-build sections even though `pip install tilelang` works out of the box on AMD hosts.

## Changes

`docs/get_started/Installation.md`:

- The pip prerequisites now branch per vendor (NVIDIA CUDA / AMD ROCm) instead of implying CUDA is always required.
- New **"Installing on AMD GPUs (ROCm)"** section covering the two things that differ from the CUDA flow:
  1. a host ROCm installation is required at runtime (kernels are JIT-compiled with the host `hipcc`; there is no pip-provided ROCm toolchain, unlike the CUDA `nvcc` extra);
  2. a ROCm build of torch must be installed from the matching `download.pytorch.org/whl/rocm<ver>` channel first, since a plain `pip install tilelang` resolves the default (CUDA) torch from PyPI.

  Plus: a copy-paste verify command that prints the detected `hip` target, the `ROCM_PATH` override for hosts with non-standard or multiple HIP toolchains, and notes that `tilelang[nvcc]` is CUDA-only and that Windows/macOS wheels do not include ROCm.
- The ROCm container-build section now states up front that a source build is *not* required just to run TileLang on AMD GPUs, and links back to the pip section.

`README.md`:

- One-paragraph AMD note in the Installation section (ROCm torch first, then `pip install tilelang`), linking to the new guide section. Previously the README lumped "ROCm setup" into the source-build sentence.

## Testing

- Every command in the new section was run as-is on an MI350X (gfx950, ROCm 7.0.2) host against the PyPI 0.1.14 wheel; the verify command prints the expected `hip` target with `mcpu=gfx950`.
- codespell clean on both files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Documented NVIDIA CUDA and AMD ROCm prerequisites for pip installation.
- Added AMD ROCm installation guidance, including:
  - Host ROCm and `hipcc` requirements.
  - ROCm-compatible PyTorch installation.
  - Installation verification.
  - Optional `ROCM_PATH` configuration.
  - CUDA-only extras and Linux platform limitations.
- Clarified that source builds are not required to run TileLang on AMD GPUs.
- Added AMD installation guidance and a link to the README.
- Verified the PyPI `0.1.14` wheel on an MI350X with ROCm 7.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->