### PR TITLE
warp reduction for any_of and all_of

### DIFF
--- a/src/op/logical.cc
+++ b/src/op/logical.cc
@@ -17,22 +17,30 @@ PrimExpr any_of_op(PrimExpr args) {
   const CallNode *call = args.as<CallNode>();
   ICHECK(call != nullptr);
   const ffi::Array<PrimExpr> &arg = call->args;
-  ICHECK_EQ(arg.size(), 2);
+  ICHECK_EQ(arg.size(), 3);
   PrimExpr buffer_address = arg[0];
   PrimExpr elems = arg[1];
+  const auto scope_imm = arg[2].as<StringImmNode>();
+  ICHECK(scope_imm != nullptr);
+  const auto scope = scope_imm->value;
   return tirx::Call(DataType::Bool(), tirx::builtin::call_extern(),
-                    {StringImm("tl::Any"), buffer_address, elems});
+                    {StringImm((scope == "warp") ? "tl::AnyWarp" : "tl::Any"),
+                     buffer_address, elems});
 }
 
 PrimExpr all_of_op(PrimExpr args) {
   const CallNode *call = args.as<CallNode>();
   ICHECK(call != nullptr);
   const ffi::Array<PrimExpr> &arg = call->args;
-  ICHECK_EQ(arg.size(), 2);
+  ICHECK_EQ(arg.size(), 3);
   PrimExpr buffer_address = arg[0];
   PrimExpr elems = arg[1];
+  const auto scope_imm = arg[2].as<StringImmNode>();
+  ICHECK(scope_imm != nullptr);
+  const auto scope = scope_imm->value;
   return tirx::Call(DataType::Bool(), tirx::builtin::call_extern(),
-                    {StringImm("tl::All"), buffer_address, elems});
+                    {StringImm((scope == "warp") ? "tl::AllWarp" : "tl::All"),
+                     buffer_address, elems});
 }
 
 TVM_REGISTER_OP("tl.any_of")

--- a/src/op/logical.cc
+++ b/src/op/logical.cc
@@ -23,9 +23,18 @@ PrimExpr any_of_op(PrimExpr args) {
   const auto scope_imm = arg[2].as<StringImmNode>();
   ICHECK(scope_imm != nullptr);
   const auto scope = scope_imm->value;
+  ffi::String fn_name;
+  if (scope == "warp") {
+    fn_name = "tl::AnyWarp";
+  } else if (scope == "thread" || scope == "auto") {
+    // By default auto uses tl::Any, if it can prove no warp divergence it'll
+    // use tl::AnyWarp instead
+    fn_name = "tl::Any";
+  } else {
+    ICHECK(false) << "Invalid scope: " << scope;
+  }
   return tirx::Call(DataType::Bool(), tirx::builtin::call_extern(),
-                    {StringImm((scope == "warp") ? "tl::AnyWarp" : "tl::Any"),
-                     buffer_address, elems});
+                    {StringImm(fn_name), buffer_address, elems});
 }
 
 PrimExpr all_of_op(PrimExpr args) {
@@ -38,9 +47,18 @@ PrimExpr all_of_op(PrimExpr args) {
   const auto scope_imm = arg[2].as<StringImmNode>();
   ICHECK(scope_imm != nullptr);
   const auto scope = scope_imm->value;
+  ffi::String fn_name;
+  if (scope == "warp") {
+    fn_name = "tl::AllWarp";
+  } else if (scope == "thread" || scope == "auto") {
+    // By default auto uses tl::Any, if it can prove no warp divergence it'll
+    // use tl::AnyWarp instead
+    fn_name = "tl::All";
+  } else {
+    ICHECK(false) << "Invalid scope: " << scope;
+  }
   return tirx::Call(DataType::Bool(), tirx::builtin::call_extern(),
-                    {StringImm((scope == "warp") ? "tl::AllWarp" : "tl::All"),
-                     buffer_address, elems});
+                    {StringImm(fn_name), buffer_address, elems});
 }
 
 TVM_REGISTER_OP("tl.any_of")

--- a/src/op/logical.cc
+++ b/src/op/logical.cc
@@ -13,52 +13,41 @@ namespace tvm {
 namespace tl {
 using namespace tirx;
 
-PrimExpr any_of_op(PrimExpr args) {
+namespace {
+
+PrimExpr LowerLogicalReduction(PrimExpr args, ffi::String thread_helper,
+                               ffi::String warp_helper) {
   const CallNode *call = args.as<CallNode>();
   ICHECK(call != nullptr);
   const ffi::Array<PrimExpr> &arg = call->args;
-  ICHECK_EQ(arg.size(), 3);
+  ICHECK(arg.size() == 2 || arg.size() == 3);
   PrimExpr buffer_address = arg[0];
   PrimExpr elems = arg[1];
-  const auto scope_imm = arg[2].as<StringImmNode>();
-  ICHECK(scope_imm != nullptr);
-  const auto scope = scope_imm->value;
-  ffi::String fn_name;
-  if (scope == "warp") {
-    fn_name = "tl::AnyWarp";
-  } else if (scope == "thread" || scope == "auto") {
-    // By default auto uses tl::Any, if it can prove no warp divergence it'll
-    // use tl::AnyWarp instead
-    fn_name = "tl::Any";
-  } else {
-    ICHECK(false) << "Invalid scope: " << scope;
+
+  ffi::String helper = thread_helper;
+  if (arg.size() == 3) {
+    const auto *scope = arg[2].as<StringImmNode>();
+    ICHECK(scope != nullptr);
+    if (scope->value == "warp") {
+      helper = warp_helper;
+    } else {
+      ICHECK(scope->value == "thread" || scope->value == "auto")
+          << "Invalid internal logical reduction scope: " << scope->value;
+    }
   }
+
   return tirx::Call(DataType::Bool(), tirx::builtin::call_extern(),
-                    {StringImm(fn_name), buffer_address, elems});
+                    {StringImm(helper), buffer_address, elems});
+}
+
+} // namespace
+
+PrimExpr any_of_op(PrimExpr args) {
+  return LowerLogicalReduction(args, "tl::Any", "tl::AnyWarp");
 }
 
 PrimExpr all_of_op(PrimExpr args) {
-  const CallNode *call = args.as<CallNode>();
-  ICHECK(call != nullptr);
-  const ffi::Array<PrimExpr> &arg = call->args;
-  ICHECK_EQ(arg.size(), 3);
-  PrimExpr buffer_address = arg[0];
-  PrimExpr elems = arg[1];
-  const auto scope_imm = arg[2].as<StringImmNode>();
-  ICHECK(scope_imm != nullptr);
-  const auto scope = scope_imm->value;
-  ffi::String fn_name;
-  if (scope == "warp") {
-    fn_name = "tl::AllWarp";
-  } else if (scope == "thread" || scope == "auto") {
-    // By default auto uses tl::Any, if it can prove no warp divergence it'll
-    // use tl::AnyWarp instead
-    fn_name = "tl::All";
-  } else {
-    ICHECK(false) << "Invalid scope: " << scope;
-  }
-  return tirx::Call(DataType::Bool(), tirx::builtin::call_extern(),
-                    {StringImm(fn_name), buffer_address, elems});
+  return LowerLogicalReduction(args, "tl::All", "tl::AllWarp");
 }
 
 TVM_REGISTER_OP("tl.any_of")

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -900,6 +900,18 @@ template <typename T> TL_DEVICE bool Any(T *a, int size) {
   return false;
 }
 
+// AnyWarp
+template <typename T> TL_DEVICE bool AnyWarp(T *a, int size) {
+  unsigned int lane_id;
+  asm volatile("mov.u32 %0, %laneid;" : "=r"(lane_id));
+
+  bool result = false;
+  for (int i = lane_id; i < size; i += 32) {
+    result |= a[i];
+  }
+  return __any_sync(0xffffffffu, result);
+}
+
 // All
 template <typename T> TL_DEVICE bool All(T *a, int size) {
   for (int i = 0; i < size; i++) {
@@ -908,6 +920,18 @@ template <typename T> TL_DEVICE bool All(T *a, int size) {
     }
   }
   return true;
+}
+
+// AllWarp
+template <typename T> TL_DEVICE bool AllWarp(T *a, int size) {
+  unsigned int lane_id;
+  asm volatile("mov.u32 %0, %laneid;" : "=r"(lane_id));
+
+  bool result = true;
+  for (int i = lane_id; i < size; i += 32) {
+    result &= a[i];
+  }
+  return __all_sync(0xffffffffu, result);
 }
 
 // Pow of int

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -906,7 +906,7 @@ template <typename T> TL_DEVICE bool AnyWarp(T *a, int size) {
   asm volatile("mov.u32 %0, %laneid;" : "=r"(lane_id));
 
   bool result = false;
-  for (int i = lane_id; i < size; i += 32) {
+  for (int i = lane_id; i < size; i += warpSize) {
     result |= a[i];
   }
   return __any_sync(0xffffffffu, result);
@@ -928,7 +928,7 @@ template <typename T> TL_DEVICE bool AllWarp(T *a, int size) {
   asm volatile("mov.u32 %0, %laneid;" : "=r"(lane_id));
 
   bool result = true;
-  for (int i = lane_id; i < size; i += 32) {
+  for (int i = lane_id; i < size; i += warpSize) {
     result &= a[i];
   }
   return __all_sync(0xffffffffu, result);

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -310,6 +310,16 @@ template <typename T> TL_DEVICE bool Any(T *a, int size) {
   return false;
 }
 
+template <typename T> TL_DEVICE bool AnyWarp(T *a, int size) {
+  const auto lane_id = __lane_id();
+
+  bool result = false;
+  for (int i = lane_id; i < size; i += 64) {
+    result |= a[i];
+  }
+  return __any(result) == 1;
+}
+
 // All
 template <typename T> TL_DEVICE bool All(T *a, int size) {
   for (int i = 0; i < size; i++) {
@@ -318,6 +328,16 @@ template <typename T> TL_DEVICE bool All(T *a, int size) {
     }
   }
   return true;
+}
+
+template <typename T> TL_DEVICE bool AllWarp(T *a, int size) {
+  const auto lane_id = __lane_id();
+
+  bool result = true;
+  for (int i = lane_id; i < size; i += 64) {
+    result &= a[i];
+  }
+  return __all(result) == 1;
 }
 
 // TODO(gong): support shfl_sync(rocm 7.1.1 provide shfl_sync)

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -314,7 +314,7 @@ template <typename T> TL_DEVICE bool AnyWarp(T *a, int size) {
   const auto lane_id = __lane_id();
 
   bool result = false;
-  for (int i = lane_id; i < size; i += 64) {
+  for (int i = lane_id; i < size; i += warpSize) {
     result |= a[i];
   }
   return __any(result) == 1;
@@ -334,7 +334,7 @@ template <typename T> TL_DEVICE bool AllWarp(T *a, int size) {
   const auto lane_id = __lane_id();
 
   bool result = true;
-  for (int i = lane_id; i < size; i += 64) {
+  for (int i = lane_id; i < size; i += warpSize) {
     result &= a[i];
   }
   return __all(result) == 1;

--- a/src/transform/resolve_logical_scope.cc
+++ b/src/transform/resolve_logical_scope.cc
@@ -1,0 +1,190 @@
+  #include "support/check.h"
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt_functor.h>
+#include <tvm/tirx/transform.h>
+#include <tvm/target/target.h>
+
+  #include "runtime/thread_storage_scope.h"
+  #include "tvm/runtime/data_type.h"
+  #include "tvm/tirx/stmt.h"
+  #include <tvm/arith/analyzer.h>
+  #include <tvm/ir/cast.h>
+  #include <tvm/tirx/analysis.h>
+
+  namespace tvm {
+  namespace tl {
+
+  using namespace tirx;
+  using namespace ffi;
+
+  namespace {
+  PrimExpr MakeLinearThreadId(const Array<IterVar> &thread_vars) {
+    DataType dtype = DataType::Int(64);
+    PrimExpr linear_id = make_const(dtype, 0);
+    PrimExpr stride = make_const(dtype, 1);
+
+    static const char *thread_tags[] = {
+        "threadIdx.x",
+        "threadIdx.y",
+        "threadIdx.z",
+    };
+    for(const char *tag : thread_tags) {
+      for(const IterVar &thread : thread_vars) {
+        if (thread->thread_tag != tag) {
+          continue;
+        }
+
+        PrimExpr index =
+            Cast(dtype, thread->var - thread->dom->min);
+        linear_id = linear_id + index * stride;
+        stride = stride * Cast(dtype, thread->dom->extent);
+        break;
+      }
+    }
+    return linear_id;
+  }
+
+  class LogicalScopeResolver : public StmtExprMutator {
+  public:
+    explicit LogicalScopeResolver(int warp_size) : warp_size_(warp_size) {}
+
+    PrimExpr Visit(PrimExpr expr) {
+      return VisitExpr(std::move(expr));
+    }
+
+  private:
+    bool IsWarpUniformCondition(const PrimExpr &condition) {
+      Map<Var, PrimExpr> thread_one;
+      Map<Var, PrimExpr> thread_two;
+      arith::Analyzer analyzer;
+
+      for(const IterVar &thread : env_threads_) {
+        Var one(thread->var->name_hint + "<T1>", thread->var->dtype);
+        Var two(thread->var->name_hint + "<T2>", thread->var->dtype);
+
+        thread_one.Set(thread->var, one);
+        thread_two.Set(thread->var, two);
+
+        analyzer.Bind(one, thread->dom);
+        analyzer.Bind(two, thread->dom);
+      }
+      if (thread_one.empty()) {
+        return true;
+      }
+      PrimExpr linear_id = MakeLinearThreadId(env_threads_);
+
+      PrimExpr condition_one = Substitute(condition, thread_one);
+      PrimExpr condition_two = Substitute(condition, thread_two);
+      PrimExpr linear_one = Substitute(linear_id, thread_one);
+      PrimExpr linear_two = Substitute(linear_id, thread_two);
+
+      PrimExpr warp_size = make_const(DataType::Int(64), warp_size_);
+
+      PrimExpr same_warp = FloorDiv(linear_one, warp_size) == FloorDiv(linear_two, warp_size);
+      PrimExpr agree = Or(And(condition_one, condition_two), And(Not(condition_one), Not(condition_two)));
+      return analyzer.CanProve(Or(Not(same_warp), agree));
+    }
+    PrimExpr VisitExpr_(const CallNode *op) final {
+      PrimExpr visited = StmtExprMutator::VisitExpr_(op);
+      const auto *call = visited.as<CallNode>();
+      ICHECK(call != nullptr);
+
+      if (!call->op.same_as(Op::Get("tl.any_of")) &&
+          !call->op.same_as(Op::Get("tl.all_of"))) {
+        return visited;
+      }
+
+      ICHECK_EQ(call->args.size(), 3U);
+      const auto *scope = call->args[2].as<StringImmNode>();
+      ICHECK(scope != nullptr);
+
+      if (scope->value != "auto") {
+        return visited;
+      }
+
+      Array<PrimExpr> args = call->args;
+      args.Set(2, StringImm( is_warp_uniform_? "warp" : "thread"));
+      return Call(call->dtype, call->op, args, call->span);
+    }
+
+    Stmt VisitStmt_(const AttrStmtNode *op) final {
+      if (op->attr_key != tirx::attr::thread_extent) {
+        return StmtExprMutator::VisitStmt_(op);
+      }
+      IterVar thread = Downcast<IterVar>(op->node);
+      runtime::ThreadScope scope =
+        runtime::ThreadScope::Create(thread->thread_tag);
+      if (scope.rank != 1) {
+        return StmtExprMutator::VisitStmt_(op);
+      }
+      env_threads_.push_back(thread);
+      Stmt visited = StmtExprMutator::VisitStmt_(op);
+      env_threads_.pop_back();
+      return visited;
+    }
+
+    Stmt VisitStmt_(const IfThenElseNode *op) final {
+      auto condition = VisitExpr(op->condition);
+
+      bool condition_is_uniform = IsWarpUniformCondition(condition);
+
+      bool parent_is_uniform = is_warp_uniform_;
+      is_warp_uniform_ = parent_is_uniform && condition_is_uniform;
+      Stmt then_case = VisitStmt(op->then_case);
+
+      Optional<Stmt> else_case = std::nullopt;
+      if (op->else_case.defined()) {
+        is_warp_uniform_ = parent_is_uniform && condition_is_uniform;
+        else_case = VisitStmt(op->else_case.value());
+      }
+      is_warp_uniform_ = parent_is_uniform;
+      return IfThenElse(condition, then_case, else_case, op->span);
+    }
+
+    Array<IterVar> env_threads_;
+    bool is_warp_uniform_{true};
+    int warp_size_;
+  };
+
+  PrimFunc ResolveLogicalScopePrimFunc(PrimFunc func) {
+    if (!func.defined() || !func->body.defined()) {
+      return func;
+    }
+
+    auto target = func->GetAttr<Target>(tvm::attr::kTarget);
+    ICHECK(target.defined()) << "ResolveLogicalScope requires a bound target";
+    auto warp_size_attr =
+        target.value()->GetAttr<Integer>("thread_warp_size");
+    ICHECK(warp_size_attr.defined())
+        << "ResolveLogicalScope requires target attribute thread_warp_size";
+    int warp_size = warp_size_attr.value().IntValue();
+    ICHECK_GT(warp_size, 0);
+
+    LogicalScopeResolver resolver(warp_size);
+    PrimFuncNode *node = func.CopyOnWrite();
+    node->body = resolver(std::move(node->body));
+    return func;
+  }
+
+  } // namespace
+
+  namespace transform {
+
+  tvm::transform::Pass ResolveLogicalScope() {
+    auto pass_func = [](PrimFunc func, const IRModule &,
+                        const tvm::transform::PassContext &) {
+      return ResolveLogicalScopePrimFunc(std::move(func));
+    };
+
+  return tvm::tirx::transform::CreatePrimFuncPass(pass_func, 0,
+                                                  "tl.ResolveLogicalScope", {});
+  }
+  TVM_FFI_STATIC_INIT_BLOCK() {
+    namespace refl = reflection;
+    refl::GlobalDef().def("tl.transform.ResolveLogicalScope",
+                          ResolveLogicalScope);
+  }
+
+  } // namespace transform
+  } // namespace tl
+  } // namespace tvm

--- a/src/transform/resolve_logical_scope.cc
+++ b/src/transform/resolve_logical_scope.cc
@@ -1,190 +1,188 @@
-  #include "support/check.h"
+#include "support/check.h"
+#include <tvm/target/target.h>
 #include <tvm/tirx/op.h>
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
-#include <tvm/target/target.h>
 
-  #include "runtime/thread_storage_scope.h"
-  #include "tvm/runtime/data_type.h"
-  #include "tvm/tirx/stmt.h"
-  #include <tvm/arith/analyzer.h>
-  #include <tvm/ir/cast.h>
-  #include <tvm/tirx/analysis.h>
+#include "runtime/thread_storage_scope.h"
+#include "tvm/runtime/data_type.h"
+#include "tvm/tirx/stmt.h"
+#include <tvm/arith/analyzer.h>
+#include <tvm/ir/cast.h>
+#include <tvm/tirx/analysis.h>
 
-  namespace tvm {
-  namespace tl {
+namespace tvm {
+namespace tl {
 
-  using namespace tirx;
-  using namespace ffi;
+using namespace tirx;
+using namespace ffi;
 
-  namespace {
-  PrimExpr MakeLinearThreadId(const Array<IterVar> &thread_vars) {
-    DataType dtype = DataType::Int(64);
-    PrimExpr linear_id = make_const(dtype, 0);
-    PrimExpr stride = make_const(dtype, 1);
+namespace {
+PrimExpr MakeLinearThreadId(const Array<IterVar> &thread_vars) {
+  DataType dtype = DataType::Int(64);
+  PrimExpr linear_id = make_const(dtype, 0);
+  PrimExpr stride = make_const(dtype, 1);
 
-    static const char *thread_tags[] = {
-        "threadIdx.x",
-        "threadIdx.y",
-        "threadIdx.z",
-    };
-    for(const char *tag : thread_tags) {
-      for(const IterVar &thread : thread_vars) {
-        if (thread->thread_tag != tag) {
-          continue;
-        }
-
-        PrimExpr index =
-            Cast(dtype, thread->var - thread->dom->min);
-        linear_id = linear_id + index * stride;
-        stride = stride * Cast(dtype, thread->dom->extent);
-        break;
+  static const char *thread_tags[] = {
+      "threadIdx.x",
+      "threadIdx.y",
+      "threadIdx.z",
+  };
+  for (const char *tag : thread_tags) {
+    for (const IterVar &thread : thread_vars) {
+      if (thread->thread_tag != tag) {
+        continue;
       }
+
+      PrimExpr index = Cast(dtype, thread->var - thread->dom->min);
+      linear_id = linear_id + index * stride;
+      stride = stride * Cast(dtype, thread->dom->extent);
+      break;
     }
-    return linear_id;
   }
+  return linear_id;
+}
 
-  class LogicalScopeResolver : public StmtExprMutator {
-  public:
-    explicit LogicalScopeResolver(int warp_size) : warp_size_(warp_size) {}
+class LogicalScopeResolver : public StmtExprMutator {
+public:
+  explicit LogicalScopeResolver(int warp_size) : warp_size_(warp_size) {}
 
-    PrimExpr Visit(PrimExpr expr) {
-      return VisitExpr(std::move(expr));
+  PrimExpr Visit(PrimExpr expr) { return VisitExpr(std::move(expr)); }
+
+private:
+  bool IsWarpUniformCondition(const PrimExpr &condition) {
+    Map<Var, PrimExpr> thread_one;
+    Map<Var, PrimExpr> thread_two;
+    arith::Analyzer analyzer;
+
+    for (const IterVar &thread : env_threads_) {
+      Var one(thread->var->name_hint + "<T1>", thread->var->dtype);
+      Var two(thread->var->name_hint + "<T2>", thread->var->dtype);
+
+      thread_one.Set(thread->var, one);
+      thread_two.Set(thread->var, two);
+
+      analyzer.Bind(one, thread->dom);
+      analyzer.Bind(two, thread->dom);
     }
-
-  private:
-    bool IsWarpUniformCondition(const PrimExpr &condition) {
-      Map<Var, PrimExpr> thread_one;
-      Map<Var, PrimExpr> thread_two;
-      arith::Analyzer analyzer;
-
-      for(const IterVar &thread : env_threads_) {
-        Var one(thread->var->name_hint + "<T1>", thread->var->dtype);
-        Var two(thread->var->name_hint + "<T2>", thread->var->dtype);
-
-        thread_one.Set(thread->var, one);
-        thread_two.Set(thread->var, two);
-
-        analyzer.Bind(one, thread->dom);
-        analyzer.Bind(two, thread->dom);
-      }
-      if (thread_one.empty()) {
-        return true;
-      }
-      PrimExpr linear_id = MakeLinearThreadId(env_threads_);
-
-      PrimExpr condition_one = Substitute(condition, thread_one);
-      PrimExpr condition_two = Substitute(condition, thread_two);
-      PrimExpr linear_one = Substitute(linear_id, thread_one);
-      PrimExpr linear_two = Substitute(linear_id, thread_two);
-
-      PrimExpr warp_size = make_const(DataType::Int(64), warp_size_);
-
-      PrimExpr same_warp = FloorDiv(linear_one, warp_size) == FloorDiv(linear_two, warp_size);
-      PrimExpr agree = Or(And(condition_one, condition_two), And(Not(condition_one), Not(condition_two)));
-      return analyzer.CanProve(Or(Not(same_warp), agree));
+    if (thread_one.empty()) {
+      return true;
     }
-    PrimExpr VisitExpr_(const CallNode *op) final {
-      PrimExpr visited = StmtExprMutator::VisitExpr_(op);
-      const auto *call = visited.as<CallNode>();
-      ICHECK(call != nullptr);
+    PrimExpr linear_id = MakeLinearThreadId(env_threads_);
 
-      if (!call->op.same_as(Op::Get("tl.any_of")) &&
-          !call->op.same_as(Op::Get("tl.all_of"))) {
-        return visited;
-      }
+    PrimExpr condition_one = Substitute(condition, thread_one);
+    PrimExpr condition_two = Substitute(condition, thread_two);
+    PrimExpr linear_one = Substitute(linear_id, thread_one);
+    PrimExpr linear_two = Substitute(linear_id, thread_two);
 
-      ICHECK_EQ(call->args.size(), 3U);
-      const auto *scope = call->args[2].as<StringImmNode>();
-      ICHECK(scope != nullptr);
+    PrimExpr warp_size = make_const(DataType::Int(64), warp_size_);
 
-      if (scope->value != "auto") {
-        return visited;
-      }
+    PrimExpr same_warp =
+        FloorDiv(linear_one, warp_size) == FloorDiv(linear_two, warp_size);
+    PrimExpr agree = Or(And(condition_one, condition_two),
+                        And(Not(condition_one), Not(condition_two)));
+    return analyzer.CanProve(Or(Not(same_warp), agree));
+  }
+  PrimExpr VisitExpr_(const CallNode *op) final {
+    PrimExpr visited = StmtExprMutator::VisitExpr_(op);
+    const auto *call = visited.as<CallNode>();
+    ICHECK(call != nullptr);
 
-      Array<PrimExpr> args = call->args;
-      args.Set(2, StringImm( is_warp_uniform_? "warp" : "thread"));
-      return Call(call->dtype, call->op, args, call->span);
-    }
-
-    Stmt VisitStmt_(const AttrStmtNode *op) final {
-      if (op->attr_key != tirx::attr::thread_extent) {
-        return StmtExprMutator::VisitStmt_(op);
-      }
-      IterVar thread = Downcast<IterVar>(op->node);
-      runtime::ThreadScope scope =
-        runtime::ThreadScope::Create(thread->thread_tag);
-      if (scope.rank != 1) {
-        return StmtExprMutator::VisitStmt_(op);
-      }
-      env_threads_.push_back(thread);
-      Stmt visited = StmtExprMutator::VisitStmt_(op);
-      env_threads_.pop_back();
+    if (!call->op.same_as(Op::Get("tl.any_of")) &&
+        !call->op.same_as(Op::Get("tl.all_of"))) {
       return visited;
     }
 
-    Stmt VisitStmt_(const IfThenElseNode *op) final {
-      auto condition = VisitExpr(op->condition);
+    ICHECK_EQ(call->args.size(), 3U);
+    const auto *scope = call->args[2].as<StringImmNode>();
+    ICHECK(scope != nullptr);
 
-      bool condition_is_uniform = IsWarpUniformCondition(condition);
+    if (scope->value != "auto") {
+      return visited;
+    }
 
-      bool parent_is_uniform = is_warp_uniform_;
+    Array<PrimExpr> args = call->args;
+    args.Set(2, StringImm(is_warp_uniform_ ? "warp" : "thread"));
+    return Call(call->dtype, call->op, args, call->span);
+  }
+
+  Stmt VisitStmt_(const AttrStmtNode *op) final {
+    if (op->attr_key != tirx::attr::thread_extent) {
+      return StmtExprMutator::VisitStmt_(op);
+    }
+    IterVar thread = Downcast<IterVar>(op->node);
+    runtime::ThreadScope scope =
+        runtime::ThreadScope::Create(thread->thread_tag);
+    if (scope.rank != 1) {
+      return StmtExprMutator::VisitStmt_(op);
+    }
+    env_threads_.push_back(thread);
+    Stmt visited = StmtExprMutator::VisitStmt_(op);
+    env_threads_.pop_back();
+    return visited;
+  }
+
+  Stmt VisitStmt_(const IfThenElseNode *op) final {
+    auto condition = VisitExpr(op->condition);
+
+    bool condition_is_uniform = IsWarpUniformCondition(condition);
+
+    bool parent_is_uniform = is_warp_uniform_;
+    is_warp_uniform_ = parent_is_uniform && condition_is_uniform;
+    Stmt then_case = VisitStmt(op->then_case);
+
+    Optional<Stmt> else_case = std::nullopt;
+    if (op->else_case.defined()) {
       is_warp_uniform_ = parent_is_uniform && condition_is_uniform;
-      Stmt then_case = VisitStmt(op->then_case);
-
-      Optional<Stmt> else_case = std::nullopt;
-      if (op->else_case.defined()) {
-        is_warp_uniform_ = parent_is_uniform && condition_is_uniform;
-        else_case = VisitStmt(op->else_case.value());
-      }
-      is_warp_uniform_ = parent_is_uniform;
-      return IfThenElse(condition, then_case, else_case, op->span);
+      else_case = VisitStmt(op->else_case.value());
     }
+    is_warp_uniform_ = parent_is_uniform;
+    return IfThenElse(condition, then_case, else_case, op->span);
+  }
 
-    Array<IterVar> env_threads_;
-    bool is_warp_uniform_{true};
-    int warp_size_;
-  };
+  Array<IterVar> env_threads_;
+  bool is_warp_uniform_{true};
+  int warp_size_;
+};
 
-  PrimFunc ResolveLogicalScopePrimFunc(PrimFunc func) {
-    if (!func.defined() || !func->body.defined()) {
-      return func;
-    }
-
-    auto target = func->GetAttr<Target>(tvm::attr::kTarget);
-    ICHECK(target.defined()) << "ResolveLogicalScope requires a bound target";
-    auto warp_size_attr =
-        target.value()->GetAttr<Integer>("thread_warp_size");
-    ICHECK(warp_size_attr.defined())
-        << "ResolveLogicalScope requires target attribute thread_warp_size";
-    int warp_size = warp_size_attr.value().IntValue();
-    ICHECK_GT(warp_size, 0);
-
-    LogicalScopeResolver resolver(warp_size);
-    PrimFuncNode *node = func.CopyOnWrite();
-    node->body = resolver(std::move(node->body));
+PrimFunc ResolveLogicalScopePrimFunc(PrimFunc func) {
+  if (!func.defined() || !func->body.defined()) {
     return func;
   }
 
-  } // namespace
+  auto target = func->GetAttr<Target>(tvm::attr::kTarget);
+  ICHECK(target.defined()) << "ResolveLogicalScope requires a bound target";
+  auto warp_size_attr = target.value()->GetAttr<Integer>("thread_warp_size");
+  ICHECK(warp_size_attr.defined())
+      << "ResolveLogicalScope requires target attribute thread_warp_size";
+  int warp_size = warp_size_attr.value().IntValue();
+  ICHECK_GT(warp_size, 0);
 
-  namespace transform {
+  LogicalScopeResolver resolver(warp_size);
+  PrimFuncNode *node = func.CopyOnWrite();
+  node->body = resolver(std::move(node->body));
+  return func;
+}
 
-  tvm::transform::Pass ResolveLogicalScope() {
-    auto pass_func = [](PrimFunc func, const IRModule &,
-                        const tvm::transform::PassContext &) {
-      return ResolveLogicalScopePrimFunc(std::move(func));
-    };
+} // namespace
+
+namespace transform {
+
+tvm::transform::Pass ResolveLogicalScope() {
+  auto pass_func = [](PrimFunc func, const IRModule &,
+                      const tvm::transform::PassContext &) {
+    return ResolveLogicalScopePrimFunc(std::move(func));
+  };
 
   return tvm::tirx::transform::CreatePrimFuncPass(pass_func, 0,
                                                   "tl.ResolveLogicalScope", {});
-  }
-  TVM_FFI_STATIC_INIT_BLOCK() {
-    namespace refl = reflection;
-    refl::GlobalDef().def("tl.transform.ResolveLogicalScope",
-                          ResolveLogicalScope);
-  }
+}
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = reflection;
+  refl::GlobalDef().def("tl.transform.ResolveLogicalScope",
+                        ResolveLogicalScope);
+}
 
-  } // namespace transform
-  } // namespace tl
-  } // namespace tvm
+} // namespace transform
+} // namespace tl
+} // namespace tvm

--- a/src/transform/resolve_logical_scope.cc
+++ b/src/transform/resolve_logical_scope.cc
@@ -1,10 +1,13 @@
 #include "support/check.h"
+#include <optional>
 #include <tvm/target/target.h>
 #include <tvm/tirx/op.h>
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
 
 #include "runtime/thread_storage_scope.h"
+#include "../op/builtin.h"
+#include "../op/utils.h"
 #include "tvm/runtime/data_type.h"
 #include "tvm/tirx/stmt.h"
 #include <tvm/arith/analyzer.h>
@@ -43,6 +46,43 @@ PrimExpr MakeLinearThreadId(const Array<IterVar> &thread_vars) {
   return linear_id;
 }
 
+class ThreadPrivateLoadDetector : public ExprVisitor {
+public:
+  bool Detect(const PrimExpr &expr) {
+    found_ = false;
+    VisitExpr(expr);
+    return found_;
+  }
+
+private:
+  void VisitExpr_(const BufferLoadNode *op) final {
+    runtime::StorageScope scope =
+        runtime::StorageScope::Create(op->buffer.scope());
+
+    switch (scope.rank) {
+    case runtime::StorageRank::kWarp:
+    case runtime::StorageRank::kLocal:
+    case runtime::StorageRank::kWMMAMatrixA:
+    case runtime::StorageRank::kWMMAMatrixB:
+    case runtime::StorageRank::kWMMAAccumulator:
+    case runtime::StorageRank::kAMXTMM:
+    case runtime::StorageRank::kMMAMatrixA:
+    case runtime::StorageRank::kMMAMatrixB:
+    case runtime::StorageRank::kMMAMatrixC:
+    case runtime::StorageRank::kMetalSimdGroup:
+      found_ = true;
+      return;
+
+    case runtime::StorageRank::kGlobal:
+    case runtime::StorageRank::kShared:
+    case runtime::StorageRank::kTexture:
+      ExprVisitor::VisitExpr_(op);
+      return;
+    }
+  }
+  bool found_{false};
+};
+
 class LogicalScopeResolver : public StmtExprMutator {
 public:
   explicit LogicalScopeResolver(int warp_size) : warp_size_(warp_size) {}
@@ -50,7 +90,25 @@ public:
   PrimExpr Visit(PrimExpr expr) { return VisitExpr(std::move(expr)); }
 
 private:
-  bool IsWarpUniformCondition(const PrimExpr &condition) {
+  bool IsSharedAccess(const CallNode *logical_call) const {
+    ICHECK_EQ(logical_call->args.size(), 3U);
+    const auto *access_ptr = logical_call->args[0].as<CallNode>();
+    ICHECK(access_ptr != nullptr);
+    ICHECK(access_ptr->op.same_as(tl::access_ptr()));
+    ICHECK_EQ(access_ptr->args.size(), 3U);
+
+    const auto base_load_node = access_ptr->args[0].as<BufferLoadNode>();
+    ICHECK(base_load_node) << "tl.access_ptr base must be BufferLoad, but got "
+                          << access_ptr->args[0];
+    return IsSharedBuffer(base_load_node->buffer);
+  }
+
+  bool IsWarpUniformExpr(const PrimExpr &expr) {
+    PrimExpr expanded_expr = Substitute(expr, bind_values_);
+    ThreadPrivateLoadDetector detector;
+    if (detector.Detect(expanded_expr)) {
+      return false;
+    }
     Map<Var, PrimExpr> thread_one;
     Map<Var, PrimExpr> thread_two;
     arith::Analyzer analyzer;
@@ -70,8 +128,8 @@ private:
     }
     PrimExpr linear_id = MakeLinearThreadId(env_threads_);
 
-    PrimExpr condition_one = Substitute(condition, thread_one);
-    PrimExpr condition_two = Substitute(condition, thread_two);
+    PrimExpr lhs = Substitute(expanded_expr, thread_one);
+    PrimExpr rhs = Substitute(expanded_expr, thread_two);
     PrimExpr linear_one = Substitute(linear_id, thread_one);
     PrimExpr linear_two = Substitute(linear_id, thread_two);
 
@@ -79,11 +137,31 @@ private:
 
     PrimExpr same_warp =
         FloorDiv(linear_one, warp_size) == FloorDiv(linear_two, warp_size);
-    PrimExpr agree = Or(And(condition_one, condition_two),
-                        And(Not(condition_one), Not(condition_two)));
+    PrimExpr agree;
+    if (expanded_expr.dtype().is_bool()) {
+      agree = Or(And(lhs, rhs),
+                        And(Not(lhs), Not(rhs)));
+    } else {
+      agree = lhs == rhs;
+    }
     return analyzer.CanProve(Or(Not(same_warp), agree));
   }
+
   PrimExpr VisitExpr_(const CallNode *op) final {
+    static const Op &if_then_else_op = Op::Get("tirx.if_then_else");
+
+    if (op->op.same_as(if_then_else_op)) {
+      ICHECK_EQ(op->args.size(), 3U);
+      PrimExpr condition = VisitExpr(op->args[0]);
+      const bool condition_is_uniform = IsWarpUniformExpr(condition);
+      const bool parent_is_uniform = is_warp_uniform_;
+      is_warp_uniform_ = condition_is_uniform && parent_is_uniform;
+      PrimExpr then_case = VisitExpr(op->args[1]);
+      is_warp_uniform_ = condition_is_uniform && parent_is_uniform;
+      PrimExpr else_case = VisitExpr(op->args[2]);
+      is_warp_uniform_ = parent_is_uniform;
+      return Call(op->dtype, op->op, {condition, then_case, else_case}, op->span);
+    }
     PrimExpr visited = StmtExprMutator::VisitExpr_(op);
     const auto *call = visited.as<CallNode>();
     ICHECK(call != nullptr);
@@ -102,7 +180,8 @@ private:
     }
 
     Array<PrimExpr> args = call->args;
-    args.Set(2, StringImm(is_warp_uniform_ ? "warp" : "thread"));
+    const bool use_warp = is_warp_uniform_ && IsSharedAccess(call);
+    args.Set(2, StringImm(use_warp ? "warp" : "thread"));
     return Call(call->dtype, call->op, args, call->span);
   }
 
@@ -125,7 +204,7 @@ private:
   Stmt VisitStmt_(const IfThenElseNode *op) final {
     auto condition = VisitExpr(op->condition);
 
-    bool condition_is_uniform = IsWarpUniformCondition(condition);
+    bool condition_is_uniform = IsWarpUniformExpr(condition);
 
     bool parent_is_uniform = is_warp_uniform_;
     is_warp_uniform_ = parent_is_uniform && condition_is_uniform;
@@ -140,7 +219,56 @@ private:
     return IfThenElse(condition, then_case, else_case, op->span);
   }
 
+  Stmt VisitStmt_(const ForNode *op) final {
+    auto min = VisitExpr(op->min);
+    auto extent = VisitExpr(op->extent);
+
+    Optional<PrimExpr> new_step = std::nullopt;
+    auto effective_step = make_const(op->loop_var.dtype(), 1);
+    if (op->step.defined()) {
+      effective_step = VisitExpr(op->step.value());
+      new_step = effective_step;
+    }
+    bool condition_is_uniform = IsWarpUniformExpr(min) && IsWarpUniformExpr(extent) && IsWarpUniformExpr(effective_step);
+
+    bool parent_is_uniform = is_warp_uniform_;
+    is_warp_uniform_ = parent_is_uniform && condition_is_uniform;
+    Stmt body = VisitStmt(op->body);
+
+    is_warp_uniform_ = parent_is_uniform;
+    return For(op->loop_var, min, extent, op->kind, body, op->thread_binding, op->annotations, new_step, op->span);
+  }
+  Stmt VisitStmt_(const WhileNode *op) final {
+    // In a while loop we always turn "auto" -> "thread"
+    bool parent_is_uniform = is_warp_uniform_;
+    is_warp_uniform_ = false;
+    const auto condition = VisitExpr(op->condition);
+    const auto body = VisitStmt(op->body);
+    is_warp_uniform_ = parent_is_uniform;
+    return While(condition, body, op->span);
+  }
+
+  Stmt VisitStmt_(const BindNode *op) final {
+    PrimExpr value = VisitExpr(op->value);
+    PrimExpr expanded_value = Substitute(value, bind_values_);
+
+    bind_values_.Set(op->var, expanded_value);
+    return Bind(op->var, value, op->span);
+  }
+
+  Stmt VisitStmt_(const SeqStmtNode *op) final {
+    auto const parent_bind_values = bind_values_;
+    Array<Stmt> statements;
+    statements.reserve(op->size());
+    for (const Stmt &stmt : op->seq) {
+      statements.push_back(VisitStmt(stmt));
+    }
+    bind_values_ = parent_bind_values;
+    return SeqStmt(statements, op->span);
+  }
+
   Array<IterVar> env_threads_;
+  Map<Var, PrimExpr> bind_values_;
   bool is_warp_uniform_{true};
   int warp_size_;
 };

--- a/src/transform/resolve_logical_scope.cc
+++ b/src/transform/resolve_logical_scope.cc
@@ -80,6 +80,11 @@ private:
       ExprVisitor::VisitExpr_(op);
       return;
     }
+
+    // Treat future storage ranks as thread-private until explicitly
+    // classified above. Keeping this outside the switch preserves -Wswitch
+    // diagnostics when StorageRank gains a new value.
+    found_ = true;
   }
   bool found_{false};
 };

--- a/src/transform/resolve_logical_scope.cc
+++ b/src/transform/resolve_logical_scope.cc
@@ -1,18 +1,19 @@
-#include "support/check.h"
 #include <optional>
+
+#include <tvm/arith/analyzer.h>
+#include <tvm/ir/cast.h>
+#include <tvm/runtime/data_type.h>
 #include <tvm/target/target.h>
+#include <tvm/tirx/analysis.h>
 #include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt.h>
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
 
-#include "runtime/thread_storage_scope.h"
 #include "../op/builtin.h"
 #include "../op/utils.h"
-#include "tvm/runtime/data_type.h"
-#include "tvm/tirx/stmt.h"
-#include <tvm/arith/analyzer.h>
-#include <tvm/ir/cast.h>
-#include <tvm/tirx/analysis.h>
+#include "runtime/thread_storage_scope.h"
+#include "support/check.h"
 
 namespace tvm {
 namespace tl {
@@ -87,23 +88,24 @@ class LogicalScopeResolver : public StmtExprMutator {
 public:
   explicit LogicalScopeResolver(int warp_size) : warp_size_(warp_size) {}
 
-  PrimExpr Visit(PrimExpr expr) { return VisitExpr(std::move(expr)); }
-
 private:
-  bool IsSharedAccess(const CallNode *logical_call) const {
-    ICHECK_EQ(logical_call->args.size(), 3U);
-    const auto *access_ptr = logical_call->args[0].as<CallNode>();
-    ICHECK(access_ptr != nullptr);
-    ICHECK(access_ptr->op.same_as(tl::access_ptr()));
-    ICHECK_EQ(access_ptr->args.size(), 3U);
+  bool HasFullWarps() const {
+    if (env_threads_.empty()) {
+      return false;
+    }
 
-    const auto base_load_node = access_ptr->args[0].as<BufferLoadNode>();
-    ICHECK(base_load_node) << "tl.access_ptr base must be BufferLoad, but got "
-                          << access_ptr->args[0];
-    return IsSharedBuffer(base_load_node->buffer);
+    DataType dtype = DataType::Int(64);
+    PrimExpr thread_count = make_const(dtype, 1);
+    for (const IterVar &thread : env_threads_) {
+      thread_count = thread_count * Cast(dtype, thread->dom->extent);
+    }
+
+    arith::Analyzer analyzer;
+    PrimExpr warp_size = make_const(dtype, warp_size_);
+    return analyzer.CanProve(FloorMod(thread_count, warp_size) == 0);
   }
 
-  bool IsWarpUniformExpr(const PrimExpr &expr) {
+  bool IsWarpUniformExpr(const PrimExpr &expr) const {
     PrimExpr expanded_expr = Substitute(expr, bind_values_);
     ThreadPrivateLoadDetector detector;
     if (detector.Detect(expanded_expr)) {
@@ -139,12 +141,43 @@ private:
         FloorDiv(linear_one, warp_size) == FloorDiv(linear_two, warp_size);
     PrimExpr agree;
     if (expanded_expr.dtype().is_bool()) {
-      agree = Or(And(lhs, rhs),
-                        And(Not(lhs), Not(rhs)));
+      agree = Or(And(lhs, rhs), And(Not(lhs), Not(rhs)));
     } else {
       agree = lhs == rhs;
     }
     return analyzer.CanProve(Or(Not(same_warp), agree));
+  }
+
+  bool IsWarpUniformAccess(const CallNode *logical_call) const {
+    ICHECK(logical_call->args.size() == 2U || logical_call->args.size() == 3U);
+    const auto *access_ptr = logical_call->args[0].as<CallNode>();
+    ICHECK(access_ptr != nullptr);
+    ICHECK(access_ptr->op.same_as(tl::access_ptr()));
+    ICHECK_EQ(access_ptr->args.size(), 3U);
+    const auto *base_load = access_ptr->args[0].as<BufferLoadNode>();
+    ICHECK(base_load != nullptr)
+        << "tl.access_ptr base must be BufferLoad, but got "
+        << access_ptr->args[0];
+    if (!IsSharedBuffer(base_load->buffer) &&
+        !IsGlobalBuffer(base_load->buffer)) {
+      return false;
+    }
+    for (const PrimExpr &index : base_load->indices) {
+      if (!IsWarpUniformExpr(index)) {
+        return false;
+      }
+    }
+    const PrimExpr &access_extent = access_ptr->args[1];
+    if (!IsWarpUniformExpr(access_extent)) {
+      return false;
+    }
+
+    const PrimExpr &reduction_size = logical_call->args[1];
+    if (!IsWarpUniformExpr(reduction_size)) {
+      return false;
+    }
+
+    return true;
   }
 
   PrimExpr VisitExpr_(const CallNode *op) final {
@@ -160,7 +193,8 @@ private:
       is_warp_uniform_ = condition_is_uniform && parent_is_uniform;
       PrimExpr else_case = VisitExpr(op->args[2]);
       is_warp_uniform_ = parent_is_uniform;
-      return Call(op->dtype, op->op, {condition, then_case, else_case}, op->span);
+      return Call(op->dtype, op->op, {condition, then_case, else_case},
+                  op->span);
     }
     PrimExpr visited = StmtExprMutator::VisitExpr_(op);
     const auto *call = visited.as<CallNode>();
@@ -171,18 +205,35 @@ private:
       return visited;
     }
 
-    ICHECK_EQ(call->args.size(), 3U);
-    const auto *scope = call->args[2].as<StringImmNode>();
-    ICHECK(scope != nullptr);
-
-    if (scope->value != "auto") {
-      return visited;
+    ICHECK(call->args.size() == 2U || call->args.size() == 3U);
+    if (call->args.size() == 3U) {
+      const auto *scope = call->args[2].as<StringImmNode>();
+      ICHECK(scope != nullptr);
+      if (scope->value != "auto") {
+        return visited;
+      }
     }
 
     Array<PrimExpr> args = call->args;
-    const bool use_warp = is_warp_uniform_ && IsSharedAccess(call);
-    args.Set(2, StringImm(use_warp ? "warp" : "thread"));
+    const bool use_warp =
+        is_warp_uniform_ && HasFullWarps() && IsWarpUniformAccess(call);
+    if (args.size() == 2U) {
+      args.push_back(StringImm(use_warp ? "warp" : "thread"));
+    } else {
+      args.Set(2, StringImm(use_warp ? "warp" : "thread"));
+    }
     return Call(call->dtype, call->op, args, call->span);
+  }
+
+  PrimExpr VisitExpr_(const LetNode *op) final {
+    PrimExpr value = VisitExpr(op->value);
+    PrimExpr expanded_value = Substitute(value, bind_values_);
+
+    Map<Var, PrimExpr> parent_bind_values = bind_values_;
+    bind_values_.Set(op->var, expanded_value);
+    PrimExpr body = VisitExpr(op->body);
+    bind_values_ = parent_bind_values;
+    return Let(op->var, value, body, op->span);
   }
 
   Stmt VisitStmt_(const AttrStmtNode *op) final {
@@ -229,14 +280,17 @@ private:
       effective_step = VisitExpr(op->step.value());
       new_step = effective_step;
     }
-    bool condition_is_uniform = IsWarpUniformExpr(min) && IsWarpUniformExpr(extent) && IsWarpUniformExpr(effective_step);
+    bool condition_is_uniform = IsWarpUniformExpr(min) &&
+                                IsWarpUniformExpr(extent) &&
+                                IsWarpUniformExpr(effective_step);
 
     bool parent_is_uniform = is_warp_uniform_;
     is_warp_uniform_ = parent_is_uniform && condition_is_uniform;
     Stmt body = VisitStmt(op->body);
 
     is_warp_uniform_ = parent_is_uniform;
-    return For(op->loop_var, min, extent, op->kind, body, op->thread_binding, op->annotations, new_step, op->span);
+    return For(op->loop_var, min, extent, op->kind, body, op->thread_binding,
+               op->annotations, new_step, op->span);
   }
   Stmt VisitStmt_(const WhileNode *op) final {
     // In a while loop we always turn "auto" -> "thread"

--- a/testing/python/language/test_tilelang_language_all_of.py
+++ b/testing/python/language/test_tilelang_language_all_of.py
@@ -25,7 +25,7 @@ def shared_all_of(size, threads, scope=None):
 
 
 @tilelang.testing.requires_cuda
-@pytest.mark.parametrize("scope", [None, "thread", "warp"])
+@pytest.mark.parametrize("scope", [None, "auto", "thread", "warp"])
 def test_all_of_shared_scope(scope):
     size, threads = 70, 32
     kernel = tilelang.compile(shared_all_of(size, threads, scope), target="cuda", out_idx=-1)
@@ -54,6 +54,18 @@ def test_all_of_shared_warp_scope_rocm():
         torch.testing.assert_close(result, expected)
 
     assert "tl::AllWarp" in kernel.get_kernel_source()
+
+
+def test_all_of_rejects_invalid_scope():
+    with pytest.raises(
+        ValueError,
+        match="scope must be 'auto', 'thread' or 'warp'",
+    ):
+
+        @T.prim_func
+        def main(source: T.Tensor((1,), "int32")):
+            with T.Kernel(1, threads=1):
+                T.evaluate(T.all_of(source, scope="block"))
 
 
 def ref_program(A, B, BlockMask, block_M, block_N, block_K):

--- a/testing/python/language/test_tilelang_language_all_of.py
+++ b/testing/python/language/test_tilelang_language_all_of.py
@@ -1,7 +1,59 @@
 import tilelang
 import tilelang.testing
 import tilelang.language as T
+import pytest
 import torch
+
+
+def shared_all_of(size, threads, scope=None):
+    @T.prim_func
+    def main(
+        source: T.Tensor((size,), "int32"),
+        result: T.Tensor((threads,), "bool"),
+    ):
+        with T.Kernel(1, threads=threads):
+            shared = T.alloc_shared((size,), "int32")
+            tx = T.get_thread_binding()
+            T.copy(source, shared)
+            T.sync_threads()
+            if scope is None:
+                result[tx] = T.all_of(shared)
+            else:
+                result[tx] = T.all_of(shared, scope=scope)
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("scope", [None, "thread", "warp"])
+def test_all_of_shared_scope(scope):
+    size, threads = 70, 32
+    kernel = tilelang.compile(shared_all_of(size, threads, scope), target="cuda", out_idx=-1)
+    for false_index in (None, 0, threads - 1, size - 1):
+        source = torch.ones(size, dtype=torch.int32, device="cuda")
+        if false_index is not None:
+            source[false_index] = 0
+        result = kernel(source)
+        expected = torch.full((threads,), false_index is None, dtype=torch.bool, device="cuda")
+        torch.testing.assert_close(result, expected)
+
+    helper = "tl::AllWarp" if scope == "warp" else "tl::All"
+    assert helper in kernel.get_kernel_source()
+
+
+@tilelang.testing.requires_rocm
+def test_all_of_shared_warp_scope_rocm():
+    size, threads = 134, 64
+    kernel = tilelang.compile(shared_all_of(size, threads, "warp"), target="hip", out_idx=-1)
+    for false_index in (None, size - 1):
+        source = torch.ones(size, dtype=torch.int32, device="cuda")
+        if false_index is not None:
+            source[false_index] = 0
+        result = kernel(source)
+        expected = torch.full((threads,), false_index is None, dtype=torch.bool, device="cuda")
+        torch.testing.assert_close(result, expected)
+
+    assert "tl::AllWarp" in kernel.get_kernel_source()
 
 
 def ref_program(A, B, BlockMask, block_M, block_N, block_K):

--- a/testing/python/language/test_tilelang_language_all_of.py
+++ b/testing/python/language/test_tilelang_language_all_of.py
@@ -1,11 +1,10 @@
 import tilelang
 import tilelang.testing
 import tilelang.language as T
-import pytest
 import torch
 
 
-def shared_all_of(size, threads, scope=None):
+def shared_all_of(size, threads):
     @T.prim_func
     def main(
         source: T.Tensor((size,), "int32"),
@@ -16,19 +15,28 @@ def shared_all_of(size, threads, scope=None):
             tx = T.get_thread_binding()
             T.copy(source, shared)
             T.sync_threads()
-            if scope is None:
-                result[tx] = T.all_of(shared)
-            else:
-                result[tx] = T.all_of(shared, scope=scope)
+            result[tx] = T.all_of(shared)
+
+    return main
+
+
+def global_all_of(size, threads):
+    @T.prim_func
+    def main(
+        source: T.Tensor((size,), "int32"),
+        result: T.Tensor((threads,), "bool"),
+    ):
+        with T.Kernel(1, threads=threads):
+            tx = T.get_thread_binding()
+            result[tx] = T.all_of(source)
 
     return main
 
 
 @tilelang.testing.requires_cuda
-@pytest.mark.parametrize("scope", [None, "auto", "thread", "warp"])
-def test_all_of_shared_scope(scope):
+def test_all_of_shared_scope():
     size, threads = 70, 32
-    kernel = tilelang.compile(shared_all_of(size, threads, scope), target="cuda", out_idx=-1)
+    kernel = tilelang.compile(shared_all_of(size, threads), target="cuda", out_idx=-1)
     for false_index in (None, 0, threads - 1, size - 1):
         source = torch.ones(size, dtype=torch.int32, device="cuda")
         if false_index is not None:
@@ -37,14 +45,39 @@ def test_all_of_shared_scope(scope):
         expected = torch.full((threads,), false_index is None, dtype=torch.bool, device="cuda")
         torch.testing.assert_close(result, expected)
 
-    helper = "tl::AllWarp" if scope == "warp" else "tl::All"
-    assert helper in kernel.get_kernel_source()
+    assert "tl::AllWarp(" in kernel.get_kernel_source()
+
+
+@tilelang.testing.requires_cuda
+def test_all_of_auto_scope_partial_warp_falls_back_to_thread():
+    size, threads = 70, 48
+    kernel = tilelang.compile(shared_all_of(size, threads), target="cuda", out_idx=-1)
+    source = torch.ones(size, dtype=torch.int32, device="cuda")
+    source[20] = 0
+
+    result = kernel(source)
+    expected = torch.zeros(threads, dtype=torch.bool, device="cuda")
+    torch.testing.assert_close(result, expected)
+    assert "tl::All(" in kernel.get_kernel_source()
+
+
+@tilelang.testing.requires_cuda
+def test_all_of_global_uniform_range_uses_warp():
+    size, threads = 70, 32
+    kernel = tilelang.compile(global_all_of(size, threads), target="cuda", out_idx=-1)
+    source = torch.ones(size, dtype=torch.int32, device="cuda")
+    source[-1] = 0
+
+    result = kernel(source)
+    expected = torch.zeros(threads, dtype=torch.bool, device="cuda")
+    torch.testing.assert_close(result, expected)
+    assert "tl::AllWarp(" in kernel.get_kernel_source()
 
 
 @tilelang.testing.requires_rocm
-def test_all_of_shared_warp_scope_rocm():
+def test_all_of_shared_scope_rocm():
     size, threads = 134, 64
-    kernel = tilelang.compile(shared_all_of(size, threads, "warp"), target="hip", out_idx=-1)
+    kernel = tilelang.compile(shared_all_of(size, threads), target="hip", out_idx=-1)
     for false_index in (None, size - 1):
         source = torch.ones(size, dtype=torch.int32, device="cuda")
         if false_index is not None:
@@ -54,18 +87,6 @@ def test_all_of_shared_warp_scope_rocm():
         torch.testing.assert_close(result, expected)
 
     assert "tl::AllWarp" in kernel.get_kernel_source()
-
-
-def test_all_of_rejects_invalid_scope():
-    with pytest.raises(
-        ValueError,
-        match="scope must be 'auto', 'thread' or 'warp'",
-    ):
-
-        @T.prim_func
-        def main(source: T.Tensor((1,), "int32")):
-            with T.Kernel(1, threads=1):
-                T.evaluate(T.all_of(source, scope="block"))
 
 
 def ref_program(A, B, BlockMask, block_M, block_N, block_K):

--- a/testing/python/language/test_tilelang_language_any_of.py
+++ b/testing/python/language/test_tilelang_language_any_of.py
@@ -25,7 +25,7 @@ def shared_any_of(size, threads, scope=None):
 
 
 @tilelang.testing.requires_cuda
-@pytest.mark.parametrize("scope", [None, "thread", "warp"])
+@pytest.mark.parametrize("scope", [None, "auto", "thread", "warp"])
 def test_any_of_shared_scope(scope):
     size, threads = 70, 32
     kernel = tilelang.compile(shared_any_of(size, threads, scope), target="cuda", out_idx=-1)
@@ -57,7 +57,7 @@ def test_any_of_shared_warp_scope_rocm():
 
 
 def test_any_of_rejects_invalid_scope():
-    with pytest.raises(ValueError, match="scope must be 'thread' or 'warp'"):
+    with pytest.raises(ValueError, match="scope must be 'auto', 'thread' or 'warp'"):
 
         @T.prim_func
         def main(source: T.Tensor((1,), "int32")):

--- a/testing/python/language/test_tilelang_language_any_of.py
+++ b/testing/python/language/test_tilelang_language_any_of.py
@@ -1,7 +1,68 @@
 import tilelang
 import tilelang.testing
 import tilelang.language as T
+import pytest
 import torch
+
+
+def shared_any_of(size, threads, scope=None):
+    @T.prim_func
+    def main(
+        source: T.Tensor((size,), "int32"),
+        result: T.Tensor((threads,), "bool"),
+    ):
+        with T.Kernel(1, threads=threads):
+            shared = T.alloc_shared((size,), "int32")
+            tx = T.get_thread_binding()
+            T.copy(source, shared)
+            T.sync_threads()
+            if scope is None:
+                result[tx] = T.any_of(shared)
+            else:
+                result[tx] = T.any_of(shared, scope=scope)
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("scope", [None, "thread", "warp"])
+def test_any_of_shared_scope(scope):
+    size, threads = 70, 32
+    kernel = tilelang.compile(shared_any_of(size, threads, scope), target="cuda", out_idx=-1)
+    for true_index in (None, 0, threads - 1, size - 1):
+        source = torch.zeros(size, dtype=torch.int32, device="cuda")
+        if true_index is not None:
+            source[true_index] = 1
+        result = kernel(source)
+        expected = torch.full((threads,), true_index is not None, dtype=torch.bool, device="cuda")
+        torch.testing.assert_close(result, expected)
+
+    helper = "tl::AnyWarp" if scope == "warp" else "tl::Any"
+    assert helper in kernel.get_kernel_source()
+
+
+@tilelang.testing.requires_rocm
+def test_any_of_shared_warp_scope_rocm():
+    size, threads = 134, 64
+    kernel = tilelang.compile(shared_any_of(size, threads, "warp"), target="hip", out_idx=-1)
+    for true_index in (None, size - 1):
+        source = torch.zeros(size, dtype=torch.int32, device="cuda")
+        if true_index is not None:
+            source[true_index] = 1
+        result = kernel(source)
+        expected = torch.full((threads,), true_index is not None, dtype=torch.bool, device="cuda")
+        torch.testing.assert_close(result, expected)
+
+    assert "tl::AnyWarp" in kernel.get_kernel_source()
+
+
+def test_any_of_rejects_invalid_scope():
+    with pytest.raises(ValueError, match="scope must be 'thread' or 'warp'"):
+
+        @T.prim_func
+        def main(source: T.Tensor((1,), "int32")):
+            with T.Kernel(1, threads=1):
+                T.evaluate(T.any_of(source, scope="block"))
 
 
 def ref_program(A, B, BlockMask, block_M, block_N, block_K):

--- a/testing/python/language/test_tilelang_language_any_of.py
+++ b/testing/python/language/test_tilelang_language_any_of.py
@@ -1,11 +1,10 @@
 import tilelang
 import tilelang.testing
 import tilelang.language as T
-import pytest
 import torch
 
 
-def shared_any_of(size, threads, scope=None):
+def shared_any_of(size, threads):
     @T.prim_func
     def main(
         source: T.Tensor((size,), "int32"),
@@ -16,19 +15,28 @@ def shared_any_of(size, threads, scope=None):
             tx = T.get_thread_binding()
             T.copy(source, shared)
             T.sync_threads()
-            if scope is None:
-                result[tx] = T.any_of(shared)
-            else:
-                result[tx] = T.any_of(shared, scope=scope)
+            result[tx] = T.any_of(shared)
+
+    return main
+
+
+def global_any_of(size, threads):
+    @T.prim_func
+    def main(
+        source: T.Tensor((size,), "int32"),
+        result: T.Tensor((threads,), "bool"),
+    ):
+        with T.Kernel(1, threads=threads):
+            tx = T.get_thread_binding()
+            result[tx] = T.any_of(source)
 
     return main
 
 
 @tilelang.testing.requires_cuda
-@pytest.mark.parametrize("scope", [None, "auto", "thread", "warp"])
-def test_any_of_shared_scope(scope):
+def test_any_of_shared_scope():
     size, threads = 70, 32
-    kernel = tilelang.compile(shared_any_of(size, threads, scope), target="cuda", out_idx=-1)
+    kernel = tilelang.compile(shared_any_of(size, threads), target="cuda", out_idx=-1)
     for true_index in (None, 0, threads - 1, size - 1):
         source = torch.zeros(size, dtype=torch.int32, device="cuda")
         if true_index is not None:
@@ -37,14 +45,39 @@ def test_any_of_shared_scope(scope):
         expected = torch.full((threads,), true_index is not None, dtype=torch.bool, device="cuda")
         torch.testing.assert_close(result, expected)
 
-    helper = "tl::AnyWarp" if scope == "warp" else "tl::Any"
-    assert helper in kernel.get_kernel_source()
+    assert "tl::AnyWarp(" in kernel.get_kernel_source()
+
+
+@tilelang.testing.requires_cuda
+def test_any_of_auto_scope_partial_warp_falls_back_to_thread():
+    size, threads = 70, 48
+    kernel = tilelang.compile(shared_any_of(size, threads), target="cuda", out_idx=-1)
+    source = torch.zeros(size, dtype=torch.int32, device="cuda")
+    source[20] = 1
+
+    result = kernel(source)
+    expected = torch.ones(threads, dtype=torch.bool, device="cuda")
+    torch.testing.assert_close(result, expected)
+    assert "tl::Any(" in kernel.get_kernel_source()
+
+
+@tilelang.testing.requires_cuda
+def test_any_of_global_uniform_range_uses_warp():
+    size, threads = 70, 32
+    kernel = tilelang.compile(global_any_of(size, threads), target="cuda", out_idx=-1)
+    source = torch.zeros(size, dtype=torch.int32, device="cuda")
+    source[-1] = 1
+
+    result = kernel(source)
+    expected = torch.ones(threads, dtype=torch.bool, device="cuda")
+    torch.testing.assert_close(result, expected)
+    assert "tl::AnyWarp(" in kernel.get_kernel_source()
 
 
 @tilelang.testing.requires_rocm
-def test_any_of_shared_warp_scope_rocm():
+def test_any_of_shared_scope_rocm():
     size, threads = 134, 64
-    kernel = tilelang.compile(shared_any_of(size, threads, "warp"), target="hip", out_idx=-1)
+    kernel = tilelang.compile(shared_any_of(size, threads), target="hip", out_idx=-1)
     for true_index in (None, size - 1):
         source = torch.zeros(size, dtype=torch.int32, device="cuda")
         if true_index is not None:
@@ -54,15 +87,6 @@ def test_any_of_shared_warp_scope_rocm():
         torch.testing.assert_close(result, expected)
 
     assert "tl::AnyWarp" in kernel.get_kernel_source()
-
-
-def test_any_of_rejects_invalid_scope():
-    with pytest.raises(ValueError, match="scope must be 'auto', 'thread' or 'warp'"):
-
-        @T.prim_func
-        def main(source: T.Tensor((1,), "int32")):
-            with T.Kernel(1, threads=1):
-                T.evaluate(T.any_of(source, scope="block"))
 
 
 def ref_program(A, B, BlockMask, block_M, block_N, block_K):

--- a/testing/python/transform/test_tilelang_transform_resolve_logical_scope.py
+++ b/testing/python/transform/test_tilelang_transform_resolve_logical_scope.py
@@ -8,9 +8,7 @@ from tvm.tirx.stmt_functor import post_order_visit
 
 
 _CUDA_TARGET = tvm.target.Target({"kind": "cuda", "arch": "sm_90"})
-_ROCM_TARGET = tvm.target.Target(
-    {"kind": "hip", "mcpu": "gfx90a", "thread_warp_size": 64}
-)
+_ROCM_TARGET = tvm.target.Target({"kind": "hip", "mcpu": "gfx90a", "thread_warp_size": 64})
 
 
 def _make_any_of_kernel(condition_kind, scope="auto"):

--- a/testing/python/transform/test_tilelang_transform_resolve_logical_scope.py
+++ b/testing/python/transform/test_tilelang_transform_resolve_logical_scope.py
@@ -1,0 +1,150 @@
+import pytest
+
+import tilelang
+import tilelang.language as T
+from tilelang import tvm
+from tvm.tirx import op
+from tvm.tirx.stmt_functor import post_order_visit
+
+
+_CUDA_TARGET = tvm.target.Target({"kind": "cuda", "arch": "sm_90"})
+_ROCM_TARGET = tvm.target.Target(
+    {"kind": "hip", "mcpu": "gfx90a", "thread_warp_size": 64}
+)
+
+
+def _make_any_of_kernel(condition_kind, scope="auto"):
+    @T.prim_func
+    def main(
+        source: T.Tensor((70,), "int32"),
+        result: T.Tensor((64,), "bool"),
+    ):
+        with T.Kernel(1, threads=64):
+            tx = T.get_thread_binding()
+
+            if condition_kind == "none":
+                result[tx] = T.any_of(source, scope=scope)
+            elif condition_kind == "single_lane":
+                if tx == 0:
+                    result[tx] = T.any_of(source, scope=scope)
+            elif condition_kind == "warp_group":
+                if tx // 32 == 0:
+                    result[tx] = T.any_of(source, scope=scope)
+            elif condition_kind == "alternating":
+                if tx % 2 == 0:
+                    result[tx] = T.any_of(source, scope=scope)
+            else:
+                raise ValueError(condition_kind)
+
+    return main
+
+
+def _make_all_of_kernel(divergent):
+    @T.prim_func
+    def main(
+        source: T.Tensor((70,), "int32"),
+        result: T.Tensor((64,), "bool"),
+    ):
+        with T.Kernel(1, threads=64):
+            tx = T.get_thread_binding()
+            if divergent:
+                if tx == 0:
+                    result[tx] = T.all_of(source)
+            else:
+                result[tx] = T.all_of(source)
+
+    return main
+
+
+def _make_nested_any_of_kernel():
+    @T.prim_func
+    def main(
+        source: T.Tensor((70,), "int32"),
+        result: T.Tensor((64,), "bool"),
+    ):
+        with T.Kernel(1, threads=64):
+            tx = T.get_thread_binding()
+            if tx == 0:
+                result[tx] = T.any_of(source)
+            result[tx] = T.any_of(source)
+
+    return main
+
+
+def _make_wave_partitioned_kernel(divisor):
+    @T.prim_func
+    def main(
+        source: T.Tensor((70,), "int32"),
+        result: T.Tensor((128,), "bool"),
+    ):
+        with T.Kernel(1, threads=128):
+            tx = T.get_thread_binding()
+            if tx // divisor == 0:
+                result[tx] = T.any_of(source)
+
+    return main
+
+
+def _resolve(func, target=_CUDA_TARGET):
+    mod = tvm.IRModule({"main": func})
+    mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch()(mod)
+    return tilelang.transform.ResolveLogicalScope()(mod)["main"]
+
+
+def _logical_scopes(func, op_name="tl.any_of"):
+    scopes = []
+    logical_op = op.Op.get(op_name)
+
+    def collect(node):
+        if isinstance(node, tvm.tirx.Call) and node.op.same_as(logical_op):
+            assert len(node.args) == 3
+            scope = node.args[2]
+            assert isinstance(scope, tvm.tirx.StringImm)
+            scopes.append(scope.value)
+
+    post_order_visit(func.body, collect)
+    return scopes
+
+
+@pytest.mark.parametrize(
+    ("condition_kind", "expected_scope"),
+    [
+        ("none", "warp"),
+        ("single_lane", "thread"),
+        ("warp_group", "warp"),
+        ("alternating", "thread"),
+    ],
+)
+def test_resolve_any_of_auto_scope(condition_kind, expected_scope):
+    resolved = _resolve(_make_any_of_kernel(condition_kind))
+    assert _logical_scopes(resolved) == [expected_scope]
+
+
+@pytest.mark.parametrize("scope", ["thread", "warp"])
+def test_resolve_any_of_preserves_explicit_scope(scope):
+    resolved = _resolve(_make_any_of_kernel("single_lane", scope=scope))
+    assert _logical_scopes(resolved) == [scope]
+
+
+@pytest.mark.parametrize(
+    ("divergent", "expected_scope"),
+    [(False, "warp"), (True, "thread")],
+)
+def test_resolve_all_of_auto_scope(divergent, expected_scope):
+    resolved = _resolve(_make_all_of_kernel(divergent))
+    assert _logical_scopes(resolved, "tl.all_of") == [expected_scope]
+
+
+def test_resolve_restores_scope_after_divergent_branch():
+    resolved = _resolve(_make_nested_any_of_kernel())
+    assert _logical_scopes(resolved) == ["thread", "warp"]
+
+
+@pytest.mark.parametrize(
+    ("divisor", "expected_scope"),
+    [(64, "warp"), (32, "thread")],
+)
+def test_resolve_uses_target_warp_size(divisor, expected_scope):
+    resolved = _resolve(_make_wave_partitioned_kernel(divisor), _ROCM_TARGET)
+    assert _logical_scopes(resolved) == [expected_scope]

--- a/testing/python/transform/test_tilelang_transform_resolve_logical_scope.py
+++ b/testing/python/transform/test_tilelang_transform_resolve_logical_scope.py
@@ -18,19 +18,20 @@ def _make_any_of_kernel(condition_kind, scope="auto"):
         result: T.Tensor((64,), "bool"),
     ):
         with T.Kernel(1, threads=64):
+            shared = T.alloc_shared((70,), "int32")
             tx = T.get_thread_binding()
 
             if condition_kind == "none":
-                result[tx] = T.any_of(source, scope=scope)
+                result[tx] = T.any_of(shared, scope=scope)
             elif condition_kind == "single_lane":
                 if tx == 0:
-                    result[tx] = T.any_of(source, scope=scope)
+                    result[tx] = T.any_of(shared, scope=scope)
             elif condition_kind == "warp_group":
                 if tx // 32 == 0:
-                    result[tx] = T.any_of(source, scope=scope)
+                    result[tx] = T.any_of(shared, scope=scope)
             elif condition_kind == "alternating":
                 if tx % 2 == 0:
-                    result[tx] = T.any_of(source, scope=scope)
+                    result[tx] = T.any_of(shared, scope=scope)
             else:
                 raise ValueError(condition_kind)
 
@@ -44,12 +45,13 @@ def _make_all_of_kernel(divergent):
         result: T.Tensor((64,), "bool"),
     ):
         with T.Kernel(1, threads=64):
+            shared = T.alloc_shared((70,), "int32")
             tx = T.get_thread_binding()
             if divergent:
                 if tx == 0:
-                    result[tx] = T.all_of(source)
+                    result[tx] = T.all_of(shared)
             else:
-                result[tx] = T.all_of(source)
+                result[tx] = T.all_of(shared)
 
     return main
 
@@ -61,10 +63,11 @@ def _make_nested_any_of_kernel():
         result: T.Tensor((64,), "bool"),
     ):
         with T.Kernel(1, threads=64):
+            shared = T.alloc_shared((70,), "int32")
             tx = T.get_thread_binding()
             if tx == 0:
-                result[tx] = T.any_of(source)
-            result[tx] = T.any_of(source)
+                result[tx] = T.any_of(shared)
+            result[tx] = T.any_of(shared)
 
     return main
 
@@ -76,9 +79,89 @@ def _make_wave_partitioned_kernel(divisor):
         result: T.Tensor((128,), "bool"),
     ):
         with T.Kernel(1, threads=128):
+            shared = T.alloc_shared((70,), "int32")
             tx = T.get_thread_binding()
             if tx // divisor == 0:
-                result[tx] = T.any_of(source)
+                result[tx] = T.any_of(shared)
+
+    return main
+
+
+def _make_loop_any_of_kernel(loop_kind):
+    @T.prim_func
+    def main(
+        source: T.Tensor((70,), "int32"),
+        result: T.Tensor((64,), "bool"),
+    ):
+        with T.Kernel(1, threads=64):
+            shared = T.alloc_shared((70,), "int32")
+            tx = T.get_thread_binding()
+
+            if loop_kind == "constant":
+                for _ in T.serial(4):
+                    result[tx] = T.any_of(shared)
+            elif loop_kind == "lane_extent":
+                for _ in T.serial(tx + 1):
+                    result[tx] = T.any_of(shared)
+            elif loop_kind == "warp_extent":
+                for _ in T.serial(tx // 32 + 1):
+                    result[tx] = T.any_of(shared)
+            elif loop_kind == "alternating_extent":
+                for _ in T.serial(tx % 2 + 1):
+                    result[tx] = T.any_of(shared)
+            else:
+                raise ValueError(loop_kind)
+
+    return main
+
+
+def _make_bound_condition_kernel(binding_kind):
+    @T.prim_func
+    def main(
+        source: T.Tensor((70,), "int32"),
+        result: T.Tensor((64,), "bool"),
+    ):
+        with T.Kernel(1, threads=64):
+            shared = T.alloc_shared((70,), "int32")
+            tx = T.get_thread_binding()
+
+            if binding_kind == "direct":
+                lane = T.bind(tx % 2)
+                if lane == 0:
+                    result[tx] = T.any_of(shared)
+            elif binding_kind == "chained":
+                lane = T.bind(tx % 2)
+                predicate = T.bind(lane == 0)
+                if predicate:
+                    result[tx] = T.any_of(shared)
+            elif binding_kind == "warp_group":
+                warp = T.bind(tx // 32)
+                if warp == 0:
+                    result[tx] = T.any_of(shared)
+            else:
+                raise ValueError(binding_kind)
+
+    return main
+
+
+def _make_if_then_else_any_of_kernel(condition_kind):
+    @T.prim_func
+    def main(
+        source: T.Tensor((70,), "int32"),
+        result: T.Tensor((64,), "bool"),
+    ):
+        with T.Kernel(1, threads=64):
+            shared = T.alloc_shared((70,), "int32")
+            tx = T.get_thread_binding()
+
+            if condition_kind == "single_lane":
+                result[tx] = T.if_then_else(tx == 0, T.any_of(shared), False)
+            elif condition_kind == "warp_group":
+                result[tx] = T.if_then_else(tx // 32 == 0, T.any_of(shared), False)
+            else:
+                raise ValueError(condition_kind)
+
+            result[tx] = T.any_of(shared)
 
     return main
 
@@ -146,3 +229,75 @@ def test_resolve_restores_scope_after_divergent_branch():
 def test_resolve_uses_target_warp_size(divisor, expected_scope):
     resolved = _resolve(_make_wave_partitioned_kernel(divisor), _ROCM_TARGET)
     assert _logical_scopes(resolved) == [expected_scope]
+
+
+def test_resolve_global_auto_scope_stays_thread():
+    @T.prim_func
+    def main(
+        source: T.Tensor((70,), "int32"),
+        result: T.Tensor((64,), "bool"),
+    ):
+        with T.Kernel(1, threads=64):
+            tx = T.get_thread_binding()
+            result[tx] = T.any_of(source)
+
+    resolved = _resolve(main)
+    assert _logical_scopes(resolved) == ["thread"]
+
+
+@pytest.mark.parametrize(
+    ("loop_kind", "expected_scope"),
+    [
+        ("constant", "warp"),
+        ("lane_extent", "thread"),
+        ("warp_extent", "warp"),
+        ("alternating_extent", "thread"),
+    ],
+)
+def test_resolve_auto_scope_in_loop(loop_kind, expected_scope):
+    resolved = _resolve(_make_loop_any_of_kernel(loop_kind))
+    assert _logical_scopes(resolved) == [expected_scope]
+
+
+@pytest.mark.parametrize(
+    ("binding_kind", "expected_scope"),
+    [
+        ("direct", "thread"),
+        ("chained", "thread"),
+        ("warp_group", "warp"),
+    ],
+)
+def test_resolve_auto_scope_through_bindings(binding_kind, expected_scope):
+    resolved = _resolve(_make_bound_condition_kernel(binding_kind))
+    assert _logical_scopes(resolved) == [expected_scope]
+
+
+@pytest.mark.parametrize(
+    ("condition_kind", "expected_scope"),
+    [
+        ("single_lane", "thread"),
+        ("warp_group", "warp"),
+    ],
+)
+def test_resolve_auto_scope_in_if_then_else(condition_kind, expected_scope):
+    resolved = _resolve(_make_if_then_else_any_of_kernel(condition_kind))
+    assert _logical_scopes(resolved) == [expected_scope, "warp"]
+
+
+def test_resolve_local_buffer_condition_stays_thread():
+    @T.prim_func
+    def main(
+        source: T.Tensor((70,), "int32"),
+        result: T.Tensor((64,), "bool"),
+    ):
+        with T.Kernel(1, threads=64):
+            shared = T.alloc_shared((70,), "int32")
+            predicate = T.alloc_local((1,), "bool")
+            tx = T.get_thread_binding()
+
+            predicate[0] = tx == 0
+            if predicate[0]:
+                result[tx] = T.any_of(shared)
+
+    resolved = _resolve(main)
+    assert _logical_scopes(resolved) == ["thread"]

--- a/testing/python/transform/test_tilelang_transform_resolve_logical_scope.py
+++ b/testing/python/transform/test_tilelang_transform_resolve_logical_scope.py
@@ -3,15 +3,17 @@ import pytest
 import tilelang
 import tilelang.language as T
 from tilelang import tvm
+from tilelang.rocm.target import with_rocm_target_attrs
 from tvm.tirx import op
 from tvm.tirx.stmt_functor import post_order_visit
 
 
 _CUDA_TARGET = tvm.target.Target({"kind": "cuda", "arch": "sm_90"})
-_ROCM_TARGET = tvm.target.Target({"kind": "hip", "mcpu": "gfx90a", "thread_warp_size": 64})
+_ROCM_TARGET = with_rocm_target_attrs(tvm.target.Target({"kind": "hip", "mcpu": "gfx90a"}))
+_ROCM_WAVE32_TARGET = with_rocm_target_attrs(tvm.target.Target({"kind": "hip", "mcpu": "gfx1100"}))
 
 
-def _make_any_of_kernel(condition_kind, scope="auto"):
+def _make_any_of_kernel(condition_kind):
     @T.prim_func
     def main(
         source: T.Tensor((70,), "int32"),
@@ -22,16 +24,16 @@ def _make_any_of_kernel(condition_kind, scope="auto"):
             tx = T.get_thread_binding()
 
             if condition_kind == "none":
-                result[tx] = T.any_of(shared, scope=scope)
+                result[tx] = T.any_of(shared)
             elif condition_kind == "single_lane":
                 if tx == 0:
-                    result[tx] = T.any_of(shared, scope=scope)
+                    result[tx] = T.any_of(shared)
             elif condition_kind == "warp_group":
                 if tx // 32 == 0:
-                    result[tx] = T.any_of(shared, scope=scope)
+                    result[tx] = T.any_of(shared)
             elif condition_kind == "alternating":
                 if tx % 2 == 0:
-                    result[tx] = T.any_of(shared, scope=scope)
+                    result[tx] = T.any_of(shared)
             else:
                 raise ValueError(condition_kind)
 
@@ -166,6 +168,33 @@ def _make_if_then_else_any_of_kernel(condition_kind):
     return main
 
 
+def _make_let_condition_kernel(condition_kind):
+    @T.prim_func
+    def main(
+        source: T.Tensor((70,), "int32"),
+        result: T.Tensor((64,), "bool"),
+    ):
+        with T.Kernel(1, threads=64):
+            shared = T.alloc_shared((70,), "int32")
+            tx = T.get_thread_binding()
+            predicate = tvm.tirx.Var("predicate", "bool")
+
+            if condition_kind == "single_lane":
+                value = tx == 0
+            elif condition_kind == "warp_group":
+                value = tx // 32 == 0
+            else:
+                raise ValueError(condition_kind)
+
+            result[tx] = tvm.tirx.Let(
+                predicate,
+                value,
+                T.if_then_else(predicate, T.any_of(shared), False),
+            )
+
+    return main
+
+
 def _resolve(func, target=_CUDA_TARGET):
     mod = tvm.IRModule({"main": func})
     mod = tvm.tirx.transform.BindTarget(target)(mod)
@@ -202,12 +231,6 @@ def test_resolve_any_of_auto_scope(condition_kind, expected_scope):
     assert _logical_scopes(resolved) == [expected_scope]
 
 
-@pytest.mark.parametrize("scope", ["thread", "warp"])
-def test_resolve_any_of_preserves_explicit_scope(scope):
-    resolved = _resolve(_make_any_of_kernel("single_lane", scope=scope))
-    assert _logical_scopes(resolved) == [scope]
-
-
 @pytest.mark.parametrize(
     ("divergent", "expected_scope"),
     [(False, "warp"), (True, "thread")],
@@ -223,15 +246,20 @@ def test_resolve_restores_scope_after_divergent_branch():
 
 
 @pytest.mark.parametrize(
-    ("divisor", "expected_scope"),
-    [(64, "warp"), (32, "thread")],
+    ("target", "divisor", "expected_scope"),
+    [
+        (_ROCM_TARGET, 64, "warp"),
+        (_ROCM_TARGET, 32, "thread"),
+        (_ROCM_WAVE32_TARGET, 32, "warp"),
+        (_ROCM_WAVE32_TARGET, 16, "thread"),
+    ],
 )
-def test_resolve_uses_target_warp_size(divisor, expected_scope):
-    resolved = _resolve(_make_wave_partitioned_kernel(divisor), _ROCM_TARGET)
+def test_resolve_uses_target_warp_size(target, divisor, expected_scope):
+    resolved = _resolve(_make_wave_partitioned_kernel(divisor), target)
     assert _logical_scopes(resolved) == [expected_scope]
 
 
-def test_resolve_global_auto_scope_stays_thread():
+def test_resolve_global_uniform_range_uses_warp():
     @T.prim_func
     def main(
         source: T.Tensor((70,), "int32"),
@@ -240,6 +268,49 @@ def test_resolve_global_auto_scope_stays_thread():
         with T.Kernel(1, threads=64):
             tx = T.get_thread_binding()
             result[tx] = T.any_of(source)
+
+    resolved = _resolve(main)
+    assert _logical_scopes(resolved) == ["warp"]
+
+
+def test_resolve_lane_dependent_shared_range_stays_thread():
+    @T.prim_func
+    def main(
+        source: T.Tensor((128,), "int32"),
+        result: T.Tensor((64,), "bool"),
+    ):
+        with T.Kernel(1, threads=64):
+            shared = T.alloc_shared((128,), "int32")
+            tx = T.get_thread_binding()
+            result[tx] = T.any_of(shared[tx : tx + 8])
+
+    resolved = _resolve(main)
+    assert _logical_scopes(resolved) == ["thread"]
+
+
+def test_frontend_logical_call_keeps_two_argument_form():
+    func = _make_any_of_kernel("none")
+    argument_counts = []
+    logical_op = op.Op.get("tl.any_of")
+
+    def collect(node):
+        if isinstance(node, tvm.tirx.Call) and node.op.same_as(logical_op):
+            argument_counts.append(len(node.args))
+
+    post_order_visit(func.body, collect)
+    assert argument_counts == [2]
+
+
+def test_resolve_partial_warp_launch_stays_thread():
+    @T.prim_func
+    def main(
+        source: T.Tensor((70,), "int32"),
+        result: T.Tensor((48,), "bool"),
+    ):
+        with T.Kernel(1, threads=48):
+            shared = T.alloc_shared((70,), "int32")
+            tx = T.get_thread_binding()
+            result[tx] = T.any_of(shared)
 
     resolved = _resolve(main)
     assert _logical_scopes(resolved) == ["thread"]
@@ -301,3 +372,15 @@ def test_resolve_local_buffer_condition_stays_thread():
 
     resolved = _resolve(main)
     assert _logical_scopes(resolved) == ["thread"]
+
+
+@pytest.mark.parametrize(
+    ("condition_kind", "expected_scope"),
+    [
+        ("single_lane", "thread"),
+        ("warp_group", "warp"),
+    ],
+)
+def test_resolve_auto_scope_through_let(condition_kind, expected_scope):
+    resolved = _resolve(_make_let_condition_kernel(condition_kind))
+    assert _logical_scopes(resolved) == [expected_scope]

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -150,6 +150,9 @@ def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.LegalizeVectorizedLoop()(mod)
     # Add safety checks for memory accesses
     mod = tilelang.transform.LegalizeSafeMemoryAccess()(mod)
+    # Resolve automatic logical-reduction scopes while buffer metadata and
+    # structured control flow are still available.
+    mod = tilelang.transform.ResolveLogicalScope()(mod)
     # Lower frontend pointer metadata op to standard tvm_access_ptr
     mod = tilelang.transform.LowerAccessPtr()(mod)
     # Simplify again to clean up any duplicated conditions

--- a/tilelang/language/logical.py
+++ b/tilelang/language/logical.py
@@ -9,19 +9,27 @@ from tilelang.utils.language import get_buffer_elems
 from tilelang._typing import BufferLikeType
 
 
-def any_of(buffer: BufferLikeType) -> tirx.PrimExpr:
+def any_of(buffer: BufferLikeType, scope: str = "thread") -> tirx.PrimExpr:
     """Check if any element in the buffer is true.
 
     Args:
         buffer: Either a TVM buffer or buffer region to be checked
+        scope: Reduction scope. ``"thread"`` makes each thread scan the full
+            buffer independently. ``"warp"`` partitions the buffer across a
+            warp and returns a warp-uniform result.
 
     Returns:
         A TVM intrinsic call that performs the any operation
     """
     return_type: str = "bool"
+    if not isinstance(scope, str):
+        raise TypeError(f"T.any_of scope must be a string, but got {type(scope)}")
+    if scope not in ("thread", "warp"):
+        raise ValueError(f"T.any_of scope must be 'thread' or 'warp', but got {scope!r}")
+
     if isinstance(buffer, Buffer):
         elems = get_buffer_elems(buffer)
-        return T.call_intrin(return_type, tirx.op.Op.get("tl.any_of"), T.access_ptr(buffer, "r"), elems)
+        return T.call_intrin(return_type, tirx.op.Op.get("tl.any_of"), T.access_ptr(buffer, "r"), elems, scope)
     elif isinstance(buffer, BufferRegion):
         buffer, region = buffer.buffer, buffer.region
         new_region = []
@@ -43,24 +51,34 @@ def any_of(buffer: BufferLikeType) -> tirx.PrimExpr:
             tirx.op.Op.get("tl.any_of"),
             T.access_ptr(buffer_load, "r", extent=extent),
             extent,
+            scope,
         )
     else:
-        raise ValueError(f"Invalid buffer type: {type(buffer)}")
+        raise TypeError(f"Invalid buffer type: {type(buffer)}")
 
 
-def all_of(buffer: BufferLikeType) -> tirx.PrimExpr:
+def all_of(buffer: BufferLikeType, scope: str = "thread") -> tirx.PrimExpr:
     """Check if all elements in the buffer are true.
 
     Args:
         buffer: Either a TVM buffer or buffer region to be checked
+        scope: Reduction scope. ``"thread"`` makes each thread scan the full
+            buffer independently. ``"warp"`` partitions the buffer across a
+            warp and returns a warp-uniform result.
 
     Returns:
         A TVM intrinsic call that performs the any operation
     """
+
+    if not isinstance(scope, str):
+        raise TypeError(f"T.all_of scope must be a string, but got {type(scope)}")
+    if scope not in ("thread", "warp"):
+        raise ValueError(f"T.all_of scope must be 'thread' or 'warp', but got {scope!r}")
+
     return_type: str = "bool"
     if isinstance(buffer, Buffer):
         elems = get_buffer_elems(buffer)
-        return T.call_intrin(return_type, tirx.op.Op.get("tl.all_of"), T.access_ptr(buffer, "r"), elems)
+        return T.call_intrin(return_type, tirx.op.Op.get("tl.all_of"), T.access_ptr(buffer, "r"), elems, scope)
     elif isinstance(buffer, BufferRegion):
         buffer, region = buffer.buffer, buffer.region
         new_region = []
@@ -82,6 +100,7 @@ def all_of(buffer: BufferLikeType) -> tirx.PrimExpr:
             tirx.op.Op.get("tl.all_of"),
             T.access_ptr(buffer_load, "r", extent=extent),
             extent,
+            scope,
         )
     else:
-        raise ValueError(f"Invalid buffer type: {type(buffer)}")
+        raise TypeError(f"Invalid buffer type: {type(buffer)}")

--- a/tilelang/language/logical.py
+++ b/tilelang/language/logical.py
@@ -9,7 +9,7 @@ from tilelang.utils.language import get_buffer_elems
 from tilelang._typing import BufferLikeType
 
 
-def any_of(buffer: BufferLikeType, scope: str = "thread") -> tirx.PrimExpr:
+def any_of(buffer: BufferLikeType, scope: str = "auto") -> tirx.PrimExpr:
     """Check if any element in the buffer is true.
 
     Args:
@@ -24,8 +24,8 @@ def any_of(buffer: BufferLikeType, scope: str = "thread") -> tirx.PrimExpr:
     return_type: str = "bool"
     if not isinstance(scope, str):
         raise TypeError(f"T.any_of scope must be a string, but got {type(scope)}")
-    if scope not in ("thread", "warp"):
-        raise ValueError(f"T.any_of scope must be 'thread' or 'warp', but got {scope!r}")
+    if scope not in ("thread", "warp", "auto"):
+        raise ValueError(f"T.any_of scope must be 'auto', 'thread' or 'warp', but got {scope!r}")
 
     if isinstance(buffer, Buffer):
         elems = get_buffer_elems(buffer)
@@ -57,23 +57,24 @@ def any_of(buffer: BufferLikeType, scope: str = "thread") -> tirx.PrimExpr:
         raise TypeError(f"Invalid buffer type: {type(buffer)}")
 
 
-def all_of(buffer: BufferLikeType, scope: str = "thread") -> tirx.PrimExpr:
+def all_of(buffer: BufferLikeType, scope: str = "auto") -> tirx.PrimExpr:
     """Check if all elements in the buffer are true.
 
     Args:
         buffer: Either a TVM buffer or buffer region to be checked
-        scope: Reduction scope. ``"thread"`` makes each thread scan the full
+        scope: Reduction scope. ``"auto"`` uses ``"warp"`` reduction if it can prove that there is no warp divergence, else ``"thread"``.
+            ``"thread"`` makes each thread scan the full
             buffer independently. ``"warp"`` partitions the buffer across a
             warp and returns a warp-uniform result.
 
     Returns:
-        A TVM intrinsic call that performs the any operation
+        A TVM intrinsic call that performs the all operation
     """
 
     if not isinstance(scope, str):
         raise TypeError(f"T.all_of scope must be a string, but got {type(scope)}")
-    if scope not in ("thread", "warp"):
-        raise ValueError(f"T.all_of scope must be 'thread' or 'warp', but got {scope!r}")
+    if scope not in ("thread", "warp", "auto"):
+        raise ValueError(f"T.all_of scope must be 'auto', 'thread' or 'warp', but got {scope!r}")
 
     return_type: str = "bool"
     if isinstance(buffer, Buffer):

--- a/tilelang/language/logical.py
+++ b/tilelang/language/logical.py
@@ -9,30 +9,20 @@ from tilelang.utils.language import get_buffer_elems
 from tilelang._typing import BufferLikeType
 
 
-def any_of(buffer: BufferLikeType, scope: str = "auto") -> tirx.PrimExpr:
+def any_of(buffer: BufferLikeType) -> tirx.PrimExpr:
     """Check if any element in the buffer is true.
 
     Args:
         buffer: The buffer or buffer region to check.
-        scope: Reduction scope. ``"auto"`` uses a cooperative warp reduction
-            when the compiler can prove warp-uniform execution and otherwise
-            falls back to ``"thread"``. ``"thread"`` makes each thread scan
-            the full buffer independently. ``"warp"`` explicitly partitions
-            the scan across a warp and requires every participating lane to
-            reach the call in converged control flow.
 
     Returns:
         A boolean expression indicating whether any element is true.
     """
     return_type: str = "bool"
-    if not isinstance(scope, str):
-        raise TypeError(f"T.any_of scope must be a string, but got {type(scope)}")
-    if scope not in ("thread", "warp", "auto"):
-        raise ValueError(f"T.any_of scope must be 'auto', 'thread' or 'warp', but got {scope!r}")
 
     if isinstance(buffer, Buffer):
         elems = get_buffer_elems(buffer)
-        return T.call_intrin(return_type, tirx.op.Op.get("tl.any_of"), T.access_ptr(buffer, "r"), elems, scope)
+        return T.call_intrin(return_type, tirx.op.Op.get("tl.any_of"), T.access_ptr(buffer, "r"), elems)
     elif isinstance(buffer, BufferRegion):
         buffer, region = buffer.buffer, buffer.region
         new_region = []
@@ -54,37 +44,24 @@ def any_of(buffer: BufferLikeType, scope: str = "auto") -> tirx.PrimExpr:
             tirx.op.Op.get("tl.any_of"),
             T.access_ptr(buffer_load, "r", extent=extent),
             extent,
-            scope,
         )
     else:
         raise TypeError(f"Invalid buffer type: {type(buffer)}")
 
 
-def all_of(buffer: BufferLikeType, scope: str = "auto") -> tirx.PrimExpr:
+def all_of(buffer: BufferLikeType) -> tirx.PrimExpr:
     """Check if all elements in the buffer are true.
 
     Args:
         buffer: The buffer or buffer region to check.
-        scope: Reduction scope. ``"auto"`` uses a cooperative warp reduction
-            when the compiler can prove warp-uniform execution and otherwise
-            falls back to ``"thread"``. ``"thread"`` makes each thread scan
-            the full buffer independently. ``"warp"`` explicitly partitions
-            the scan across a warp and requires every participating lane to
-            reach the call in converged control flow.
 
     Returns:
         A boolean expression indicating whether all elements are true.
     """
-
-    if not isinstance(scope, str):
-        raise TypeError(f"T.all_of scope must be a string, but got {type(scope)}")
-    if scope not in ("thread", "warp", "auto"):
-        raise ValueError(f"T.all_of scope must be 'auto', 'thread' or 'warp', but got {scope!r}")
-
     return_type: str = "bool"
     if isinstance(buffer, Buffer):
         elems = get_buffer_elems(buffer)
-        return T.call_intrin(return_type, tirx.op.Op.get("tl.all_of"), T.access_ptr(buffer, "r"), elems, scope)
+        return T.call_intrin(return_type, tirx.op.Op.get("tl.all_of"), T.access_ptr(buffer, "r"), elems)
     elif isinstance(buffer, BufferRegion):
         buffer, region = buffer.buffer, buffer.region
         new_region = []
@@ -106,7 +83,6 @@ def all_of(buffer: BufferLikeType, scope: str = "auto") -> tirx.PrimExpr:
             tirx.op.Op.get("tl.all_of"),
             T.access_ptr(buffer_load, "r", extent=extent),
             extent,
-            scope,
         )
     else:
         raise TypeError(f"Invalid buffer type: {type(buffer)}")

--- a/tilelang/language/logical.py
+++ b/tilelang/language/logical.py
@@ -13,13 +13,16 @@ def any_of(buffer: BufferLikeType, scope: str = "auto") -> tirx.PrimExpr:
     """Check if any element in the buffer is true.
 
     Args:
-        buffer: Either a TVM buffer or buffer region to be checked
-        scope: Reduction scope. ``"thread"`` makes each thread scan the full
-            buffer independently. ``"warp"`` partitions the buffer across a
-            warp and returns a warp-uniform result.
+        buffer: The buffer or buffer region to check.
+        scope: Reduction scope. ``"auto"`` uses a cooperative warp reduction
+            when the compiler can prove warp-uniform execution and otherwise
+            falls back to ``"thread"``. ``"thread"`` makes each thread scan
+            the full buffer independently. ``"warp"`` explicitly partitions
+            the scan across a warp and requires every participating lane to
+            reach the call in converged control flow.
 
     Returns:
-        A TVM intrinsic call that performs the any operation
+        A boolean expression indicating whether any element is true.
     """
     return_type: str = "bool"
     if not isinstance(scope, str):
@@ -61,14 +64,16 @@ def all_of(buffer: BufferLikeType, scope: str = "auto") -> tirx.PrimExpr:
     """Check if all elements in the buffer are true.
 
     Args:
-        buffer: Either a TVM buffer or buffer region to be checked
-        scope: Reduction scope. ``"auto"`` uses ``"warp"`` reduction if it can prove that there is no warp divergence, else ``"thread"``.
-            ``"thread"`` makes each thread scan the full
-            buffer independently. ``"warp"`` partitions the buffer across a
-            warp and returns a warp-uniform result.
+        buffer: The buffer or buffer region to check.
+        scope: Reduction scope. ``"auto"`` uses a cooperative warp reduction
+            when the compiler can prove warp-uniform execution and otherwise
+            falls back to ``"thread"``. ``"thread"`` makes each thread scan
+            the full buffer independently. ``"warp"`` explicitly partitions
+            the scan across a warp and requires every participating lane to
+            reach the call in converged control flow.
 
     Returns:
-        A TVM intrinsic call that performs the all operation
+        A boolean expression indicating whether all elements are true.
     """
 
     if not isinstance(scope, str):

--- a/tilelang/rocm/pipeline.py
+++ b/tilelang/rocm/pipeline.py
@@ -50,6 +50,7 @@ def ROCMPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.DecoupleTypeCast()(mod)
     mod = tilelang.transform.LegalizeVectorizedLoop()(mod)
     mod = tilelang.transform.LegalizeSafeMemoryAccess()(mod)
+    mod = tilelang.transform.ResolveLogicalScope()(mod)
     mod = tilelang.transform.LowerAccessPtr()(mod)
     mod = tilelang.transform.Simplify()(mod)
     mod = tilelang.transform.HoistNonRestrictParams()(mod)

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -433,3 +433,14 @@ def UnrollLoop():
         The result pass
     """
     return _ffi_api.UnrollLoop()  # type: ignore
+
+
+def ResolveLogicalScope():
+    """Resolve automatic scopes for logical reductions.
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The resulting pass.
+    """
+    return _ffi_api.ResolveLogicalScope()  # type: ignore


### PR DESCRIPTION
#3120

tested locally on H100.

Will implemented automatic warp divergence detection next

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added automatic warp-or-thread scope resolution for `T.any_of` and `T.all_of`.
- Removed the public `scope` argument while preserving raw two-argument TIR compatibility.
- Added CUDA and HIP warp reduction helpers: `tl::AnyWarp` and `tl::AllWarp`.
- Added conservative warp-uniformity analysis through `ResolveLogicalScope`.
- Integrated scope resolution into the CUDA and ROCm lowering pipelines.
- Added tests for control-flow uniformity, partial warps, shared and global buffers, and target-specific warp sizes.
- Verified native C++ builds, resolver tests, H100 tests, expected ROCm skips, and pre-commit checks.

## C++ style / lint notes

- The PR changes C++ source and headers but does not change rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step is relevant.
- TLCPP003/TLCPP004 findings are advisory unless they indicate a clear API, FFI, or maintainability risk.
- No correctness, build, or test issue is identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->