### PR TITLE
[Layout] Consider scalar reducer plans in register-count search

### DIFF
--- a/maint/layout_inference/README.md
+++ b/maint/layout_inference/README.md
@@ -18,6 +18,13 @@ Why this exists:
 
 ## Usage
 
+The default `register-count` model also tries one scalar plan at each
+unannotated reducer-update root. Both native and scalar plans use the unchanged
+spill/register-slot score; native plans win same-root ties. This can remove
+replicated column accumulators without forcing scalar layouts for full
+reductions. Explicit widths and layouts remain authoritative. The opt-in
+`io-aware` model retains its existing candidate search and scoring.
+
 ```bash
 python run.py                # verify all cases against expected/
 python run.py --case NAME    # substring filter
@@ -59,7 +66,7 @@ io-aware scorer on the in-tree CuTe layout algebra
   exactly. `CUTE_STATEMENTS` in a case supplies real enclosing-buffer
   shapes where they differ from the fragment shape (offset_region_copy).
 
-Current status: 88/88 statements match with a 100% conversion hit rate.
+Current status: 112/112 statements match with a 100% conversion hit rate.
 The production scorer in `layout_cost_model.cc` uses this formulation; its
 mode arithmetic was additionally audited once, in-tree, against a full
 exact-enumeration oracle across the layout-relevant test corpus (~264
@@ -111,3 +118,4 @@ nest's `parallel_loop_layout` annotation (see `common.py`).
 | `reduce_broadcast` | Softmax-shaped row-reduce + broadcast consume: the most common real-kernel component. Both models agree, including the reduced fragment's canonical partial replication. |
 | `offset_region_copy` | Multi-block tiled copies whose region mins carry block indices (the model's "foreign vars"): offset regions must rank exactly like zero-offset ones. |
 | `shared_staging` | global→shared→fragment→global chain: the shared-side copy is outside the io model, so the fragment is decided by the copy-out alone; goldens would surface any change to that boundary. |
+| `reducer_scalar_candidates` | Register-count can choose scalar column ownership while preserving native packed layouts for a full reduction; io-aware keeps its existing search. |

--- a/maint/layout_inference/cases/reducer_scalar_candidates.py
+++ b/maint/layout_inference/cases/reducer_scalar_candidates.py
@@ -1,0 +1,58 @@
+"""Scalar column ownership versus a necessary full-participant reduction."""
+
+import tilelang.language as T
+
+
+def make_reducer(total=False, width=None, pinned=False, pin_loop=False, updates=1):
+    width = None if width is None else T.int32(width)
+    rows, cols = (4, 256) if total else (8, 128)
+    outputs = 1 if total else cols
+    dtype = T.bfloat16 if total else T.float32
+    if total:
+        layout = T.Fragment(
+            (rows, cols),
+            forward_thread_fn=lambda i, j: (i * cols + j) // 8,
+            forward_index_fn=lambda i, j: j % 8,
+        )
+    else:
+        layout = T.Fragment(
+            (rows, cols),
+            forward_thread_fn=lambda i, j: (i % 4) * 32 + j // 4,
+            forward_index_fn=lambda i, j: (i // 4) * 4 + j % 4,
+        )
+
+    @T.prim_func
+    def main(A: T.Tensor((rows, cols), dtype), B: T.Tensor((outputs,), T.float32)):
+        with T.Kernel(1, threads=128):
+            shared = T.alloc_shared((rows, cols), dtype)
+            values = T.alloc_fragment((rows, cols), T.float32)
+            if pinned:
+                T.annotate_layout({values: layout})
+            T.copy(A, shared)
+            T.copy(shared, values)
+            acc = T.alloc_reducer((outputs,), T.float32)
+            result = T.alloc_fragment((outputs,), T.float32)
+            T.reducer_init(acc)
+            if updates > 0:
+                for i, j in T.Parallel(rows, cols, coalesced_width=width, loop_layout=layout if pin_loop else None):
+                    T.reducer_update(acc[0 if total else j], values[i, j])
+            if updates > 1:
+                for i, j in T.Parallel(rows, cols):
+                    T.reducer_update(acc[0 if total else j], values[i, j])
+            T.finalize_reducer(acc, result)
+            T.copy(result, B)
+
+    return main
+
+
+VARIANTS = {
+    "columns": lambda: make_reducer(),
+    "full_bf16": lambda: make_reducer(total=True),
+}
+
+
+def check(variant, model, result):
+    if variant == "columns" and model == "register-count":
+        assert result["buffers"]["acc"]["replicate"] == 1
+    if variant == "full_bf16":
+        assert result["buffers"]["acc"]["replicate"] == 128

--- a/maint/layout_inference/expected/reducer_scalar_candidates.json
+++ b/maint/layout_inference/expected/reducer_scalar_candidates.json
@@ -1,0 +1,342 @@
+{
+  "columns": {
+    "io-aware": {
+      "buffers": {
+        "acc": {
+          "forward_index": [
+            "_i % 4"
+          ],
+          "forward_thread": "_rep * 32 + _i // 4",
+          "input_shape": [
+            128
+          ],
+          "kind": "PartialFragment",
+          "output_shape": [
+            4
+          ],
+          "replicate": 4,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "result": {
+          "forward_index": [
+            "_i % 4"
+          ],
+          "forward_thread": "_rep * 32 + _i // 4",
+          "input_shape": [
+            128
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            4
+          ],
+          "replicate": 4,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "values": {
+          "forward_index": [
+            "_i // 4 * 4 + _j % 4"
+          ],
+          "forward_thread": "_i % 4 * 32 + _j // 4",
+          "input_shape": [
+            8,
+            128
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            8
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      },
+      "loops": {
+        "i,j[8x128]": {
+          "forward_index": [
+            "_i // 4 * 4 + _j % 4"
+          ],
+          "forward_thread": "_i % 4 * 32 + _j // 4",
+          "input_shape": [
+            8,
+            128
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            8
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      }
+    },
+    "register-count": {
+      "buffers": {
+        "acc": {
+          "forward_index": [
+            "0"
+          ],
+          "forward_thread": "_i",
+          "input_shape": [
+            128
+          ],
+          "kind": "PartialFragment",
+          "output_shape": [
+            1
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "result": {
+          "forward_index": [
+            "0"
+          ],
+          "forward_thread": "_i",
+          "input_shape": [
+            128
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            1
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "values": {
+          "forward_index": [
+            "_i"
+          ],
+          "forward_thread": "_j",
+          "input_shape": [
+            8,
+            128
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            8
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      },
+      "loops": {
+        "i,j[8x128]": {
+          "forward_index": [
+            "_i"
+          ],
+          "forward_thread": "_j",
+          "input_shape": [
+            8,
+            128
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            8
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      }
+    }
+  },
+  "full_bf16": {
+    "io-aware": {
+      "buffers": {
+        "acc": {
+          "forward_index": [
+            "0"
+          ],
+          "forward_thread": "_rep % 4 * 32 + _rep // 4",
+          "input_shape": [
+            1
+          ],
+          "kind": "PartialFragment",
+          "output_shape": [
+            1
+          ],
+          "replicate": 128,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "result": {
+          "forward_index": [
+            "0"
+          ],
+          "forward_thread": "_rep",
+          "input_shape": [
+            1
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            1
+          ],
+          "replicate": 128,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "values": {
+          "forward_index": [
+            "_j % 8"
+          ],
+          "forward_thread": "_i * 32 + _j // 8",
+          "input_shape": [
+            4,
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            8
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      },
+      "loops": {
+        "i,j[4x256]": {
+          "forward_index": [
+            "_j % 8"
+          ],
+          "forward_thread": "_i * 32 + _j // 8",
+          "input_shape": [
+            4,
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            8
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      }
+    },
+    "register-count": {
+      "buffers": {
+        "acc": {
+          "forward_index": [
+            "0"
+          ],
+          "forward_thread": "_rep % 4 * 32 + _rep // 4",
+          "input_shape": [
+            1
+          ],
+          "kind": "PartialFragment",
+          "output_shape": [
+            1
+          ],
+          "replicate": 128,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "result": {
+          "forward_index": [
+            "0"
+          ],
+          "forward_thread": "_rep",
+          "input_shape": [
+            1
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            1
+          ],
+          "replicate": 128,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        },
+        "values": {
+          "forward_index": [
+            "_j % 8"
+          ],
+          "forward_thread": "_i * 32 + _j // 8",
+          "input_shape": [
+            4,
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            8
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      },
+      "loops": {
+        "i,j[4x256]": {
+          "forward_index": [
+            "_j % 8"
+          ],
+          "forward_thread": "_i * 32 + _j // 8",
+          "input_shape": [
+            4,
+            256
+          ],
+          "kind": "Fragment",
+          "output_shape": [
+            8
+          ],
+          "replicate": 1,
+          "thread_range": [
+            0,
+            128
+          ],
+          "threads": 128
+        }
+      }
+    }
+  }
+}

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -172,6 +172,10 @@ struct LayoutInferArgs {
   // that update nests must satisfy rather than widen. Empty at
   // lowering-time re-inference call sites.
   LayoutMap strict_layout_map;
+  // Per-call cap for generating a free-mode parallel plan. Zero preserves
+  // the vectorizer's width; scalar reducer-root attempts pass one. This is
+  // a search option, not operator state or a constraint on inferred layouts.
+  int plan_vector_size_limit = 0;
 };
 
 class TileOperator;

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -172,10 +172,10 @@ struct LayoutInferArgs {
   // that update nests must satisfy rather than widen. Empty at
   // lowering-time re-inference call sites.
   LayoutMap strict_layout_map;
-  // Per-call cap for generating a free-mode parallel plan. Zero preserves
+  // Per-call cap for generating a free-mode parallel candidate. Zero preserves
   // the vectorizer's width; scalar reducer-root attempts pass one. This is
   // a search option, not operator state or a constraint on inferred layouts.
-  int plan_vector_size_limit = 0;
+  int candidate_vector_size_limit = 0;
 };
 
 class TileOperator;

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -1004,8 +1004,9 @@ ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &layout_args) const {
       root_, layout_args.buffer_remap, layout_args.layout_map);
   int vector_size = GetVectorizeSize(maybe_remapped_root_, layout_args.analyzer,
                                      layout_args.layout_map);
-  if (layout_args.plan_vector_size_limit > 0) {
-    vector_size = std::min(vector_size, layout_args.plan_vector_size_limit);
+  if (layout_args.candidate_vector_size_limit > 0) {
+    vector_size =
+        std::min(vector_size, layout_args.candidate_vector_size_limit);
   }
   DLOG(INFO) << "[PlanLoopPartition] vector_size = " << vector_size << '\n';
 

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -1004,6 +1004,9 @@ ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &layout_args) const {
       root_, layout_args.buffer_remap, layout_args.layout_map);
   int vector_size = GetVectorizeSize(maybe_remapped_root_, layout_args.analyzer,
                                      layout_args.layout_map);
+  if (plan_vector_size_limit_ > 0) {
+    vector_size = std::min(vector_size, plan_vector_size_limit_);
+  }
   DLOG(INFO) << "[PlanLoopPartition] vector_size = " << vector_size << '\n';
 
   PrimExpr loop_total_size = 1;

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -1004,8 +1004,8 @@ ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &layout_args) const {
       root_, layout_args.buffer_remap, layout_args.layout_map);
   int vector_size = GetVectorizeSize(maybe_remapped_root_, layout_args.analyzer,
                                      layout_args.layout_map);
-  if (plan_vector_size_limit_ > 0) {
-    vector_size = std::min(vector_size, plan_vector_size_limit_);
+  if (layout_args.plan_vector_size_limit > 0) {
+    vector_size = std::min(vector_size, layout_args.plan_vector_size_limit);
   }
   DLOG(INFO) << "[PlanLoopPartition] vector_size = " << vector_size << '\n';
 

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -116,9 +116,6 @@ public:
   // Whether the inferred loop layout intentionally over-covers a ragged
   // non-fragment iteration space and therefore needs guarded inverse lowering.
   mutable bool loop_layout_requires_padding_guard_ = false;
-  // Attempt-local cap for exploring a scalar reducer layout. Zero preserves
-  // the vectorizer's plan; explicit user annotations always take precedence.
-  int plan_vector_size_limit_ = 0;
   // The predicate expression for the loop, if any, mutable for lazy
   // construction.
   mutable Optional<PrimExpr> predicate_;
@@ -159,7 +156,6 @@ public:
     loop_layout_inferred_ = other.loop_layout_inferred_;
     loop_layout_requires_padding_guard_ =
         other.loop_layout_requires_padding_guard_;
-    plan_vector_size_limit_ = other.plan_vector_size_limit_;
     annotated_layout_unbound_ = other.annotated_layout_unbound_;
     annotated_predicate_ = other.annotated_predicate_;
     annotated_requires_padding_guard_ = other.annotated_requires_padding_guard_;

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -116,6 +116,9 @@ public:
   // Whether the inferred loop layout intentionally over-covers a ragged
   // non-fragment iteration space and therefore needs guarded inverse lowering.
   mutable bool loop_layout_requires_padding_guard_ = false;
+  // Attempt-local cap for exploring a scalar reducer layout. Zero preserves
+  // the vectorizer's plan; explicit user annotations always take precedence.
+  int plan_vector_size_limit_ = 0;
   // The predicate expression for the loop, if any, mutable for lazy
   // construction.
   mutable Optional<PrimExpr> predicate_;
@@ -156,6 +159,7 @@ public:
     loop_layout_inferred_ = other.loop_layout_inferred_;
     loop_layout_requires_padding_guard_ =
         other.loop_layout_requires_padding_guard_;
+    plan_vector_size_limit_ = other.plan_vector_size_limit_;
     annotated_layout_unbound_ = other.annotated_layout_unbound_;
     annotated_predicate_ = other.annotated_predicate_;
     annotated_requires_padding_guard_ = other.annotated_requires_padding_guard_;
@@ -171,6 +175,7 @@ public:
   // Get the parallel nest loop vars (visit order, outermost first) — the
   // input dims of GetLoopLayout().
   const Array<IterVar> &GetLoopVars() const { return loop_vars_; }
+  bool HasReducerUpdates() const { return !reducer_updates_.empty(); }
   // Get the mapping from buffer to access indices + access type.
   const BufferIndiceMap &GetIndiceMap() const { return indice_map_; }
   // Get buffers in the order they first appear in the loop body.

--- a/src/transform/layout_inference/layout_cost_model.cc
+++ b/src/transform/layout_inference/layout_cost_model.cc
@@ -990,6 +990,7 @@ public:
     return cost;
   }
   const char *Name() const final { return "register-count"; }
+  bool ExploreReducerScalarLayouts() const final { return true; }
 };
 
 /*! \brief IO-aware policy (layout RFC, design B2): every global-touching

--- a/src/transform/layout_inference/layout_cost_model.h
+++ b/src/transform/layout_inference/layout_cost_model.h
@@ -2,12 +2,13 @@
  * \file layout_cost_model.h
  * \brief Cost models that rank free-mode layout attempts.
  *
- * The inference engine enumerates one attempt per candidate root inside a
+ * The inference engine enumerates attempts per candidate root inside a
  * connected component and keeps the cheapest complete layout assignment.
  * What "cheapest" means is a pluggable policy behind LayoutCostModel:
  *
- *  - RegisterCountCostModel (default): total fragment register slots,
- *    nothing else.
+ *  - RegisterCountCostModel (default): total fragment register slots.
+ *    Also considers scalar plans at unannotated reducer-update roots,
+ *    scored with the same spill/register ordering as native plans.
  *  - IOAwareCostModel (layout RFC, design B2): walks the component's
  *    global-memory-touching statements (fragment<->global copies and
  *    parallel loops with direct global accesses) and charges each one
@@ -69,6 +70,10 @@ public:
 
   /*! \brief Model name for diagnostics. */
   virtual const char *Name() const = 0;
+
+  /*! \brief Whether to also try a scalar plan at unannotated reducer roots.
+   *  Adds one attempt per eligible root, not a Cartesian width search. */
+  virtual bool ExploreReducerScalarLayouts() const { return false; }
 
   /*! \brief Instantiate the model selected by `tl.layout_cost_model`
    *  by name ("io-aware" or "register-count" — each model's Name());

--- a/src/transform/layout_inference/layout_inference.cc
+++ b/src/transform/layout_inference/layout_inference.cc
@@ -242,7 +242,8 @@ public:
 
   void RunInferStep(int cur_infer_id, InferLevel level, bool update_queue,
                     LayoutMap &layout_map, const LayoutMap &strict_layout_map,
-                    std::deque<int> &q, std::vector<bool> &in_queue) {
+                    std::deque<int> &q, std::vector<bool> &in_queue,
+                    int plan_vector_size_limit = 0) {
     auto num_infer = infer_list_.size();
 
     // Range check for cur_infer_id
@@ -282,7 +283,8 @@ public:
                                                   {},
                                                   bind_var_to_expr_,
                                                   false,
-                                                  strict_layout_map},
+                                                  strict_layout_map,
+                                                  plan_vector_size_limit},
                                   level);
     } catch (const std::bad_optional_access &e) {
       LOG(FATAL) << "bad_optional_access while inferring layout for op "
@@ -1343,12 +1345,6 @@ private:
                 const LayoutCostModel &cost_model, std::deque<int> &q,
                 std::vector<bool> &in_queue, bool scalar_reducer_root = false) {
     auto back_infer_list = BackupInferList();
-    if (scalar_reducer_root) {
-      auto loop = make_object<ParallelOpNode>(
-          *infer_list_[attempt_root].as<ParallelOpNode>());
-      loop->plan_vector_size_limit_ = 1;
-      infer_list_[attempt_root] = TileOperator(loop);
-    }
     LayoutMap tmp_layout_map = base_layout_map;
     for (const auto &[buffer, fragment] : seed_layouts) {
       if (!tmp_layout_map.count(buffer)) {
@@ -1358,8 +1354,11 @@ private:
     bool ok = true;
     std::string failure;
     try {
+      // Only the root's first inference receives the scalar-plan cap. Its
+      // solved layout is frozen; propagation and later visits use normal args.
       RunInferStep(attempt_root, InferLevel::kFree, true, tmp_layout_map,
-                   strict_layout_map, q, in_queue);
+                   strict_layout_map, q, in_queue,
+                   /*plan_vector_size_limit=*/scalar_reducer_root ? 1 : 0);
       FinishInferQueue(InferLevel::kFree, tmp_layout_map, strict_layout_map, q,
                        in_queue);
       for (int other : members) {

--- a/src/transform/layout_inference/layout_inference.cc
+++ b/src/transform/layout_inference/layout_inference.cc
@@ -243,7 +243,7 @@ public:
   void RunInferStep(int cur_infer_id, InferLevel level, bool update_queue,
                     LayoutMap &layout_map, const LayoutMap &strict_layout_map,
                     std::deque<int> &q, std::vector<bool> &in_queue,
-                    int plan_vector_size_limit = 0) {
+                    int candidate_vector_size_limit = 0) {
     auto num_infer = infer_list_.size();
 
     // Range check for cur_infer_id
@@ -284,7 +284,7 @@ public:
                                                   bind_var_to_expr_,
                                                   false,
                                                   strict_layout_map,
-                                                  plan_vector_size_limit},
+                                                  candidate_vector_size_limit},
                                   level);
     } catch (const std::bad_optional_access &e) {
       LOG(FATAL) << "bad_optional_access while inferring layout for op "
@@ -1337,15 +1337,17 @@ private:
     LayoutMap layout_map;
     AttemptCost cost;
   };
-  std::optional<AttemptOutcome>
-  RunOneAttempt(int attempt_root, const std::vector<int> &members,
-                const LayoutMap &base_layout_map,
-                const LayoutMap &strict_layout_map,
-                const std::vector<std::pair<Buffer, Fragment>> &seed_layouts,
-                const LayoutCostModel &cost_model, std::deque<int> &q,
-                std::vector<bool> &in_queue, bool scalar_reducer_root = false) {
+  std::optional<AttemptOutcome> RunOneAttempt(
+      int attempt_root, const std::vector<int> &members,
+      const LayoutMap &base_layout_map, const LayoutMap &strict_layout_map,
+      const std::vector<std::pair<Buffer, Fragment>> &seed_layouts,
+      const LayoutCostModel &cost_model, int candidate_vector_size_limit = 0) {
     auto back_infer_list = BackupInferList();
     LayoutMap tmp_layout_map = base_layout_map;
+    // A failed attempt can leave pending propagation work. Keep both the
+    // queue and its membership flags local so no later attempt inherits it.
+    std::deque<int> q;
+    std::vector<bool> in_queue(infer_list_.size(), false);
     for (const auto &[buffer, fragment] : seed_layouts) {
       if (!tmp_layout_map.count(buffer)) {
         tmp_layout_map.Set(buffer, fragment);
@@ -1354,11 +1356,10 @@ private:
     bool ok = true;
     std::string failure;
     try {
-      // Only the root's first inference receives the scalar-plan cap. Its
+      // Only the root's first inference receives the candidate cap. Its
       // solved layout is frozen; propagation and later visits use normal args.
       RunInferStep(attempt_root, InferLevel::kFree, true, tmp_layout_map,
-                   strict_layout_map, q, in_queue,
-                   /*plan_vector_size_limit=*/scalar_reducer_root ? 1 : 0);
+                   strict_layout_map, q, in_queue, candidate_vector_size_limit);
       FinishInferQueue(InferLevel::kFree, tmp_layout_map, strict_layout_map, q,
                        in_queue);
       for (int other : members) {
@@ -1456,9 +1457,6 @@ private:
 
     // For each component, try each op as root, and determine the least
     // replicated one
-    std::deque<int> q;
-    std::vector<bool> in_queue(infer_list_.size(), false);
-
     std::unique_ptr<LayoutCostModel> cost_model =
         LayoutCostModel::Create(tl_config::LayoutCostModelName(), target_);
     DLOG(INFO) << "[InferInFreeMode] cost model: " << cost_model->Name();
@@ -1489,16 +1487,17 @@ private:
             loop->HasReducerUpdates() && !loop->GetLoopLayout().defined() &&
             !loop->annotated_layout_unbound_.defined() &&
             !loop->GetRoot()->annotations.count(attr::kCoalescedWidth);
-        for (bool scalar_root : {false, true}) {
-          if (scalar_root && !try_scalar) {
+        for (int candidate_vector_size_limit : {0, 1}) {
+          if (candidate_vector_size_limit != 0 && !try_scalar) {
             continue;
           }
           DLOG(INFO) << "----------------------- try root "
                      << attempt_infer_root << " members " << members.size()
-                     << " scalar_reducer_root=" << scalar_root << '\n';
-          auto outcome = RunOneAttempt(attempt_infer_root, members, layout_map,
-                                       strict_layout_map, /*seed_layouts=*/{},
-                                       *cost_model, q, in_queue, scalar_root);
+                     << " candidate_vector_size_limit="
+                     << candidate_vector_size_limit << '\n';
+          auto outcome = RunOneAttempt(
+              attempt_infer_root, members, layout_map, strict_layout_map,
+              /*seed_layouts=*/{}, *cost_model, candidate_vector_size_limit);
           if (!outcome) {
             continue;
           }
@@ -1530,9 +1529,8 @@ private:
         if (!seeds.empty()) {
           DLOG(INFO) << "[InferInFreeMode] all attempts failed; retrying with "
                      << "wide fallback dst layouts";
-          auto outcome =
-              RunOneAttempt(members.front(), members, layout_map,
-                            strict_layout_map, seeds, *cost_model, q, in_queue);
+          auto outcome = RunOneAttempt(members.front(), members, layout_map,
+                                       strict_layout_map, seeds, *cost_model);
           if (outcome) {
             adopt(std::move(*outcome), members.front());
           }

--- a/src/transform/layout_inference/layout_inference.cc
+++ b/src/transform/layout_inference/layout_inference.cc
@@ -1341,8 +1341,14 @@ private:
                 const LayoutMap &strict_layout_map,
                 const std::vector<std::pair<Buffer, Fragment>> &seed_layouts,
                 const LayoutCostModel &cost_model, std::deque<int> &q,
-                std::vector<bool> &in_queue) {
+                std::vector<bool> &in_queue, bool scalar_reducer_root = false) {
     auto back_infer_list = BackupInferList();
+    if (scalar_reducer_root) {
+      auto loop = make_object<ParallelOpNode>(
+          *infer_list_[attempt_root].as<ParallelOpNode>());
+      loop->plan_vector_size_limit_ = 1;
+      infer_list_[attempt_root] = TileOperator(loop);
+    }
     LayoutMap tmp_layout_map = base_layout_map;
     for (const auto &[buffer, fragment] : seed_layouts) {
       if (!tmp_layout_map.count(buffer)) {
@@ -1474,27 +1480,40 @@ private:
         best_infer_root = attempt_root;
       };
 
-      // Try each member as the root of inference for this component.
+      // Try the native plan first, then a scalar alternative at eligible
+      // reducer roots. Scalar ownership can avoid replicated accumulator
+      // slots; the existing cost model decides whether that is worthwhile.
       for (int attempt_infer_root : members) {
-        DLOG(INFO) << "----------------------- try root " << attempt_infer_root
-                   << " members " << members.size() << '\n';
-        auto outcome = RunOneAttempt(attempt_infer_root, members, layout_map,
-                                     strict_layout_map, /*seed_layouts=*/{},
-                                     *cost_model, q, in_queue);
-        if (!outcome) {
-          continue;
-        }
-        DLOG(INFO) << "[InferInFreeMode] attempt root " << attempt_infer_root
-                   << " cost model " << cost_model->Name()
-                   << " output: mem=" << outcome->cost.mem
-                   << " regs=" << outcome->cost.regs;
-        // Keep the cheapest attempt; ties resolve to the earliest root so
-        // the selection stays deterministic (and, with the cost model
-        // disabled, byte-identical to the legacy register ordering).
-        if (!has_best || outcome->cost.BetterThan(best_cost) ||
-            (!best_cost.BetterThan(outcome->cost) &&
-             attempt_infer_root < best_infer_root)) {
-          adopt(std::move(*outcome), attempt_infer_root);
+        const auto *loop = infer_list_[attempt_infer_root].as<ParallelOpNode>();
+        bool try_scalar =
+            cost_model->ExploreReducerScalarLayouts() && loop &&
+            loop->HasReducerUpdates() && !loop->GetLoopLayout().defined() &&
+            !loop->annotated_layout_unbound_.defined() &&
+            !loop->GetRoot()->annotations.count(attr::kCoalescedWidth);
+        for (bool scalar_root : {false, true}) {
+          if (scalar_root && !try_scalar) {
+            continue;
+          }
+          DLOG(INFO) << "----------------------- try root "
+                     << attempt_infer_root << " members " << members.size()
+                     << " scalar_reducer_root=" << scalar_root << '\n';
+          auto outcome = RunOneAttempt(attempt_infer_root, members, layout_map,
+                                       strict_layout_map, /*seed_layouts=*/{},
+                                       *cost_model, q, in_queue, scalar_root);
+          if (!outcome) {
+            continue;
+          }
+          DLOG(INFO) << "[InferInFreeMode] attempt root " << attempt_infer_root
+                     << " cost model " << cost_model->Name()
+                     << " output: mem=" << outcome->cost.mem
+                     << " regs=" << outcome->cost.regs;
+          // Ties keep the earliest root and its native plan. The scalar
+          // alternative must improve the score to replace the same root.
+          if (!has_best || outcome->cost.BetterThan(best_cost) ||
+              (!best_cost.BetterThan(outcome->cost) &&
+               attempt_infer_root < best_infer_root)) {
+            adopt(std::move(*outcome), attempt_infer_root);
+          }
         }
       }
       if (!has_best) {

--- a/testing/python/transform/test_tilelang_transform_reducer_scalar_candidates.py
+++ b/testing/python/transform/test_tilelang_transform_reducer_scalar_candidates.py
@@ -1,0 +1,137 @@
+"""Register-count search must consider scalar ownership without forcing it."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+import tilelang as tl
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+
+
+def make_reducer(**kwargs):
+    path = Path(__file__).resolve().parents[3] / "maint/layout_inference/cases/reducer_scalar_candidates.py"
+    spec = importlib.util.spec_from_file_location("reducer_scalar_candidates", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.make_reducer(**kwargs)
+
+
+def infer_reducer(model="register-count", factory=make_reducer, **kwargs):
+    target = tvm.target.Target({"kind": "cuda", "arch": "sm_90"})
+    with target:
+        mod = tvm.IRModule({"main": factory(**kwargs)})
+        mod = tvm.tirx.transform.BindTarget(target)(mod)
+        mod = tl.transform.MaterializeKernelLaunch()(mod)
+        configs = {} if model is None else {"tl.layout_cost_model": model}
+        with tl.transform.PassContext(config=configs):
+            mod = tl.transform.LayoutInference()(mod)
+    layouts = {}
+
+    def visit(node):
+        if isinstance(node, tvm.tirx.SBlock):
+            for buffer, layout in node.annotations.get("layout_map", {}).items():
+                layouts[buffer.name] = layout
+
+    tvm.tirx.stmt_functor.post_order_visit(mod["main"].body, visit)
+    return layouts
+
+
+@tilelang.testing.requires_cuda
+def test_register_count_considers_scalar_column_ownership():
+    native = infer_reducer(width=4)
+    scalar = infer_reducer()
+    default = infer_reducer(model=None)
+    assert int(native["acc"].combine_size) == 4
+    assert int(scalar["acc"].combine_size) == 1
+    assert default["values"].is_equal(scalar["values"])
+
+
+@tilelang.testing.requires_cuda
+def test_full_reduction_keeps_native_packed_layout():
+    native = infer_reducer(total=True, pinned=True)
+    automatic = infer_reducer(total=True)
+    assert int(automatic["acc"].combine_size) == 128
+    assert automatic["values"].is_equal(native["values"])
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("kwargs", [{"width": 4}, {"pinned": True}, {"pin_loop": True}])
+def test_explicit_layout_constraints_win(kwargs):
+    automatic = infer_reducer(**kwargs)
+    pinned = infer_reducer(width=4)
+    assert int(automatic["acc"].combine_size) == 4
+    assert automatic["values"].is_equal(pinned["values"])
+
+
+@tilelang.testing.requires_cuda
+def test_scalar_plan_cap_does_not_leak():
+    before = infer_reducer(total=True)
+    infer_reducer()
+    after = infer_reducer(total=True)
+    assert before["values"].is_equal(after["values"])
+    assert before["acc"].is_equal(after["acc"])
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("updates", [0, 2])
+def test_zero_and_multiple_update_sites(updates):
+    layouts = infer_reducer(updates=updates)
+    assert int(layouts["acc"].combine_size) == (128 if updates == 0 else 1)
+
+
+@tilelang.testing.requires_cuda
+def test_io_aware_retains_its_candidate_search():
+    native = infer_reducer(model="io-aware", width=4)
+    automatic = infer_reducer(model="io-aware")
+    assert automatic["values"].is_equal(native["values"])
+    assert int(automatic["acc"].combine_size) == 4
+
+
+def make_dynamic_full_reduction():
+    n = T.dynamic("n")
+
+    @T.prim_func
+    def main(A: T.Tensor((n, 512), T.float32), B: T.Tensor((n,), T.float32)):
+        with T.Kernel(n, threads=64) as row:
+            values = T.alloc_fragment((512,), T.float32)
+            acc = T.alloc_reducer((1,), T.float32)
+            result = T.alloc_fragment((1,), T.float32)
+            T.copy(A[row, :], values)
+            T.reducer_init(acc)
+            for i in T.Parallel(512):
+                T.reducer_update(acc[0], values[i])
+            T.finalize_reducer(acc, result)
+            T.copy(result, B[row : row + 1])
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+def test_dynamic_shape_does_not_favor_replicated_fragments():
+    layouts = infer_reducer(factory=make_dynamic_full_reduction)
+    assert int(layouts["values"].replicate_size) == 1
+    assert int(layouts["values"].get_output_shape()[0]) == 8
+    assert int(layouts["acc"].combine_size) == 64
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("total", [False, True])
+def test_scalar_candidate_kernel_correctness(total):
+    kernel = tl.compile(make_reducer(total=total), target="cuda", pass_configs={"tl.layout_cost_model": "register-count"})
+    if total:
+        inputs = torch.randn((4, 256), device="cuda", dtype=torch.bfloat16)
+        expected = inputs.float().sum().reshape(1)
+    else:
+        inputs = torch.randn((8, 128), device="cuda", dtype=torch.float32)
+        expected = inputs.sum(dim=0)
+        assert "tl::AllReduce<" not in kernel.get_kernel_source()
+    output = torch.empty_like(expected)
+    kernel(inputs, output)
+    torch.testing.assert_close(output, expected, rtol=1e-4, atol=1e-4)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_reducer_scalar_candidates.py
+++ b/testing/python/transform/test_tilelang_transform_reducer_scalar_candidates.py
@@ -67,12 +67,72 @@ def test_explicit_layout_constraints_win(kwargs):
 
 
 @tilelang.testing.requires_cuda
-def test_scalar_plan_cap_does_not_leak():
+def test_candidate_vector_size_limit_does_not_leak():
     before = infer_reducer(total=True)
     infer_reducer()
     after = infer_reducer(total=True)
     assert before["values"].is_equal(after["values"])
     assert before["acc"].is_equal(after["acc"])
+
+
+def make_reducer_with_pinned_consumer(width=None):
+    width = None if width is None else T.int32(width)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((8, 128), T.float32),
+        O: T.Tensor((128,), T.float32),
+        B: T.Tensor((128,), T.float32),
+        C: T.Tensor((128,), T.float32),
+    ):
+        with T.Kernel(1, threads=128):
+            shared = T.alloc_shared((8, 128), T.float32)
+            values = T.alloc_fragment((8, 128), T.float32)
+            T.copy(A, shared)
+            T.copy(shared, values)
+            acc = T.alloc_reducer((128,), T.float32)
+            T.reducer_init(acc)
+            for i, j in T.Parallel(8, 128, coalesced_width=width):
+                T.reducer_update(acc[j], values[i, j])
+            result = T.alloc_fragment((128,), T.float32)
+            other = T.alloc_fragment((128,), T.float32)
+            T.annotate_layout({other: T.Fragment((128,), forward_fn=lambda a: (a, 0))})
+            T.copy(O, other)
+            T.finalize_reducer(acc, result)
+            out = T.alloc_fragment((128,), T.float32)
+            for j in T.Parallel(128):
+                out[j] = result[j] + other[j]
+            T.copy(out, B)
+            T.copy(result, C)
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("width", [None, 4])
+def test_failed_reducer_attempt_can_retry(width):
+    # The native column layout conflicts with the pinned consumer when
+    # finalize publishes its narrow result. Its other consumer leaves pending
+    # propagation work. A later attempt must still find scalar ownership, or
+    # the wide fallback if an explicit width prevents the scalar candidate.
+    layouts = infer_reducer(factory=make_reducer_with_pinned_consumer, width=width)
+    assert int(layouts["result"].replicate_size) == (1 if width is None else 128)
+    if width is None:
+        assert int(layouts["acc"].combine_size) == 1
+
+    kernel = tl.compile(
+        make_reducer_with_pinned_consumer(width),
+        target="cuda",
+        pass_configs={"tl.layout_cost_model": "register-count"},
+    )
+    inputs = torch.randn((8, 128), device="cuda")
+    other = torch.randn((128,), device="cuda")
+    output = torch.empty_like(other)
+    copied = torch.empty_like(other)
+    kernel(inputs, other, output, copied)
+    expected = inputs.sum(dim=0)
+    torch.testing.assert_close(output, expected + other, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(copied, expected, rtol=1e-4, atol=1e-4)
 
 
 @tilelang.testing.requires_cuda


### PR DESCRIPTION
## Summary

Let the default `register-count` policy consider one additional scalar loop-partition candidate at each eligible reducer-update root. The existing spill/register-slot score is unchanged. Native plans remain available and win same-root ties; explicit layouts and widths remain authoritative. The opt-in `io-aware` policy is unchanged.

This fixes a gap in **candidate generation**, not a missing communication term in the score: a layout with fewer accumulator slots cannot win if the search never constructs it.

## Why this PR is needed

In free-mode inference, `ComputePlanCandidate` starts with the width returned by `GetVectorizeSize` and passes the resulting width to `PlanLoopPartition`. Trying different inference roots does not, by itself, try different planning widths at the same root. Buffer-derived candidates still exist, but the scalar alternative described below is not necessarily among them.

For a column reduction of an `8 x 128` tile using 128 threads, consider the following two valid mappings of element `(i, j)`:

```cpp
// Native width-4 loop-partition candidate:
thread = (i % 4) * 32 + j / 4;
slot   = (i / 4) * 4 + j % 4;

// Scalar loop-partition candidate:
thread = j;
slot   = i;
```

In the width-4 mapping, each thread owns four neighboring columns, but each column is split across four warps. In the scalar mapping, thread `j` owns all eight elements of column `j` and can finish that column's reduction locally.

| Per-thread storage / reduction property | Native width 4 | Scalar width 1 |
| --- | ---: | ---: |
| Input fragment slots | 8 | 8 |
| Accumulator slots | 4 | 1 |
| Result fragment slots | 4 | 1 |
| Threads contributing to each output column | 4 | 1 |
| Cross-thread combine for this column reduction | Required | Not required |

The existing register-count score can already prefer the scalar mapping because the accumulator/result use fewer slots, without increasing the input fragment size. Previously, its scalar planning width was not explicitly explored at that root. The new regression case records both the layout and the absence of `AllReduce` in the selected scalar column-reduction kernel.

A planning width of four is a logical distribution choice, not a guarantee of a single `float4` load or arithmetic instruction in the final code. Conversely, scalar per-thread access can still be coalesced across neighboring lanes. Wider access and packed arithmetic can be valuable, but their benefit must not be assumed to outweigh cross-thread reduction costs in every kernel.

## What changes, and what stays unchanged

1. Try the normal inference attempt first.
2. Under `register-count`, try one additional scalar-root attempt only when the root is a parallel loop with reducer updates, has no resolved or annotated loop layout, and has no explicit `coalesced_width`.
3. Propagate each attempt to a complete component layout and compare it with the **same existing** spill/register-slot score. A scalar attempt must strictly improve the score to replace the native attempt at the same root. Existing root-order tie-breaking remains deterministic.

Existing buffer-layout constraints and normal compatibility checks still apply. This is not an instruction to make every reduction scalar: the packed bf16 full-reduction control still needs all 128 participants and retains its native layout and generated CUDA.

There are no new bandwidth/issue terms, communication weights, register budgets, liveness estimates, or user-facing configuration flags. A communication penalty could make different tradeoffs, including accepting larger fragments to avoid a collective; this PR does not introduce that policy. It makes a previously missing candidate available to the current score and does not claim that register count universally predicts execution time.

Search growth is bounded to at most one additional **complete inference attempt per eligible root**. It is not a Cartesian search over widths or independently chosen scalar/vector layouts at every operator. This bound is not a measured compilation-time overhead guarantee.

## Meaning and lifetime of `LayoutInferArgs::candidate_vector_size_limit`

The parameter is a **candidate-generation vector-width cap**, scoped to one inference call. It affects the width used to construct a new free-mode loop-partition candidate:

```cpp
int vector_size = GetVectorizeSize(...);
if (layout_args.candidate_vector_size_limit > 0) {
  vector_size = std::min(vector_size, layout_args.candidate_vector_size_limit);
}
// Existing legality/divisibility adjustments still apply before:
auto candidate = PlanLoopPartition(root, vector_size, thread_bounds);
```

| Value | Meaning |
| --- | --- |
| `0` (default) | No additional cap; preserve the normal width-selection path. It does not bypass the vectorizer's existing limits. |
| `1` | Generate the scalar loop-partition alternative for this inference call. |
| Positive value in general | Clamp the automatically derived planning width; this PR only supplies `0` or `1` and does not enumerate other widths. |

For example, if `GetVectorizeSize` returns four, repeating the inference without an override would just regenerate the width-4 plan. Passing one is the mechanism that actually creates the alternative, rather than merely naming a second attempt "scalar."

The cap is passed only to the selected root's **first free-mode inference call** in the scalar attempt. Once solved, that root layout is retained for propagation. Queue propagation, other operators, later visits, and lowering-time re-inference receive the default arguments. The inferred layout can naturally influence connected buffers and loops, but the cap itself is not propagated as a constraint.

In particular, this parameter:

- Does **not** disable vectorization for the entire kernel or impose a maximum width on final generated instructions. Later vectorization follows the selected layout and its own legality checks.
- Does **not** cap buffer-derived/annotated layouts or override explicit `coalesced_width`/`loop_layout` choices.
- Does **not** belong to persistent `ParallelOpNode` state or require a special operator clone to carry it. Keeping it in `LayoutInferArgs` makes its per-call lifetime explicit and prevents this search option from leaking into another attempt or later inference.

The name's `candidate` refers specifically to constructing a loop-partition alternative, not a global compilation plan or a final-code vectorization setting. The same integer is passed through `RunOneAttempt` and `RunInferStep` into `LayoutInferArgs`, without an intermediate scalar boolean.

Each complete attempt also owns its propagation queue and membership flags. A discarded attempt can leave pending work; keeping this state local prevents it from affecting the next root, scalar candidate, or wide-fallback retry.

## Validation

### Latest cleanup validation

For `492684f1`, after rebuilding the changed C++ sources and removing temporary diagnostic instrumentation:

- H100 layout, transform layout-inference, reducer-v2/reduce/reduce-maxmin-NaN, and scalar-candidate tests: **514 passed, 1 skipped**. This includes all 14 scalar-candidate tests, including the two new conflict/retry cases.
- B300 scalar-candidate tests: **14 passed**.
- H100 layout golden verification passed with no golden changes; CuTe/oracle parity: **112/112**. The harness uses an auto-selected target: B300's 26 differences from the H100 goldens are identical before and after this cleanup.
- Six compute-control CUDA sources are byte-identical to the previous PR head (`068d0573`). B300 SwiGLU/MHC controls: **52 correctness tests passed**, with all **50 generated sources** unchanged (42 primary controls plus eight additional correctness-only compilations).
- Scoped `format.sh` checks and `git diff --check` passed. The worktree is clean after committing.

The new retry cases exercise actual conflicts with pending propagation work, but also pass on the previous PR head; they are path coverage, not a reproduced old wrong-result case. No full performance-matrix rerun was performed for this cleanup; the earlier performance results below are retained as earlier validation.

### Earlier candidate-search validation

Fresh CUDA builds of the base and patched source:

- New CUDA regression tests: 12 passed on H100 and 12 passed on B300. Covers scalar column ownership, packed bf16 full reduction, annotations, dynamic shapes, multiple update sites, and runtime correctness.
- Layout tests, transform layout-inference tests, and language reducer-v2/reduce/reduce-maxmin-NaN tests on H100: 500 passed, 1 skipped.
- Layout golden harness passed; existing goldens unchanged. CuTe/oracle parity: 112/112.
- Additional SwiGLU/MHC controls: 42/42 generated CUDA sources identical to the base and 52 correctness tests passed on each GPU.
- `./format.sh` and `git diff --check` passed.

An automatic-layout, compute-only compress control on H100 (median of seven randomized CUDA-graph rounds):

| Configuration | Base | Patched | Speedup |
| --- | ---: | ---: | ---: |
| 1 block, 48 tiles | 68.04 us | 28.33 us | 2.40x |
| 132 blocks, 1 tile | 2.46 us | 1.64 us | 1.50x |

Its three AllReduce sites disappear. The bf16 full-reduction control retains byte-identical CUDA, and all 12 paired compute controls pass correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added one scalar reducer-plan attempt per eligible root in `register-count`.
- Preserved native plans on ties and explicit layout or width constraints.
- Scoped `candidate_vector_size_limit` to the first root inference.
- Kept `io-aware` behavior unchanged.
- Deferred intermediate-width exploration.

## Tests

- Added reducer scalar-candidate coverage for reductions, constraints, retries, dynamic shapes, and correctness.
- Validation covered CUDA, layout, reducer, parity, generated-source, formatting, and diff checks.
- Compute-only controls showed 2.40× and 1.50× speedups with three fewer `AllReduce` sites.
- The bf16 full-reduction control remained byte-identical in CUDA.

## C++ style / lint notes

- The PR changes C++ API declarations but does not modify the documented rules in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step applies.
- TLCPP003/TLCPP004 findings are advisory and are not merge blockers unless they indicate a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->