### PR TITLE
[CUDA] Support missing 16-bit inverse and binary math operations

### DIFF
--- a/src/cuda/codegen/intrin_rule_cuda.cc
+++ b/src/cuda/codegen/intrin_rule_cuda.cc
@@ -154,6 +154,50 @@ TVM_REGISTER_OP("tirx.rsqrt")
     .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic",
                                DispatchPureExtern<CUDAMath>);
 
+TVM_REGISTER_OP("tirx.asin")
+    .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic",
+                               DispatchPureExtern<CUDAMath>);
+
+TVM_REGISTER_OP("tirx.acos")
+    .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic",
+                               DispatchPureExtern<CUDAMath>);
+
+TVM_REGISTER_OP("tirx.asinh")
+    .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic",
+                               DispatchPureExtern<CUDAMath>);
+
+TVM_REGISTER_OP("tirx.acosh")
+    .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic",
+                               DispatchPureExtern<CUDAMath>);
+
+TVM_REGISTER_OP("tirx.atanh")
+    .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic",
+                               DispatchPureExtern<CUDAMath>);
+
+TVM_REGISTER_OP("tirx.log1p")
+    .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic",
+                               DispatchPureExtern<CUDAMath>);
+
+TVM_REGISTER_OP("tirx.atan2")
+    .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic",
+                               DispatchPureExtern<CUDAMath>);
+
+TVM_REGISTER_OP("tirx.hypot")
+    .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic",
+                               DispatchPureExtern<CUDAMath>);
+
+TVM_REGISTER_OP("tirx.copysign")
+    .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic",
+                               DispatchPureExtern<CUDAMath>);
+
+TVM_REGISTER_OP("tirx.ldexp")
+    .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic",
+                               DispatchPureExtern<CUDAMath>);
+
+TVM_REGISTER_OP("tirx.nextafter")
+    .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic",
+                               DispatchPureExtern<CUDAMath>);
+
 TVM_REGISTER_OP("tirx.isfinite")
     .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic", DispatchCUDAIsFinite);
 

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -272,6 +272,54 @@ TL_PATCH TL_DEVICE bfloat16_t hnearbyint(const bfloat16_t x) {
   return bfloat16_t(nearbyintf(float(x)));
 }
 
+TL_PATCH TL_DEVICE half_t hasin(const half_t x) {
+  return half_t(asinf(float(x)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hasin(const bfloat16_t x) {
+  return bfloat16_t(asinf(float(x)));
+}
+
+TL_PATCH TL_DEVICE half_t hacos(const half_t x) {
+  return half_t(acosf(float(x)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hacos(const bfloat16_t x) {
+  return bfloat16_t(acosf(float(x)));
+}
+
+TL_PATCH TL_DEVICE half_t hasinh(const half_t x) {
+  return half_t(asinhf(float(x)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hasinh(const bfloat16_t x) {
+  return bfloat16_t(asinhf(float(x)));
+}
+
+TL_PATCH TL_DEVICE half_t hacosh(const half_t x) {
+  return half_t(acoshf(float(x)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hacosh(const bfloat16_t x) {
+  return bfloat16_t(acoshf(float(x)));
+}
+
+TL_PATCH TL_DEVICE half_t hatanh(const half_t x) {
+  return half_t(atanhf(float(x)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hatanh(const bfloat16_t x) {
+  return bfloat16_t(atanhf(float(x)));
+}
+
+TL_PATCH TL_DEVICE half_t hlog1p(const half_t x) {
+  return half_t(log1pf(float(x)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hlog1p(const bfloat16_t x) {
+  return bfloat16_t(log1pf(float(x)));
+}
+
 TL_PATCH TL_DEVICE half_t hpow(const half_t x, const half_t y) {
   return half_t(powf(float(x), float(y)));
 }
@@ -286,6 +334,67 @@ TL_PATCH TL_DEVICE half_t hfmod(const half_t x, const half_t y) {
 
 TL_PATCH TL_DEVICE bfloat16_t hfmod(const bfloat16_t x, const bfloat16_t y) {
   return bfloat16_t(fmodf(float(x), float(y)));
+}
+
+TL_PATCH TL_DEVICE half_t hatan2(const half_t x, const half_t y) {
+  return half_t(atan2f(float(x), float(y)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hatan2(const bfloat16_t x, const bfloat16_t y) {
+  return bfloat16_t(atan2f(float(x), float(y)));
+}
+
+TL_PATCH TL_DEVICE half_t hhypot(const half_t x, const half_t y) {
+  return half_t(hypotf(float(x), float(y)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hhypot(const bfloat16_t x, const bfloat16_t y) {
+  return bfloat16_t(hypotf(float(x), float(y)));
+}
+
+TL_PATCH TL_DEVICE half_t hcopysign(const half_t x, const half_t y) {
+  return half_t(copysignf(float(x), float(y)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hcopysign(const bfloat16_t x,
+                                        const bfloat16_t y) {
+  return bfloat16_t(copysignf(float(x), float(y)));
+}
+
+// ldexp's second operand is an exponent, not a value of the same type.
+TL_PATCH TL_DEVICE half_t hldexp(const half_t x, const int n) {
+  return half_t(ldexpf(float(x), n));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hldexp(const bfloat16_t x, const int n) {
+  return bfloat16_t(ldexpf(float(x), n));
+}
+
+// Step the 16-bit encoding directly: a float32 step is below one 16-bit ulp
+// and rounds back. Compare as integers too, or fast math flushes bf16
+// subnormals to zero. `inf` is the dtype's +inf encoding.
+TL_DEVICE uint16_t nextafter_bits16(const uint16_t ux, const uint16_t uy,
+                                    const uint16_t inf) {
+  const uint16_t mx = ux & 0x7FFF, my = uy & 0x7FFF;
+  if (mx > inf || my > inf)
+    return 0x7FFF;
+  if (ux == uy || (mx | my) == 0)
+    return uy;
+  if (mx == 0)
+    return (uy & 0x8000) | 0x0001;
+  const int kx = (ux & 0x8000) ? -int(mx) : int(mx);
+  const int ky = (uy & 0x8000) ? -int(my) : int(my);
+  const bool away = (kx < ky) == !(ux & 0x8000);
+  return ux + (away ? 1 : -1);
+}
+
+TL_PATCH TL_DEVICE half_t hnextafter(const half_t x, const half_t y) {
+  return half_t::bitcast(nextafter_bits16(x.raw(), y.raw(), 0x7C00));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t hnextafter(const bfloat16_t x,
+                                         const bfloat16_t y) {
+  return bfloat16_t::bitcast(nextafter_bits16(x.raw(), y.raw(), 0x7F80));
 }
 
 // TVM lowers 16-bit math ops to CUDA's half-style names (hexp, hlog, ...).

--- a/testing/python/language/test_tilelang_language_intrinsics_codegen.py
+++ b/testing/python/language/test_tilelang_language_intrinsics_codegen.py
@@ -155,12 +155,85 @@ def test_half_math_intrinsics(dtype):
         )
 
 
+# Same bridging as HALF_MATH_OPS, but asin, acos, atanh and acosh have
+# restricted domains, so this group takes inputs of its own. (op, lowered h*
+# intrinsic, torch reference, input index), in the row order
+# domain_math_kernel writes.
+DOMAIN_MATH_OPS = (
+    ("asin", "hasin", torch.asin, 0),
+    ("acos", "hacos", torch.acos, 0),
+    ("atanh", "hatanh", torch.atanh, 0),
+    ("asinh", "hasinh", torch.asinh, 0),
+    ("log1p", "hlog1p", torch.log1p, 0),
+    ("acosh", "hacosh", torch.acosh, 1),
+)
+
+
+def domain_math_kernel(dtype, N):
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        C: T.Tensor((N,), dtype),
+        B: T.Tensor((len(DOMAIN_MATH_OPS), N), dtype),
+    ):
+        with T.Kernel(1, threads=N):
+            i = T.get_thread_binding()
+            # Keep the temporaries: they copy-initialize, a store only assigns.
+            asin_value = T.asin(A[i])
+            acos_value = T.acos(A[i])
+            atanh_value = T.atanh(A[i])
+            asinh_value = T.asinh(A[i])
+            log1p_value = T.log1p(A[i])
+            acosh_value = T.acosh(C[i])
+            B[0, i] = asin_value
+            B[1, i] = acos_value
+            B[2, i] = atanh_value
+            B[3, i] = asinh_value
+            B[4, i] = log1p_value
+            B[5, i] = acosh_value
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", [T.float16, T.bfloat16])
+def test_domain_math_intrinsics(dtype):
+    N = 128
+    kernel = tilelang.compile(domain_math_kernel(dtype, N), target="cuda")
+    body = kernel.get_kernel_source()
+    body = body[body.rindex("__global__") :]
+
+    torch_dtype = dtype.as_torch()
+    idx = torch.arange(N, device="cuda", dtype=torch.float32)
+    # Exact in both dtypes and inside (-1, 1), keeping every result finite.
+    a = ((idx - 63.5) * 0.015625).to(torch_dtype)
+    # acosh needs [1, inf).
+    c = (idx * 0.03125 + 1.0).to(torch_dtype)
+    b = torch.empty(len(DOMAIN_MATH_OPS), N, device="cuda", dtype=torch_dtype)
+    kernel(a, c, b)
+
+    inputs = (a, c)
+    for row, (name, intrinsic, ref_fn, which) in enumerate(DOMAIN_MATH_OPS):
+        assert body.count(f"{intrinsic}(") == 1
+        ref = ref_fn(inputs[which].float()).to(torch_dtype)
+        torch.testing.assert_close(
+            b[row].float(),
+            ref.float(),
+            atol=2e-2,
+            rtol=2e-2,
+            msg=lambda base, name=name: f"T.{name} mismatch\n{base}",
+        )
+
+
 # (op, lowered h* intrinsic, torch reference, dtypes it can reach codegen on).
 # bfloat16 T.pow is rejected before codegen by an upstream dtype check, so its
 # bridge is not reachable yet (tile-ai/tilelang#2571).
 BINARY_MATH_OPS = (
     ("fmod", "hfmod", torch.fmod, (T.float16, T.bfloat16)),
     ("pow", "hpow", torch.pow, (T.float16,)),
+    ("atan2", "hatan2", torch.atan2, (T.float16, T.bfloat16)),
+    ("hypot", "hhypot", torch.hypot, (T.float16, T.bfloat16)),
+    ("copysign", "hcopysign", torch.copysign, (T.float16, T.bfloat16)),
 )
 
 
@@ -202,10 +275,15 @@ def test_binary_math_intrinsics(name, intrinsic, ref_fn, dtype):
         # value is exact in float16 and bfloat16.
         a = ((idx - 64) * 0.25).to(torch_dtype)
         c = (((idx % 5) - 2.5) * 1.5).to(torch_dtype)
-    else:
+    elif name == "pow":
         # [0.5, 1.5) base and [0.5, 2.5) exponent keep pow finite in float16.
         a = (idx * 0.0078125 + 0.5).to(torch_dtype)
         c = (idx * 0.015625 + 0.5).to(torch_dtype)
+    else:
+        # A crosses zero and C takes both signs at a comparable magnitude: atan2
+        # sees all four quadrants, hypot cannot pass as |A|, copysign must flip.
+        a = ((idx - 64) * 0.25).to(torch_dtype)
+        c = (((idx % 9) - 4) * 2.0).to(torch_dtype)
     b = torch.empty(N, device="cuda", dtype=torch_dtype)
     kernel(a, c, b)
 
@@ -217,6 +295,86 @@ def test_binary_math_intrinsics(name, intrinsic, ref_fn, dtype):
         rtol=2e-2,
         msg=lambda base: f"T.{name} mismatch\n{base}",
     )
+
+
+def ldexp_kernel(dtype, N):
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        C: T.Tensor((N,), T.int32),
+        B: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(1, threads=N):
+            i = T.get_thread_binding()
+            # Keep the temporary: it copy-initializes, a store only assigns.
+            value = T.ldexp(A[i], C[i])
+            B[i] = value
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", [T.float16, T.bfloat16])
+def test_ldexp_intrinsic(dtype):
+    N = 128
+    kernel = tilelang.compile(ldexp_kernel(dtype, N), target="cuda")
+    body = kernel.get_kernel_source()
+    body = body[body.rindex("__global__") :]
+    assert body.count("hldexp(") == 1
+
+    torch_dtype = dtype.as_torch()
+    idx = torch.arange(N, device="cuda", dtype=torch.float32)
+    # Exponents of both signs. Scaling exact multiples of 0.25 by 2**n is exact
+    # in both dtypes, so the result has to match exactly.
+    a = ((idx - 64) * 0.25).to(torch_dtype)
+    n = ((idx % 7) - 3).to(torch.int32)
+    b = torch.empty(N, device="cuda", dtype=torch_dtype)
+    kernel(a, n, b)
+
+    ref = torch.ldexp(a.float(), n).to(torch_dtype)
+    torch.testing.assert_close(b.float(), ref.float(), atol=0, rtol=0)
+
+
+# Fast math flushes float32 subnormals, which bfloat16 subnormals become, so
+# bfloat16 also runs with it on; float16 subnormals are float32 normals.
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    "dtype, fast_math",
+    [(T.float16, False), (T.bfloat16, False), (T.bfloat16, True)],
+)
+def test_nextafter_intrinsic(dtype, fast_math):
+    N = 128
+    kernel = tilelang.compile(
+        binary_math_kernel("nextafter", dtype, N),
+        target="cuda",
+        pass_configs={"tl.enable_fast_math": fast_math},
+    )
+    body = kernel.get_kernel_source()
+    body = body[body.rindex("__global__") :]
+    assert body.count("hnextafter(") == 1
+
+    torch_dtype = dtype.as_torch()
+    idx = torch.arange(N, device="cuda", dtype=torch.float32)
+    # Steps in both directions on both sides of zero, including x == y.
+    a = ((idx - 64) * 0.25).to(torch_dtype)
+    c = (((idx % 9) - 4) * 2.0).to(torch_dtype)
+    # The edges the encoding step has to get right: signed zeros, the
+    # smallest subnormal, the largest finite value, infinities and NaN.
+    inf, nan = float("inf"), float("nan")
+    big = torch.finfo(torch_dtype).max
+    tiny = torch.tensor([1], dtype=torch.int16).view(torch_dtype).item()
+    edge_a = [0.0, -0.0, 0.0, -0.0, tiny, -tiny, big, -big, inf, -inf, nan, 1.0]
+    edge_c = [1.0, -1.0, -0.0, 0.0, -1.0, 1.0, inf, -inf, 0.0, 0.0, 1.0, nan]
+    a[: len(edge_a)] = torch.tensor(edge_a, dtype=torch_dtype)
+    c[: len(edge_c)] = torch.tensor(edge_c, dtype=torch_dtype)
+    b = torch.empty(N, device="cuda", dtype=torch_dtype)
+    kernel(a, c, b)
+
+    ref = torch.nextafter(a, c)
+    # Compare encodings: the sign of a zero result is part of the answer.
+    non_nan = ~torch.isnan(ref)
+    assert torch.equal(torch.isnan(b), ~non_nan)
+    assert torch.equal(b.view(torch.int16)[non_nan], ref.view(torch.int16)[non_nan])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`T.asin`, `T.acos`, `T.asinh`, `T.acosh`, `T.atanh`, `T.log1p`, `T.atan2`, `T.hypot`, `T.copysign`, `T.ldexp`, and `T.nextafter` compile on float32/float64 but fail on float16/bfloat16:

```text
Unresolved call ir.Op(... name="tirx.asin" ...)
```

These ops lack CUDA-specific lowering rules. The generic `FloatSuffix` rule does not handle 16-bit types, leaving their calls unresolved.

## Fix

Register the eleven ops with the existing `CUDAMath` dispatcher and add matching `half_t`/`bfloat16_t` overloads. Float32 and float64 retain their existing function names.

Ten ops evaluate in float32 and convert back, following the bridges added in #3132 and #3163. `hldexp` takes an integer exponent.

`nextafter` steps the 16-bit encoding directly, since taking a float32 step and converting back does not produce the adjacent 16-bit value. Both overloads share an integer implementation that handles NaNs, signed zeros, subnormals and infinities. Integer comparisons avoid treating bf16 subnormals as zero when `--use_fast_math` enables float32 flush-to-zero.

## Tests

Extended `test_tilelang_language_intrinsics_codegen.py` with:

* domain-appropriate inputs for the six unary ops;
* mixed-sign inputs for `atan2`, `hypot`, and `copysign`;
* exact numerical comparisons for `ldexp`;
* encoding comparisons for `nextafter` on both dtypes, covering signed zeros, subnormals, finite limits, infinities and NaNs, plus bf16 coverage with fast math enabled.

Each test also checks the expected `h*` call in generated CUDA source.

Verified on sm_75 with CUDA 12.4 and the kernel cache disabled: 21 passed. Separate probes confirmed unchanged float32/float64 function names.

Fixes #2990.
Related to #2565; float8 support remains outside this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added CUDA lowering for 11 16-bit math intrinsics.
- Added `half_t` and `bfloat16_t` implementations, including encoding-preserving `nextafter`.
- Added code-generation and numerical tests for both 16-bit types.
- Preserved existing `float32` and `float64` behavior.

## C++ style / lint notes

- The PR changes C++ code.
- No direct change to `docs/developer_guide/cpp_style.md` was identified.
- The repository includes the warning-only `C++ API Style Audit` CI step.
- No correctness, build, or test issues were reported.

## Testing

- 21 tests passed on `sm_75` with CUDA 12.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->