### PR TITLE
[CI] Preserve perf dependency cache after setup failures

### DIFF
--- a/.github/workflows/pr-regression-test-bot.yml
+++ b/.github/workflows/pr-regression-test-bot.yml
@@ -200,7 +200,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
-          # Do not use cache for self-hosted runners, as it will download/upload caches which is slow.
+          # Keep the local cache on self-hosted runners; disable only remote
+          # cache upload/download and pruning. Setup failures can be caused by
+          # transient downloads or compilation, not cache corruption. Retain
+          # downloaded dependencies so retries do not start from a cold cache.
           enable-cache: ${{ !startsWith(matrix.runner.name, 'self-hosted') }}
           prune-cache: ${{ !startsWith(matrix.runner.name, 'self-hosted') }}
           # Use runner tool_cache for self-hosted runners
@@ -246,17 +249,6 @@ jobs:
           if command -v ccache >/dev/null 2>&1; then
             ccache -s || true
           fi
-
-      - name: Clear uv cache for self-hosted runners (if setup failed)
-        if: >-
-          ${{
-            failure() &&
-            startsWith(matrix.runner.name, 'self-hosted') &&
-            (steps.setup-uv.conclusion == 'failure' || steps.setup-venv.conclusion == 'failure')
-          }}
-        run: |
-          echo "Clearing uv cache at ${UV_CACHE_DIR} due to failure."
-          uv cache clean
 
       - name: Enable core dump generation (Linux / GitHub-hosted runners)
         if: ${{ runner.os == 'Linux' && !startsWith(matrix.runner.name, 'self-hosted') }}


### PR DESCRIPTION
## Summary

- Stop clearing the NVIDIA performance bot's entire local uv cache when environment setup fails.
- Clarify that self-hosted runners retain their local cache; only remote cache transfer and automatic pruning are disabled.

## Why

A setup failure does not imply cache corruption. In particular, a transient dependency download failure should not discard dependencies that were already cached successfully.

The recent failures show how this turns a network interruption into repeated cold starts:

- A dependency update selected Torch 2.14 and NCCL 2.30.7 instead of the previously cached Torch 2.13 and NCCL 2.29.7.
- The [September 3 setup failure](https://github.com/tile-ai/tilelang/actions/runs/33722278374/job/100543742623) hit a connection reset while downloading NCCL, then removed the entire 9.3 GiB cache.
- Later attempts had to download unchanged packages such as `nvidia-cufft==12.0.0.61` again. The [latest failed attempt](https://github.com/tile-ai/tilelang/actions/runs/34078482985/job/101615122655) failed downloading cuFFT and cleared another 1.1 GiB.

Retaining the cache allows subsequent attempts to reuse completed downloads. This does not suppress setup errors or fix the underlying network connection. Suspected corrupt entries can still be investigated and invalidated explicitly.

This patch is limited to the NVIDIA perf workflow: it does not change dependency versions, share caches between workflows, or modify kernels.

## Validation

- `git diff --check`.
- `./format.sh --files .github/workflows/pr-regression-test-bot.yml` (all applicable pre-commit checks passed).
- Parsed the workflow YAML, checked that local caching and the existing remote-cache/pruning conditions are preserved, and ran `bash -n` on all 10 remaining shell steps after substituting GitHub expressions.
- Separately validated the failure diagnosis on the runner: restoring an independent copy of the existing CI cache allowed all 121 test dependencies to install successfully without CUDA wheel downloads (6.33 s resolution, 0.84 s installation); Torch 2.14.0+cu130 imported successfully and CUDA was available. Strict offline resolution still fails for `cuda-toolkit`; this was tested using the workflow's normal online installation path.

The runner recovery is not an end-to-end validation of this workflow change. No native code changed, and native/kernel tests were not rerun for this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserve the local `uv` dependency cache on self-hosted NVIDIA performance runners when setup fails.
- Disable remote cache transfer and automatic pruning.
- Remove the cleanup step that deleted the cache after setup failures.
- Keep setup errors visible and preserve existing dependency versions and workflow isolation.

## Validation

- Checked formatting, workflow structure, YAML parsing, and shell syntax.
- Tested runner cache recovery independently.
- Did not rerun native or kernel tests.

## C++ style / lint notes

- This PR changes CI only and does not touch rules in `docs/developer_guide/cpp_style.md`.
- It does not modify the “C++ API Style Audit (warning only)” step.
- No C++ correctness, build, test, or style warnings were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->