### PR TITLE
[Transform] Add snapshot mode to FreshenMutableReads

### DIFF
--- a/src/transform/common/constr_visitor.h
+++ b/src/transform/common/constr_visitor.h
@@ -24,28 +24,51 @@
 namespace tvm::tl {
 
 /*!
- * \brief Replace every mutable read in an expression with a fresh, independent
- *        variable.
+ * \brief Replace mutable reads with unknown variables.
  *
  * `Analyzer::Bind` installs a rewrite `var -> value`, so a definition reading
  * mutable state would outlive a store this does not track, and would make two
  * instances agree where two threads read two different registers.
+ *
+ * By default, every occurrence gets an independent variable. Snapshot mode
+ * reuses variables for structurally equal reads within this mutator instance.
+ * Use it only when repeated expressions describe the same captured value, such
+ * as the bounds of one access region, and use separate instances for distinct
+ * access points. This models a snapshot; it does not capture values at runtime.
  */
 class FreshenMutableReads : public tirx::ExprMutator {
 public:
   using tirx::ExprMutator::operator();
 
+  /*! \brief Whether repeated reads denote separate evaluations or one snapshot.
+   */
+  enum class Mode {
+    kPerOccurrence,
+    kSnapshot,
+  };
+
+  explicit FreshenMutableReads(Mode mode = Mode::kPerOccurrence)
+      : mode_(mode) {}
+
 private:
   /*!
-   * \brief A fresh variable for one occurrence of \p e, never reused for a
-   *        structurally equal one.
+   * \brief Replace \p e according to the caller's evaluation model.
    *
    * An opaque call need not return the same value twice (`f() - f()` is not
    * zero), and two reads of one location may be separated by a store. Sharing
-   * would assert an equality that need not hold.
+   * would assert an equality that need not hold, so reuse requires explicit
+   * snapshot mode.
    */
   PrimExpr Fresh(const PrimExpr &e) {
-    return tirx::Var("free" + std::to_string(count_++), e.dtype());
+    if (mode_ == Mode::kSnapshot) {
+      auto it = memo_.find(e);
+      if (it != memo_.end())
+        return it->second;
+    }
+    tirx::Var fresh("free" + std::to_string(count_++), e.dtype());
+    if (mode_ == Mode::kSnapshot)
+      memo_.emplace(e, fresh);
+    return fresh;
   }
 
   PrimExpr VisitExpr_(const tirx::BufferLoadNode *op) override {
@@ -67,7 +90,11 @@ private:
     return tirx::ExprMutator::VisitExpr_(op);
   }
 
+  Mode mode_;
   int count_{0};
+  std::unordered_map<PrimExpr, PrimExpr, ffi::StructuralHash,
+                     tirx::ExprDeepEqual>
+      memo_;
 };
 
 struct Constr {


### PR DESCRIPTION
Region dependency analyses can repeat one captured mutable read in several derived bounds. Assigning a different unknown to every occurrence loses the relationships between those bounds, which currently requires a separate visitor in the Ascend backend.

Add `FreshenMutableReads::Mode` with `kPerOccurrence` (the unchanged default) and `kSnapshot`. Snapshot mode reuses structurally equal reads within one mutator instance, allowing these analyses to share the upstream implementation. Document that distinct access points require separate instances and that snapshot mode must not merge independent stateful evaluations.

Validation:

- CUDA-enabled native build.
- Standalone C++ checks for default/explicit per-occurrence behavior, structural reuse within a snapshot, independent snapshots and buffers, preserved region-bound relationships, opaque calls, SSA variables, and dtype preservation.
- ThreadSync and VerifyParallelLoop test files: 50 passed.
- `./format.sh --files src/transform/common/constr_visitor.h` and `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `FreshenMutableReads::Mode` with `kPerOccurrence` and `kSnapshot`.
- Preserved per-occurrence behavior as the default.
- Added snapshot memoization for structurally equal mutable reads within one mutator instance.
- Prevented snapshot mode from merging independent stateful evaluations.

## Validation

- Validated CUDA-native builds.
- Ran standalone C++ checks, ThreadSync tests, and VerifyParallelLoop tests.
- Ran formatting and diff checks.

## C++ style / lint notes

- This PR changes a public C++ API but does not change rules documented in `docs/developer_guide/cpp_style.md`.
- No correctness, build, or test issues are reported.
- The C++ API Style Audit is warning-only when enabled. No new blocking issue is identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->