### PR TITLE
[BugFix] Route T.sync_global to T.sync_grid; accept unsigned scalar params

### DIFF
--- a/testing/python/jit/test_tilelang_jit_cython.py
+++ b/testing/python/jit/test_tilelang_jit_cython.py
@@ -3,6 +3,7 @@ import tilelang.language as T
 import tilelang.testing
 import tilelang
 import torch
+import pytest
 
 
 @tilelang.testing.requires_cuda
@@ -55,6 +56,24 @@ def test_cython_pdl():
     tilelang.testing.torch_assert_close(c, ref_c, atol=1e-5, rtol=1e-5)
 
     print("pdl test passed!")
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", [T.uint8, T.uint16, T.uint32, T.uint64])
+def test_cython_unsigned_scalar_param(dtype):
+    """An unsigned scalar parameter must marshal like its signed counterpart."""
+
+    @T.prim_func
+    def main(A: T.Tensor((128,), T.int32), s: dtype, B: T.Tensor((128,), T.int32)):
+        with T.Kernel(1, threads=128):
+            i = T.get_thread_binding()
+            B[i] = A[i] + s
+
+    kernel = tilelang.compile(main, execution_backend="cython")
+    a = torch.arange(128, dtype=torch.int32, device="cuda")
+    b = torch.empty(128, dtype=torch.int32, device="cuda")
+    kernel(a, 5, b)
+    tilelang.testing.torch_assert_close(b, a + 5, atol=0, rtol=0)
 
 
 if __name__ == "__main__":

--- a/testing/python/language/test_tilelang_language_cooperative.py
+++ b/testing/python/language/test_tilelang_language_cooperative.py
@@ -36,5 +36,37 @@ def test_grid_sync():
     torch.testing.assert_close(tensor, target)
 
 
+@tilelang.jit
+def global_sync(N=1024):
+    block = 64
+
+    @T.prim_func
+    def kernel(A: T.Tensor((N), T.float32)):
+        with T.Kernel(T.ceildiv(N, block), threads=128) as bx:
+            A_local = T.alloc_fragment((block), dtype=T.float32)
+            n_idx = bx * block
+            for i in T.Parallel(block):
+                A[n_idx + i] = n_idx + i
+            T.sync_global()
+            for i in T.Parallel(block):
+                A_local[i] = A[N - n_idx - i - 1]
+                T.sync_global()
+                A[n_idx + i] = A[n_idx + i] + A_local[i]
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(6, 0)
+def test_global_sync():
+    N = 1024
+    kernel = global_sync(N)
+    assert "cooperative_groups::this_grid().sync()" in kernel.get_kernel_source()
+    tensor = torch.rand((N), dtype=torch.float32, device="cuda")
+    kernel(tensor)
+    target = torch.full_like(tensor, tensor[0])
+    torch.testing.assert_close(tensor, target)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -236,6 +236,10 @@ cdef class CythonKernelWrapper:
             torch.int16: ctypes.c_int16,
             torch.int32: ctypes.c_int32,
             torch.int64: ctypes.c_int64,
+            torch.uint8: ctypes.c_uint8,
+            torch.uint16: ctypes.c_uint16,
+            torch.uint32: ctypes.c_uint32,
+            torch.uint64: ctypes.c_uint64,
             torch.bool: ctypes.c_bool,
         }
 

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -230,6 +230,7 @@ class TLCUDASourceWrapper:
         "int64": "int64_t",
         "int32": "int",
         "uint32": "unsigned int",
+        "uint64": "uint64_t",
         "bool": "int8_t",
         "int8": "int8_t",
         "uint8": "uint8_t",

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -7,7 +7,6 @@ from tilelang._typing import BufferLikeType, BufferLikeTypeTuple, BarrierType, D
 from tilelang import tvm as tvm
 from tilelang.language.common import ptx_arrive_barrier, evaluate
 from tilelang.language.eager.builder import macro
-from tilelang.language.kernel import get_thread_bindings, get_block_extents
 from tvm import DataType, DataTypeCode, tirx
 from tvm.runtime import convert
 from tvm.tirx import PrimExpr, Var, Call, BufferLoad, BufferRegion
@@ -1180,12 +1179,11 @@ def match_all_sync(
 
 
 def sync_global():
-    """Synchronize all threads in the entire grid."""
-    tx, ty, tz = get_thread_bindings()
-    ex, ey, ez = get_block_extents()
-    print(tx, ty, tz, ex, ey, ez)
-    args = ["global", tx == 0 and ty == 0 and tz == 0, ex * ey * ez]
-    return evaluate(tirx.Call("handle", "tirx.tvm_storage_sync", args))
+    """Synchronize all threads in the entire grid.
+
+    Alias of :func:`sync_grid`.
+    """
+    return sync_grid()
 
 
 def sync_grid():


### PR DESCRIPTION
Two independent frontend/adapter fixes, one commit each.

### `T.sync_global()` aborts codegen (#2992)

It lowers to a `"global"`-scope `tvm_storage_sync`. Every backend either `LOG(FATAL)`s on that scope (CUDA `codegen_cuda.cc:1639`, CuteDSL `:3728`, Metal `:422`) or drops it silently — HIP `PrintStorageSync` has no `"global"` branch, so no barrier is emitted at all.

`tl.sync_grid` is the working grid barrier (`src/op/builtin.cc:124`, lowered by CUDA/HIP/CuteDSL). `PersistThreadblock` also scans for it to set `kUseCooperativeGroups`; the `tvm_storage_sync` path never did, so the old body could not have worked even with a live codegen branch. `sync_global` is now an alias of `sync_grid`. That also removes a debug `print` firing on every trace, and a `tx == 0 and ty == 0 and tz == 0` built with Python `and` over `PrimExpr`: `bool(tx == 0)` returns `False` (measured, it does not raise), so the chain short-circuits to `tx == 0` and the `ty`/`tz` terms were silently dropped.

The `"global"` `LOG(FATAL)` branches are kept — nothing emits that scope now, and removing them would turn a future stray `"global"` sync into a silently missing barrier.

@rishabhsinha17 raised this A/B on #2992 first; this is Option A. Happy to close if you would rather they take it.

### Unsigned scalar params rejected on the default backend (#2981, #2988)

`uint8/16/32` are rejected at host marshalling (`cython_wrapper.pyx` `dtype_to_ctype` has only the signed rows); `uint64` fails one layer earlier in `TLCUDASourceWrapper._TYPE_MAP`, which the HIP (`:694`) and CPU (`:749`) maps in the same file already carry.

```
                     before                                          after
int32    OK  equal=True                              int32    OK  equal=True
uint8    FAIL ValueError: Unsupported tensor dtype   uint8    OK  equal=True
uint16   FAIL ValueError: Unsupported tensor dtype   uint16   OK  equal=True
uint32   FAIL ValueError: Unsupported tensor dtype   uint32   OK  equal=True
uint64   FAIL AssertionError: Unsupported dtype      uint64   OK  equal=True
```

### Tests

H20 (sm_90), 0.1.14 wheel, cython extension rebuilt from the patched `.pyx` for both runs.

```
testing/python/jit/           before: 4 failed, 1 passed (new tests)   after: 70 passed, 14 skipped
testing/python/language/      before: 1160 passed, 35 failed          after: 1161 passed, 34 failed
```

The flipped `language/` test is `test_global_sync`, added here. No new failures; the remaining 34 are pre-existing on this box (int4 vectorize, fp16 `fmod`/`pow`, cutedsl pdl).

Fixes #2992
Fixes #2981
Fixes #2988

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Route `T.sync_global()` through `T.sync_grid()` to use supported grid-barrier lowering and remove invalid `PrimExpr` boolean handling and debug output.
- Add Cython host-marshalling support for `uint8`, `uint16`, `uint32`, and `uint64` scalar parameters.
- Add CUDA host-wrapper support for `uint64` tensor parameters.
- Add regression tests for global synchronization and unsigned parameter handling.

## Testing

- `testing/python/jit/`: 70 passed, 14 skipped.
- `testing/python/language/`: 1161 passed, 34 failures. The remaining failures are pre-existing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
