### PR TITLE
[CI] Fail the perf bot on a regression instead of only reporting it

### DIFF
--- a/.github/workflows/pr-regression-test-bot.yml
+++ b/.github/workflows/pr-regression-test-bot.yml
@@ -275,26 +275,26 @@ jobs:
           sysctl kern.corefile kern.coredump kern.sugid_coredump
 
       - name: Run performance regression test
+        id: perf
         run: |
           source test_regression/bin/activate
           OLD_PYTHON=./old/bin/python NEW_PYTHON=./new/bin/python \
             PERF_REGRESSION_MD=regression_result.md PERF_REGRESSION_PNG=regression_result.png \
             python ./maint/scripts/test_perf_regression.py
 
-      - name: Read markdown table
-        id: read_md
-        run: |
-          echo "content<<EOF" >> $GITHUB_OUTPUT
-          cat regression_result.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
+      # An `if:` without a status-check function is evaluated as `success() && ...`,
+      # which is false once the step above exits 1 on a regression. `!cancelled()`
+      # supplies the status check explicitly, so the report is still posted before
+      # the job goes red.
       - name: Upload result image as artifact
+        if: ${{ !cancelled() && (steps.perf.outcome == 'success' || steps.perf.outcome == 'failure') }}
         uses: actions/upload-artifact@v7
         with:
           name: perf-regression-${{ github.run_id }}
           path: regression_result.png
 
       - name: Post test results as PR comment
+        if: ${{ !cancelled() && (steps.perf.outcome == 'success' || steps.perf.outcome == 'failure') }}
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/maint/scripts/test_perf_regression.py
+++ b/maint/scripts/test_perf_regression.py
@@ -21,6 +21,15 @@ OLD_PYTHON = os.environ.get("OLD_PYTHON", "./old/bin/python")
 NEW_PYTHON = os.environ.get("NEW_PYTHON", "./new/bin/python")
 OUT_MD = os.environ.get("PERF_REGRESSION_MD", "regression_result.md")
 OUT_PNG = os.environ.get("PERF_REGRESSION_PNG", "regression_result.png")
+# Fail the run only when at least MIN_COUNT benchmarks drop below THRESHOLD.
+# Calibrated on the 33 bot reports posted to PRs up to #3176 (1901 samples):
+# 20 reports are clean, 6 (all on PR #2464) show a real regression with 14-23
+# benchmarks collapsing at once, and 7 carry exactly one outlier as low as 0.044
+# while every other benchmark sits at 1.000. Requiring two simultaneous drops
+# separates those cases exactly -- 6/6 real regressions caught, 0 false alarms --
+# for any threshold in 0.80..0.95.
+THRESHOLD = float(os.environ.get("PERF_REGRESSION_THRESHOLD", "0.90"))
+MIN_COUNT = int(os.environ.get("PERF_REGRESSION_MIN_COUNT", "2"))
 _RESULTS_JSON_PREFIX = "__TILELANG_PERF_RESULTS_JSON__="
 
 
@@ -226,11 +235,35 @@ if not table:
 table.sort(key=lambda x: x[-1])
 
 headers = ["File", "Original Latency", "Current Latency", "Speedup"]
-
-with open(OUT_MD, "w") as f:
-    f.write(tabulate(table, headers=headers, tablefmt="github", stralign="left", numalign="decimal"))
-    f.write("\n")
-
 df = pd.DataFrame(table, columns=headers)
 df = df.sort_values("Speedup", ascending=False).reset_index(drop=True)
 draw(df)
+
+# Speedup is old/new latency, so anything below the threshold is a slowdown.
+slow = [row for row in table if row[-1] < THRESHOLD]
+regressed = slow if len(slow) >= MIN_COUNT else []
+
+if regressed:
+    summary = f"**Regression: {len(regressed)}/{len(table)} benchmarks below {THRESHOLD:g}x**\n\n"
+    summary += "".join(f"- `{row[0]}`: {row[-1]:.3f}x\n" for row in regressed)
+elif slow:
+    summary = (
+        f"No regression. {len(slow)}/{len(table)} benchmarks landed below {THRESHOLD:g}x, "
+        f"under the {MIN_COUNT}-benchmark bar that separates a real regression from a single noisy run: "
+        + ", ".join(f"`{row[0]}` {row[-1]:.3f}x" for row in slow)
+        + "\n"
+    )
+else:
+    summary = f"No regression: all {len(table)} benchmarks kept speedup >= {THRESHOLD:g}.\n"
+
+marked = [[f"{row[0]} :warning:" if row[-1] < THRESHOLD else row[0], *row[1:]] for row in table]
+with open(OUT_MD, "w") as f:
+    f.write(summary)
+    f.write("\n")
+    f.write(tabulate(marked, headers=headers, tablefmt="github", stralign="left", numalign="decimal"))
+    f.write("\n")
+
+print(summary)
+if regressed:
+    # Exit last so the markdown table and the plot are still produced for the report.
+    exit(1)


### PR DESCRIPTION
`test_perf_regression.py` always exited 0, so a regression reached the PR as a
comment nobody had to act on. This makes the job fail when the numbers show one.

The rule is picked from the bot's own history rather than a guessed noise band.
Across the 33 reports posted to PRs up to #3176 (1901 samples):

| | reports |
|---|---|
| clean | 20 |
| real regression (all on #2464, 14-23 benchmarks collapsing together) | 6 |
| exactly one outlier, every other benchmark at 1.000 | 7 |

The 7 single-outlier reports dip as low as 0.044 and are not regressions, so
failing on any one sub-threshold benchmark turns 13 of 33 red and buries the 6
real ones. Requiring **two simultaneous drops** separates the two cases exactly,
for any threshold in 0.80..0.95:

```
threshold  min_count | flagged  TP  FP  FN
     0.90          1 |      13   6   7   0
     0.90          2 |       6   6   0   0
```

Defaults 0.90x over 2 benchmarks, both overridable
(`PERF_REGRESSION_THRESHOLD`, `PERF_REGRESSION_MIN_COUNT`). Replaying all 33
historical reports through the patched script reproduces the split exactly:

```
replayed 33 historical reports through the script
would go RED: 6
  PR #2464: **Regression: 18/58 benchmarks below 0.9x**
  PR #2464: **Regression: 14/58 benchmarks below 0.9x**
  PR #2464: **Regression: 17/57 benchmarks below 0.9x**
  PR #2464: **Regression: 23/58 benchmarks below 0.9x**
  PR #2464: **Regression: 19/58 benchmarks below 0.9x**
  PR #2464: **Regression: 20/58 benchmarks below 0.9x**
```

A lone slow benchmark is still named in the summary and marked in the table, it
just does not fail the run.

Two supporting fixes so a red run still reports: the markdown table and the plot
are written before the exit, and the upload/comment steps now run on failure
too. The `Read markdown table` step is dropped, its output was never referenced
anywhere and the comment step reads the file directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Make the performance regression bot fail when at least two benchmarks regress below the `0.90x` threshold.
- Support configuration through `PERF_REGRESSION_THRESHOLD` and `PERF_REGRESSION_MIN_COUNT`.
- Keep single-benchmark outliers in the report without failing the job.
- Generate and upload the report, plot, and PR comment before the job exits with failure.
- Remove the unused “Read markdown table” step.

Historical replay produced six expected failures for PR `#2464` with no false positives.

## C++ style / lint notes

- This PR does not change rules documented in `docs/developer_guide/cpp_style.md`.
- The existing “C++ API Style Audit (warning only)” CI step is not changed.
- No C++ style warnings are introduced or affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->