### PR TITLE
[Refactor] [CUDA] Rename `AutoSchedule` to `AutoWarpSpecialization`

### DIFF
--- a/examples/aws/flash_attention.py
+++ b/examples/aws/flash_attention.py
@@ -16,7 +16,7 @@ PASS_CFG = {
 @tilelang.jit(
     pass_configs={
         **PASS_CFG,
-        tilelang.PassConfigKey.TL_ENABLE_AUTO_SCHEDULE: "role_based",
+        tilelang.PassConfigKey.TL_ENABLE_AUTO_WARP_SPECIALIZATION: "role_based",
     }
 )
 def flash_attention(

--- a/examples/aws/gemm.py
+++ b/examples/aws/gemm.py
@@ -7,7 +7,7 @@ from tilelang.carver.arch import driver
 from tilelang.profiler import do_bench
 
 
-@tilelang.jit(pass_configs={tilelang.PassConfigKey.TL_ENABLE_AUTO_SCHEDULE: "role_based"})
+@tilelang.jit(pass_configs={tilelang.PassConfigKey.TL_ENABLE_AUTO_WARP_SPECIALIZATION: "role_based"})
 def gemm(
     A,
     B,

--- a/src/cuda/op/builtin.cc
+++ b/src/cuda/op/builtin.cc
@@ -15,7 +15,7 @@ namespace tl {
 using namespace tirx;
 
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableWarpSpecialized, Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION(kEnableAutoSchedule, ffi::String);
+TVM_REGISTER_PASS_CONFIG_OPTION(kEnableAutoWarpSpecialization, ffi::String);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableTMALower, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kPtxasRegisterUsageLevel, Integer);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableVectorize256, Bool);

--- a/src/cuda/op/builtin.h
+++ b/src/cuda/op/builtin.h
@@ -35,7 +35,8 @@ static constexpr const char *kHasTMA = "tl.has_tma";
 // because they are part of the Python PassContext interface.
 static constexpr const char *kDisableWarpSpecialized =
     "tl.disable_warp_specialized";
-static constexpr const char *kEnableAutoSchedule = "tl.enable_auto_schedule";
+static constexpr const char *kEnableAutoWarpSpecialization =
+    "tl.enable_auto_warp_specialization";
 static constexpr const char *kDisableTMALower = "tl.disable_tma_lower";
 static constexpr const char *kPtxasRegisterUsageLevel =
     "tl.ptxas_register_usage_level";

--- a/src/cuda/transform/auto_schedule.cc
+++ b/src/cuda/transform/auto_schedule.cc
@@ -2,18 +2,17 @@
  * \file auto_schedule.cc
  * \brief Generic entrypoint for automatic warp-specialization schedulers.
  *
- * The pass config "tl.enable_auto_schedule" names the scheduler to run
- * (see SchedulerRegistry; currently "role_based"); when unset the pass
- * is a no-op. For each eligible kernel — a tilelang_root block with a
- * known threadIdx.x extent, no existing schedule, and no manual warp
- * specialization — the entrypoint
- * gives every schedulable statement a stable "tl.ws_op_id" marker and
- * checks the schedulability contract (preprocess_ir), then asks the
+ * The pass config "tl.enable_auto_warp_specialization" names the scheduler to
+ * run (see SchedulerRegistry; currently "role_based"); when unset the pass is a
+ * no-op. For each eligible kernel — a tilelang_root block with a known
+ * threadIdx.x extent, no existing schedule, and no manual warp specialization —
+ * the entrypoint gives every schedulable statement a stable "tl.ws_op_id"
+ * marker and checks the schedulability contract (preprocess_ir), then asks the
  * scheduler for a typed WSSchedule, which MaterializeWSSchedule then
  * lowers. The kernel body itself only gains the id markers; any kernel
  * preprocessing or the scheduler declines is left byte-for-byte
- * unchanged, with the reason emitted as an on-site warning (auto
- * scheduling is opt-in, so the user expects it to fire).
+ * unchanged, with the reason emitted as an on-site warning (auto warp
+ * specialization is opt-in, so the user expects it to fire).
  *
  * TODO: verify dependence coverage of USER-PROVIDED schedules with a real
  * dependence analysis (synthesized schedules cover exactly the cross-role
@@ -43,10 +42,12 @@ namespace tl {
 
 using namespace tirx;
 using namespace tirx::transform;
+using namespace cuda;
 
 namespace {
 
-// Available schedulers, by the name passed in tl.enable_auto_schedule.
+// Available schedulers, by the name passed in
+// tl.enable_auto_warp_specialization.
 const std::map<std::string, SchedulerFn> &SchedulerRegistry() {
   static const std::map<std::string, SchedulerFn> registry = {
       {"role_based", RoleBasedSchedule},
@@ -61,15 +62,15 @@ SchedulerFn FindScheduler(const ffi::String &name) {
     std::string known;
     for (const auto &[known_name, fn] : registry)
       known += (known.empty() ? "" : ", ") + known_name;
-    LOG(FATAL) << "unknown auto-schedule scheduler '" << name
+    LOG(FATAL) << "unknown auto-warp-specialization scheduler '" << name
                << "'; available: " << known;
   }
   return it->second;
 }
 
-class AutoScheduleRewriter : public StmtMutator {
+class AutoWarpSpecializationRewriter : public StmtMutator {
 public:
-  AutoScheduleRewriter(SchedulerFn scheduler, Target target)
+  AutoWarpSpecializationRewriter(SchedulerFn scheduler, Target target)
       : scheduler_(scheduler), target_(std::move(target)) {}
 
 private:
@@ -120,12 +121,13 @@ private:
   int original_threads_{0};
 };
 
-PrimFunc AutoScheduleImpl(PrimFunc func, SchedulerFn scheduler) {
+PrimFunc AutoWarpSpecializationImpl(PrimFunc func, SchedulerFn scheduler) {
   auto target = func->GetAttr<Target>(tvm::attr::kTarget);
-  ICHECK(target.defined()) << "AutoSchedule: PrimFunc has no bound target "
-                              "(BindTarget must run before AutoSchedule)";
+  ICHECK(target.defined())
+      << "AutoWarpSpecialization: PrimFunc has no bound target "
+         "(BindTarget must run before AutoWarpSpecialization)";
 
-  AutoScheduleRewriter rewriter(scheduler, target.value());
+  AutoWarpSpecializationRewriter rewriter(scheduler, target.value());
   Stmt body = rewriter(func->body);
   if (body.same_as(func->body))
     return func;
@@ -135,21 +137,22 @@ PrimFunc AutoScheduleImpl(PrimFunc func, SchedulerFn scheduler) {
 
 } // namespace
 
-tvm::transform::Pass AutoSchedule() {
+tvm::transform::Pass AutoWarpSpecialization() {
   auto pass_func = [](PrimFunc func, const IRModule &, const PassContext &ctx) {
-    auto scheduler_name =
-        ctx->GetConfig(kEnableAutoSchedule, ffi::Optional<ffi::String>());
+    auto scheduler_name = ctx->GetConfig(kEnableAutoWarpSpecialization,
+                                         ffi::Optional<ffi::String>());
     if (!scheduler_name.has_value())
       return func;
-    return AutoScheduleImpl(std::move(func),
-                            FindScheduler(scheduler_name.value()));
+    return AutoWarpSpecializationImpl(std::move(func),
+                                      FindScheduler(scheduler_name.value()));
   };
-  return CreatePrimFuncPass(pass_func, 0, "tl.AutoSchedule", {});
+  return CreatePrimFuncPass(pass_func, 0, "tl.AutoWarpSpecialization", {});
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef().def("tl.cuda.transform.AutoSchedule", AutoSchedule);
+  refl::GlobalDef().def("tl.cuda.transform.AutoWarpSpecialization",
+                        AutoWarpSpecialization);
 }
 
 } // namespace tl

--- a/src/cuda/transform/auto_schedule/common.h
+++ b/src/cuda/transform/auto_schedule/common.h
@@ -1,6 +1,7 @@
 /*!
  * \file common.h
- * \brief Shared declarations of the AutoSchedule entrypoint and schedulers.
+ * \brief Shared declarations of the AutoWarpSpecialization entrypoint and
+ * schedulers.
  *
  * A scheduler receives one eligible kernel — the root block and its body
  * normalized so every schedulable statement carries a "tl.ws_op_id" marker —
@@ -19,6 +20,7 @@
 
 namespace tvm {
 namespace tl {
+namespace cuda {
 
 using SchedulerFn = ffi::Optional<WSSchedule> (*)(const tirx::SBlock &block,
                                                   const tirx::Stmt &body,
@@ -32,9 +34,10 @@ inline ffi::String ExtractOpId(const ffi::Any &value) {
     return string.value();
   if (const auto *imm = value.as<tirx::StringImmNode>())
     return imm->value;
-  TVM_FFI_THROW(ValueError) << "AutoSchedule op id must be a string";
+  TVM_FFI_THROW(ValueError) << "AutoWarpSpecialization op id must be a string";
   return "";
 }
 
+} // namespace cuda
 } // namespace tl
 } // namespace tvm

--- a/src/cuda/transform/auto_schedule/memory_detector.h
+++ b/src/cuda/transform/auto_schedule/memory_detector.h
@@ -23,6 +23,7 @@
 
 namespace tvm {
 namespace tl {
+namespace cuda {
 
 using namespace tirx;
 using ffi::Array;
@@ -459,5 +460,6 @@ private:
   }
 };
 
+} // namespace cuda
 } // namespace tl
 } // namespace tvm

--- a/src/cuda/transform/auto_schedule/preprocess_ir.cc
+++ b/src/cuda/transform/auto_schedule/preprocess_ir.cc
@@ -37,6 +37,7 @@
 
 namespace tvm {
 namespace tl {
+namespace cuda {
 
 using namespace tirx;
 using namespace ffi;
@@ -62,23 +63,26 @@ bool CheckCalls(const Stmt &body) {
     if (call == nullptr || !ok)
       return;
     if (call->op.same_as(tl::loop_break())) {
-      LOG(WARNING) << "AutoSchedule skipped: cannot schedule loop_break";
+      LOG(WARNING)
+          << "AutoWarpSpecialization skipped: cannot schedule loop_break";
       ok = false;
       return;
     }
     if (IsBarrierOrTmaControlCall(call)) {
-      LOG(WARNING) << "AutoSchedule skipped: cannot schedule hand-written "
-                      "synchronization or TMA control ('"
-                   << call->op << "'): block-wide syncs cannot be duplicated "
-                   << "into roles, and hand-managed barrier protocols are "
-                   << "invisible to the schedule";
+      LOG(WARNING)
+          << "AutoWarpSpecialization skipped: cannot schedule hand-written "
+             "synchronization or TMA control ('"
+          << call->op << "'): block-wide syncs cannot be duplicated "
+          << "into roles, and hand-managed barrier protocols are "
+          << "invisible to the schedule";
       ok = false;
       return;
     }
     if (const auto *op = call->op.as<OpNode>()) {
       if (std::string(op->name).find("atomic") != std::string::npos) {
-        LOG(WARNING) << "AutoSchedule skipped: cannot schedule atomic op '"
-                     << op->name << "'";
+        LOG(WARNING)
+            << "AutoWarpSpecialization skipped: cannot schedule atomic op '"
+            << op->name << "'";
         ok = false;
       }
     }
@@ -101,7 +105,7 @@ bool CheckHostsNoAsync(const Stmt &stmt, const Target &target) {
       return;
     if (const auto *copy = tile_op.as<CopyNode>()) {
       if (ClassifyCopy(copy, target) == TileStmtKind::kTmaProducer) {
-        LOG(WARNING) << "AutoSchedule skipped: an asynchronous "
+        LOG(WARNING) << "AutoWarpSpecialization skipped: an asynchronous "
                         "global->shared copy is nested inside a compound "
                         "statement; write it as its own statement so its "
                         "completion barrier can be wired";
@@ -111,9 +115,10 @@ bool CheckHostsNoAsync(const Stmt &stmt, const Target &target) {
     }
     if (auto gemm = GetGemmInfo(tile_op)) {
       if (IsTmemBuffer(gemm->accumulator) || gemm->wg_wait != 0) {
-        LOG(WARNING) << "AutoSchedule skipped: an asynchronous gemm is "
-                        "nested inside a compound statement; write it as "
-                        "its own statement";
+        LOG(WARNING)
+            << "AutoWarpSpecialization skipped: an asynchronous gemm is "
+               "nested inside a compound statement; write it as "
+               "its own statement";
         ok = false;
       }
     }
@@ -258,5 +263,6 @@ ffi::Optional<Stmt> PreprocessIR(Stmt body, const Target &target) {
   return OpIdNormalizer::Rewrite(std::move(body), target);
 }
 
+} // namespace cuda
 } // namespace tl
 } // namespace tvm

--- a/src/cuda/transform/auto_schedule/preprocess_ir.h
+++ b/src/cuda/transform/auto_schedule/preprocess_ir.h
@@ -8,11 +8,13 @@
 
 namespace tvm {
 namespace tl {
+namespace cuda {
 
 // Give every schedulable statement a stable "tl.ws_op_id" marker in the
 // forms MaterializeWSSchedule consumes; idempotent. Unschedulable
 // constructs decline the kernel (warning + nullopt).
 ffi::Optional<tirx::Stmt> PreprocessIR(tirx::Stmt body, const Target &target);
 
+} // namespace cuda
 } // namespace tl
 } // namespace tvm

--- a/src/cuda/transform/auto_schedule/role_based_scheduler.cc
+++ b/src/cuda/transform/auto_schedule/role_based_scheduler.cc
@@ -63,6 +63,7 @@
 
 namespace tvm {
 namespace tl {
+namespace cuda {
 
 using namespace tirx;
 using namespace ffi;
@@ -332,8 +333,8 @@ private:
     if (!ok_)
       return;
     if (op->else_case.defined()) {
-      LOG(WARNING)
-          << "AutoSchedule skipped: if-else branches are not supported";
+      LOG(WARNING) << "AutoWarpSpecialization skipped: if-else branches are "
+                      "not supported";
       ok_ = false;
       return;
     }
@@ -346,8 +347,8 @@ private:
     if (!ok_)
       return;
     auto id = op->annotations.Get(kWSOpIdKey);
-    ICHECK(id.has_value()) << "AutoSchedule normalized loop is missing "
-                           << kWSOpIdKey;
+    ICHECK(id.has_value())
+        << "AutoWarpSpecialization normalized loop is missing " << kWSOpIdKey;
     // Sequential loops are scopes; parallel / vectorized loops are one op.
     if (op->kind != ForKind::kSerial && op->kind != ForKind::kUnrolled) {
       MakeOp(ExtractOpId(id.value()), GetRef<For>(op));
@@ -413,22 +414,22 @@ private:
         return;
       }
     }
-    LOG(FATAL) << "AutoSchedule: Evaluate carries no ws op id";
+    LOG(FATAL) << "AutoWarpSpecialization: Evaluate carries no ws op id";
   }
 
   // The normalizer wraps these statement forms with an id; reaching one
   // bare is its bug.
   void VisitStmt_(const BufferStoreNode *op) final {
-    LOG(FATAL) << "AutoSchedule: BufferStore carries no ws op id";
+    LOG(FATAL) << "AutoWarpSpecialization: BufferStore carries no ws op id";
   }
   void VisitStmt_(const BindNode *op) final {
-    LOG(FATAL) << "AutoSchedule: Bind carries no ws op id";
+    LOG(FATAL) << "AutoWarpSpecialization: Bind carries no ws op id";
   }
   void VisitStmt_(const WhileNode *op) final {
-    LOG(FATAL) << "AutoSchedule: while loop carries no ws op id";
+    LOG(FATAL) << "AutoWarpSpecialization: while loop carries no ws op id";
   }
   void VisitStmt_(const SBlockNode *op) final {
-    LOG(FATAL) << "AutoSchedule: block carries no ws op id";
+    LOG(FATAL) << "AutoWarpSpecialization: block carries no ws op id";
   }
 
   Target target_;
@@ -439,8 +440,8 @@ private:
 };
 
 // Plans the schedule for one normalized kernel body. Every unsupported
-// shape declines with a warning: auto scheduling is opt-in, so the user
-// expects it to fire.
+// shape declines with a warning: auto warp specialization is opt-in, so the
+// user expects it to fire.
 class RoleBasedScheduler {
 public:
   RoleBasedScheduler(Target target, int worker_threads)
@@ -448,12 +449,14 @@ public:
 
   Optional<WSSchedule> Run(const SBlock &block, const Stmt &body) {
     if (!TargetHasBulkCopy(target_)) {
-      LOG(WARNING) << "AutoSchedule skipped: target has no bulk-copy (TMA) "
-                      "support";
+      LOG(WARNING)
+          << "AutoWarpSpecialization skipped: target has no bulk-copy (TMA) "
+             "support";
       return std::nullopt;
     }
     if (worker_threads_ % 128 != 0) {
-      LOG(WARNING) << "AutoSchedule skipped: worker threads must be a multiple "
+      LOG(WARNING) << "AutoWarpSpecialization skipped: worker threads must be "
+                      "a multiple "
                       "of 128 so issuer warps start a fresh warpgroup";
       return std::nullopt;
     }
@@ -473,8 +476,9 @@ public:
     if (!BuildPipelines(block))
       return std::nullopt;
     if (pipelines_.empty()) {
-      LOG(WARNING) << "AutoSchedule skipped: no cross-role on-chip handoff to "
-                      "pipeline";
+      LOG(WARNING)
+          << "AutoWarpSpecialization skipped: no cross-role on-chip handoff to "
+             "pipeline";
       return std::nullopt;
     }
     return Emit();
@@ -522,7 +526,7 @@ private:
           if (auto mask = copy->annotations.Get("cluster_mask")) {
             if (const auto *imm = mask.value().as<IntImmNode>();
                 imm == nullptr || imm->value != 0) {
-              LOG(WARNING) << "AutoSchedule skipped: op '" << op.id
+              LOG(WARNING) << "AutoWarpSpecialization skipped: op '" << op.id
                            << "' is a cluster multicast copy";
               return false;
             }
@@ -539,7 +543,7 @@ private:
         continue;
       case TileStmtKind::kCpAsyncRaw:
         // Raw cp.async carries its own thread-local completion protocol.
-        LOG(WARNING) << "AutoSchedule skipped: op '" << op.id
+        LOG(WARNING) << "AutoWarpSpecialization skipped: op '" << op.id
                      << "': raw cp.async statements carry their own "
                         "thread-local completion protocol";
         return false;
@@ -565,7 +569,7 @@ private:
         // release right after the gemm would race with them.
         if (auto gemm = GetGemmInfo(op.tile_op)) {
           if (gemm->wg_wait != 0) {
-            LOG(WARNING) << "AutoSchedule skipped: op '" << op.id
+            LOG(WARNING) << "AutoWarpSpecialization skipped: op '" << op.id
                          << "': gemm with wg_wait != 0 completes "
                             "asynchronously; delayed wgmma waits are not "
                             "supported yet";
@@ -619,9 +623,9 @@ private:
         if (def->roles.Contains(role))
           return true;
         if (!def->roleless) {
-          LOG(WARNING) << "AutoSchedule skipped: '" << user << "' needs op '"
-                       << def->id << "' in role " << RoleName(role)
-                       << ", but that op is fixed to role "
+          LOG(WARNING) << "AutoWarpSpecialization skipped: '" << user
+                       << "' needs op '" << def->id << "' in role "
+                       << RoleName(role) << ", but that op is fixed to role "
                        << RoleName(RoleOf(*def));
           return false;
         }
@@ -684,7 +688,8 @@ private:
     for (const auto &op : ops_)
       active.Add(op->roles);
     if (active.Empty()) {
-      LOG(WARNING) << "AutoSchedule skipped: kernel has no schedulable work";
+      LOG(WARNING)
+          << "AutoWarpSpecialization skipped: kernel has no schedulable work";
       return false;
     }
     std::vector<SchedOp *> leftovers;
@@ -797,7 +802,7 @@ private:
           two_roles = two_roles && (role == producer || role == consumer);
       }
       if (!two_roles) {
-        LOG(WARNING) << "AutoSchedule skipped: storage '"
+        LOG(WARNING) << "AutoWarpSpecialization skipped: storage '"
                      << resolution.allocation->name
                      << "' is handed between more than two roles in scope '"
                      << scope.id << "'";
@@ -879,7 +884,7 @@ private:
         ok = false;
       }
       if (!ok) {
-        LOG(WARNING) << "AutoSchedule skipped: storage '"
+        LOG(WARNING) << "AutoWarpSpecialization skipped: storage '"
                      << resolution.allocation->name << "' in scope '"
                      << scope.id << "': " << reason;
         resolution.failed = true;
@@ -934,7 +939,8 @@ private:
     // Under versioning, a guard-skipped write would expose the slot from
     // `depth` iterations ago instead of the previous value.
     if (guarded_writer && pipeline->depth > 1) {
-      LOG(WARNING) << "AutoSchedule skipped: storage '" << pipeline->name
+      LOG(WARNING) << "AutoWarpSpecialization skipped: storage '"
+                   << pipeline->name
                    << "' is written under a guard and would be "
                    << pipeline->depth
                    << "-way versioned; a skipped write would expose a "
@@ -976,7 +982,7 @@ private:
         for (const SchedOp *op : buffer_uses_[buffer->data].touches)
           others.Add(op->roles);
         if (!writer->roles.ContainsAll(others)) {
-          LOG(WARNING) << "AutoSchedule skipped: global buffer '"
+          LOG(WARNING) << "AutoWarpSpecialization skipped: global buffer '"
                        << buffer->name << "' is written by op '" << writer->id
                        << "' and touched by another role";
           return false;
@@ -1161,7 +1167,7 @@ private:
     int max_threads = static_cast<int>(
         target_->GetAttr<Integer>("max_num_threads").value_or(1024)->value);
     if (num_warps * 32 > max_threads) {
-      LOG(WARNING) << "AutoSchedule skipped: " << num_warps
+      LOG(WARNING) << "AutoWarpSpecialization skipped: " << num_warps
                    << " warps exceed the target's " << max_threads
                    << "-thread block limit";
       return std::nullopt;
@@ -1257,5 +1263,6 @@ ffi::Optional<WSSchedule> RoleBasedSchedule(const SBlock &block,
   return RoleBasedScheduler(target, worker_threads).Run(block, body);
 }
 
+} // namespace cuda
 } // namespace tl
 } // namespace tvm

--- a/src/cuda/transform/auto_schedule/role_based_scheduler.h
+++ b/src/cuda/transform/auto_schedule/role_based_scheduler.h
@@ -8,6 +8,7 @@
 
 namespace tvm {
 namespace tl {
+namespace cuda {
 
 // Fixed-role heuristic: classify ops by lowering eligibility (Load / MMA /
 // Store / Worker), pull warp-private def-use chains into their consumers'
@@ -18,5 +19,6 @@ ffi::Optional<WSSchedule> RoleBasedSchedule(const tirx::SBlock &block,
                                             int worker_threads,
                                             const Target &target);
 
+} // namespace cuda
 } // namespace tl
 } // namespace tvm

--- a/src/cuda/transform/materialize_ws_schedule.cc
+++ b/src/cuda/transform/materialize_ws_schedule.cc
@@ -100,6 +100,7 @@ namespace tl {
 
 using namespace tirx;
 using namespace ffi;
+using namespace cuda;
 
 namespace {
 

--- a/testing/python/transform/test_tilelang_transform_auto_schedule.py
+++ b/testing/python/transform/test_tilelang_transform_auto_schedule.py
@@ -1,4 +1,4 @@
-"""Tests for AutoSchedule's "role_based" scheduler.
+"""Tests for AutoWarpSpecialization's "role_based" scheduler.
 
 The pass consumes plain (schedule-free) kernels, assigns fixed roles from
 lowering eligibility (Load / MMA / Store / Worker), pulls warp-private
@@ -28,15 +28,15 @@ def _prepare(func):
     return mod
 
 
-def _auto_schedule(mod, scheduler="role_based"):
-    """Apply AutoSchedule with the scheduler opted in via pass config."""
-    with tvm.transform.PassContext(config={"tl.enable_auto_schedule": scheduler}):
-        return tilelang.cuda.transform.AutoSchedule()(mod)
+def _auto_warp_specialization(mod, scheduler="role_based"):
+    """Apply AutoWarpSpecialization with the scheduler opted in via pass config."""
+    with tvm.transform.PassContext(config={"tl.enable_auto_warp_specialization": scheduler}):
+        return tilelang.cuda.transform.AutoWarpSpecialization()(mod)
 
 
 def _schedule(func):
     """Run the pass; returns (scheduled module, root WSSchedule or None)."""
-    scheduled = _auto_schedule(_prepare(func))
+    scheduled = _auto_warp_specialization(_prepare(func))
     return scheduled, _root_schedule(scheduled["main"])
 
 
@@ -622,7 +622,7 @@ def test_guarded_write_into_versioned_pipeline_declines():
     than silently re-versioned; guarded writes to single-buffered
     pipelines (FA's rescale) keep source semantics and stay schedulable."""
     prepared = _prepare(_guarded_producer_kernel())
-    scheduled = _auto_schedule(prepared)
+    scheduled = _auto_warp_specialization(prepared)
     assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
 
 
@@ -746,7 +746,7 @@ def test_rmw_accumulator_numerical():
         _rmw_accumulator_kernel(),
         target="cuda",
         out_idx=[3],
-        pass_configs={"tl.enable_auto_schedule": "role_based"},
+        pass_configs={"tl.enable_auto_warp_specialization": "role_based"},
     )
     a = torch.randn((4, 128, 64), device="cuda", dtype=torch.float16)
     b = torch.randn((4, 64, 64), device="cuda", dtype=torch.float16)
@@ -875,7 +875,7 @@ def test_read_before_nested_cycle_declines():
                     T.copy(F, B[w, k, 0, 0])
 
     prepared = _prepare(kernel)
-    scheduled = _auto_schedule(prepared)
+    scheduled = _auto_warp_specialization(prepared)
     assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
 
 
@@ -886,7 +886,7 @@ def test_post_loop_read_numerical():
         _post_loop_read_kernel(),
         target="cuda",
         out_idx=[1, 2],
-        pass_configs={"tl.enable_auto_schedule": "role_based"},
+        pass_configs={"tl.enable_auto_warp_specialization": "role_based"},
     )
     a = torch.randn((2, 4, 64, 64), device="cuda", dtype=torch.float16)
     b, c = kernel(a)
@@ -900,7 +900,7 @@ def test_pipeline_opt_in_runs_automatic_ws():
     mod = tvm.IRModule.from_expr(func)
     with (
         _TARGET,
-        tvm.transform.PassContext(config={"tl.enable_auto_schedule": "role_based"}),
+        tvm.transform.PassContext(config={"tl.enable_auto_warp_specialization": "role_based"}),
     ):
         out = tilelang.cuda.pipeline.CUDAPassPipelineBodyPrologue(mod, _TARGET)["main"]
 
@@ -920,7 +920,7 @@ def test_no_shared_handoff_is_left_unchanged():
             T.copy(F, B)
 
     prepared = _prepare(kernel)
-    scheduled = _auto_schedule(prepared)
+    scheduled = _auto_warp_specialization(prepared)
     assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
 
 
@@ -993,7 +993,7 @@ def test_while_scope_numerical():
         _persistent_while_kernel(),
         target="cuda",
         out_idx=[1],
-        pass_configs={"tl.enable_auto_schedule": "role_based"},
+        pass_configs={"tl.enable_auto_warp_specialization": "role_based"},
     )
     a = torch.randn((2, 64, 64), device="cuda", dtype=torch.float16)
     torch.testing.assert_close(kernel(a), a)
@@ -1005,7 +1005,7 @@ def test_pipelined_load_numerical():
         _pipelined_load_kernel(),
         target="cuda",
         out_idx=[1],
-        pass_configs={"tl.enable_auto_schedule": "role_based"},
+        pass_configs={"tl.enable_auto_warp_specialization": "role_based"},
     )
     a = torch.randn((4, 64, 64), device="cuda", dtype=torch.float16)
     torch.testing.assert_close(kernel(a), a)
@@ -1017,7 +1017,7 @@ def test_two_cycles_numerical():
         _two_cycle_kernel(),
         target="cuda",
         out_idx=[1],
-        pass_configs={"tl.enable_auto_schedule": "role_based"},
+        pass_configs={"tl.enable_auto_warp_specialization": "role_based"},
     )
     a = torch.randn((2, 64, 64), device="cuda", dtype=torch.float16)
     torch.testing.assert_close(kernel(a), a)
@@ -1029,7 +1029,7 @@ def test_gather_bind_numerical():
         _gather_kernel(worker_uses_index=True),
         target="cuda",
         out_idx=[2],
-        pass_configs={"tl.enable_auto_schedule": "role_based"},
+        pass_configs={"tl.enable_auto_warp_specialization": "role_based"},
     )
     indices = torch.tensor([5, 2, 7, 0], device="cuda", dtype=torch.int32)
     a = torch.randn((8, 64, 64), device="cuda", dtype=torch.float16)
@@ -1045,7 +1045,7 @@ def test_local_chain_numerical():
         _local_chain_kernel(),
         target="cuda",
         out_idx=[1],
-        pass_configs={"tl.enable_auto_schedule": "role_based"},
+        pass_configs={"tl.enable_auto_warp_specialization": "role_based"},
     )
     a = torch.randn((4, 64, 64), device="cuda", dtype=torch.float16)
     expected = torch.stack([a[k * 2 % 4] for k in range(4)])
@@ -1058,7 +1058,7 @@ def test_worker_gemm_numerical():
         _local_accumulator_gemm(),
         target="cuda",
         out_idx=[2],
-        pass_configs={"tl.enable_auto_schedule": "role_based"},
+        pass_configs={"tl.enable_auto_warp_specialization": "role_based"},
     )
     a = torch.randn((64, 128), device="cuda", dtype=torch.float16)
     b = torch.randn((128, 64), device="cuda", dtype=torch.float16)
@@ -1097,7 +1097,7 @@ def test_storage_cycling_in_sibling_loops_declines():
     nothing chains — the second loop's pre-armed acquire could overwrite
     data the first loop's consumer still reads. The kernel declines."""
     prepared = _prepare(_two_loop_kernel())
-    scheduled = _auto_schedule(prepared)
+    scheduled = _auto_warp_specialization(prepared)
     assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
 
 
@@ -1169,7 +1169,7 @@ def test_non_tma_layout_numerical():
         _non_tma_layout_kernel(),
         target="cuda",
         out_idx=[1],
-        pass_configs={"tl.enable_auto_schedule": "role_based"},
+        pass_configs={"tl.enable_auto_warp_specialization": "role_based"},
     )
     a = torch.randn((4, 64, 64), device="cuda", dtype=torch.float16)
     torch.testing.assert_close(kernel(a), a + a)
@@ -1229,7 +1229,7 @@ def test_cp_async_load_numerical():
         _cp_async_load_kernel(),
         target="cuda",
         out_idx=[1],
-        pass_configs={"tl.enable_auto_schedule": "role_based"},
+        pass_configs={"tl.enable_auto_warp_specialization": "role_based"},
     )
     a = torch.randn((4, 64, 64), device="cuda", dtype=torch.float16)
     torch.testing.assert_close(kernel(a), a)
@@ -1261,7 +1261,7 @@ def test_async_wgmma_wait_kernel_is_left_unchanged():
             T.copy(C_local, C[0, 0])
 
     prepared = _prepare(kernel)
-    scheduled = _auto_schedule(prepared)
+    scheduled = _auto_warp_specialization(prepared)
     assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
 
 
@@ -1288,7 +1288,7 @@ def test_raw_cp_async_kernel_is_left_unchanged():
                 T.copy(F, A[k, 0, 0])
 
     prepared = _prepare(kernel)
-    scheduled = _auto_schedule(prepared)
+    scheduled = _auto_warp_specialization(prepared)
     assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
 
 
@@ -1322,7 +1322,7 @@ def test_pointer_table_bind_follows_freshened_buffer():
         _pointer_table_kernel(),
         target="cuda",
         out_idx=[1],
-        pass_configs={"tl.enable_auto_schedule": "role_based"},
+        pass_configs={"tl.enable_auto_warp_specialization": "role_based"},
     )
     src = torch.randn((64, 64), device="cuda", dtype=torch.float16)
     ptrs = torch.tensor([src.data_ptr()], device="cuda", dtype=torch.int64)
@@ -1331,8 +1331,8 @@ def test_pointer_table_bind_follows_freshened_buffer():
 
 @tilelang.testing.requires_cuda
 def test_unknown_scheduler_rejected():
-    with pytest.raises(Exception, match="unknown auto-schedule scheduler"):
-        _auto_schedule(_prepare(_pipelined_load_kernel()), scheduler="nonexistent")
+    with pytest.raises(Exception, match="unknown auto-warp-specialization scheduler"):
+        _auto_warp_specialization(_prepare(_pipelined_load_kernel()), scheduler="nonexistent")
 
 
 @tilelang.testing.requires_cuda
@@ -1371,7 +1371,7 @@ def test_unschedulable_constructs_decline():
 
     for kernel in (atomic_kernel, hosted_async_kernel, sync_threads_kernel):
         prepared = _prepare(kernel)
-        scheduled = _auto_schedule(prepared)
+        scheduled = _auto_warp_specialization(prepared)
         assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
 
 
@@ -1382,7 +1382,7 @@ def test_tmem_gemm_numerical():
         _tmem_gemm(),
         target="cuda",
         out_idx=[2],
-        pass_configs={"tl.enable_auto_schedule": "role_based"},
+        pass_configs={"tl.enable_auto_warp_specialization": "role_based"},
     )
     a = torch.randn((2, 128, 64), device="cuda", dtype=torch.float16)
     b = torch.randn((2, 128, 64), device="cuda", dtype=torch.float16)
@@ -1408,7 +1408,7 @@ def test_thread_budget_exceeded_declines():
                 T.copy(F, B[k, 0, 0])
 
     prepared = _prepare(kernel)
-    scheduled = _auto_schedule(prepared)
+    scheduled = _auto_warp_specialization(prepared)
     assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
 
 
@@ -1501,7 +1501,7 @@ def test_annotated_ws_pipeline_depth_on_inner_binding_declines():
     rescale): versioning it would expose a stale slot, so the annotated
     depth declines."""
     prepared = _prepare(_waved_rmw_accumulator_kernel(inner_depth=2))
-    scheduled = _auto_schedule(prepared)
+    scheduled = _auto_warp_specialization(prepared)
     assert tvm.ir.structural_equal(scheduled["main"], prepared["main"])
 
 
@@ -1512,7 +1512,7 @@ def test_annotated_ws_pipeline_depth_ring_numerical():
         _waved_rmw_accumulator_kernel(depth=2),
         target="cuda",
         out_idx=[3],
-        pass_configs={"tl.enable_auto_schedule": "role_based"},
+        pass_configs={"tl.enable_auto_warp_specialization": "role_based"},
     )
     a = torch.randn((2, 4, 128, 64), device="cuda", dtype=torch.float16)
     b = torch.randn((2, 4, 64, 64), device="cuda", dtype=torch.float16)

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -100,11 +100,11 @@ def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     # @CUDA-specific
     # Tile-level warp specialization: runs before layout inference so that
     # producer/consumer split happens at the high-level tile-op IR.
-    # AutoSchedule: derive a WSSchedule for kernels without one, using the scheduler named by tl.enable_auto_schedule (opt-in; no-op when unset).
+    # AutoWarpSpecialization: derive a WSSchedule for kernels without one, using the scheduler named by tl.enable_auto_warp_specialization (opt-in; no-op when unset).
     # MaterializeWSSchedule: Materialize a user-provided warp-specialization schedule (T.annotate_ws_schedule).
     # ProducerConsumerWarpSpecialized: The pass classifies copy ops as TMA/cp.async/sync inline. Shared buffers are multi-versioned internally only for functions where the WS transformation actually applies.
     if allow_warp_specialized(target=target):
-        mod = tilelang.cuda.transform.AutoSchedule()(mod)
+        mod = tilelang.cuda.transform.AutoWarpSpecialization()(mod)
         mod = tilelang.cuda.transform.MaterializeWSSchedule()(mod)
         mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
 

--- a/tilelang/cuda/transform/__init__.py
+++ b/tilelang/cuda/transform/__init__.py
@@ -3,9 +3,9 @@
 from .. import _ffi_api
 
 
-def AutoSchedule():
+def AutoWarpSpecialization():
     """Derive a warp-specialization schedule with the scheduler named by
-    the ``tl.enable_auto_schedule`` pass config (currently
+    the ``tl.enable_auto_warp_specialization`` pass config (currently
     ``"role_based"``); a no-op when the config is unset.
 
     Eligible kernels gain stable ``tl.ws_op_id`` markers and a typed
@@ -18,7 +18,7 @@ def AutoSchedule():
     fpass : tvm.transform.Pass
         The result pass
     """
-    return _ffi_api.AutoSchedule()  # type: ignore
+    return _ffi_api.AutoWarpSpecialization()  # type: ignore
 
 
 def AnnotateDeviceBoundTmaCopies():
@@ -178,7 +178,7 @@ def PersistThreadblock():
 
 __all__ = [
     "AnnotateDeviceBoundTmaCopies",
-    "AutoSchedule",
+    "AutoWarpSpecialization",
     "AnnotateWarpGroupRegAlloc",
     "FuseMBarrierArriveExpectTx",
     "InjectFenceProxy",

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -73,7 +73,7 @@ class PassConfigKey(str, Enum):
     TL_DISABLE_WARP_SPECIALIZED = "tl.disable_warp_specialized"
     """Disable warp specialization optimization. Default: False"""
 
-    TL_ENABLE_AUTO_SCHEDULE = "tl.enable_auto_schedule"
+    TL_ENABLE_AUTO_WARP_SPECIALIZATION = "tl.enable_auto_warp_specialization"
     """Name of the automatic warp-specialization scheduler to run (e.g.
     "role_based"). Default: unset (disabled)."""
 


### PR DESCRIPTION
This avoids potential ODR violation against other backends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Renames the CUDA `AutoSchedule` pass to `AutoWarpSpecialization`.

- Updates C++, Python, FFI, pass configuration, examples, and tests.
- Changes the pass key to `tl.enable_auto_warp_specialization`.
- Moves related declarations into `tvm::tl::cuda`.
- Updates diagnostics and comments.
- Preserves scheduling behavior.

## C++ style / lint notes

The PR touches namespace usage covered by `docs/developer_guide/cpp_style.md`. The implementation-only `using namespace cuda` change follows the documented guidance, but namespace changes should be reviewed for clarity.

The `C++ API Style Audit (warning only)` CI step applies. Any TLCPP003/TLCPP004 findings are advisory unless they indicate an API, FFI, or maintainability risk. No correctness, build, or test result is established by this change summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->