### PR TITLE
Fix crash when applying bitwise_not to vec integers

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -1377,6 +1377,34 @@ void CodeGenTileLangCUDA::PrintVecBinaryOp(const std::string &op, DataType t,
   os << sret;
 }
 
+void CodeGenTileLangCUDA::PrintVecUnaryOp_(const std::string &op,
+                                           DataType dtype,
+                                           const PrimExpr &input,
+                                           std::ostream &os) {
+  std::string result = name_supply_->FreshName("_");
+  PrintIndent();
+  PrintType(dtype, stream);
+  stream << ' ' << result << ";\n";
+  int ssa_scope = BeginScope();
+  // Evaluate the vector once before extracting its lanes.
+  std::string value = SSAGetID(PrintExpr(input), input.dtype());
+  for (int i = 0; i < dtype.lanes(); ++i) {
+    std::ostringstream lane;
+    lane << '(' << op;
+    PrintVecElemLoad(value, input.dtype(), i, lane);
+    lane << ')';
+    // The packed byte store combines lanes with OR. Integer promotion must
+    // not leave upper bits set and overwrite neighboring bytes.
+    std::string lane_value = lane.str();
+    if (dtype.bits() == 8 && (dtype.is_int() || dtype.is_uint())) {
+      lane_value = "(" + lane_value + " & 0xffu)";
+    }
+    PrintVecElemStore(result, dtype, i, lane_value);
+  }
+  EndScope(ssa_scope);
+  os << result;
+}
+
 void CodeGenTileLangCUDA::PrintVecElemLoad(const std::string &vec, DataType t,
                                            int i,
                                            std::ostream &os) { // NOLINT(*)
@@ -4692,6 +4720,11 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
        << ", " << PrintExpr(offset) << ")";
   } else if (HandleLateIntrinsicCall(op, os)) {
     // Handled by a helper to keep MSVC's parser away from the giant tail chain.
+  } else if (op->op.same_as(builtin::bitwise_not()) &&
+             op->dtype.is_fixed_length_vector() && !op->dtype.is_bool() &&
+             (op->dtype.is_int() || op->dtype.is_uint())) {
+    ICHECK_EQ(op->args.size(), 1U);
+    PrintVecUnaryOp_("~", op->dtype, op->args[0], os);
   } else {
     CodeGenC::VisitExpr_(op, os);
   }

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -1377,6 +1377,15 @@ void CodeGenTileLangCUDA::PrintVecBinaryOp(const std::string &op, DataType t,
   os << sret;
 }
 
+/*!
+ * \brief Emit a prefix unary operator, such as `~`, on each vector lane.
+ *
+ * Materializes the input once and uses the lane load/store helpers to
+ * assemble the result, including packed integer representations. Masks
+ * 8-bit integer results so promoted upper bits cannot affect adjacent lanes.
+ * Supporting statements go to `stream`; the result variable name goes to
+ * `os`. The input and result must have the same fixed-length vector type.
+ */
 void CodeGenTileLangCUDA::PrintVecUnaryOp_(const std::string &op,
                                            DataType dtype,
                                            const PrimExpr &input,

--- a/src/cuda/codegen/codegen_cuda.h
+++ b/src/cuda/codegen/codegen_cuda.h
@@ -80,6 +80,8 @@ protected:
                        std::ostream &os) final; // NOLINT(*)
 
 private:
+  void PrintVecUnaryOp_(const std::string &op, DataType dtype,
+                        const PrimExpr &input, std::ostream &os);
   // Handle volatile loads
   void HandleVolatileLoads(const std::string &value, const BufferLoadNode *op,
                            std::ostream &os) final;

--- a/testing/python/language/test_tilelang_language_bitwise_not.py
+++ b/testing/python/language/test_tilelang_language_bitwise_not.py
@@ -1,0 +1,60 @@
+"""Regression coverage for vectorized integer bitwise NOT (#2993)."""
+
+import pytest
+import torch
+
+import tilelang
+from tilelang import tvm
+from tilelang.cuda import language as T
+
+
+DTYPES = [f"{sign}{bits}" for sign in ("int", "uint") for bits in (8, 16, 32, 64)]
+
+
+def make_bitwise_not(dtype, elements_per_thread):
+    n = 32 * elements_per_thread
+
+    @T.prim_func
+    def kernel(A: T.Tensor((n,), dtype), B: T.Tensor((n,), dtype)):
+        with T.Kernel(1, threads=32):
+            for i in T.Parallel(n):
+                B[i] = ~A[i]
+
+    return kernel
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("elements_per_thread", [1, 2, 4])
+def test_bitwise_not_codegen(dtype, elements_per_thread):
+    target = tvm.target.Target({"kind": "cuda", "arch": "sm_90"})
+    with target:
+        source = tilelang.lower(make_bitwise_not(dtype, elements_per_thread), target=target).kernel_source
+    assert "~" in source
+    if elements_per_thread > 1:
+        # A direct complement of a packed vector load is invalid for CUDA structs.
+        assert "(~*(" not in source
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA device required")
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("elements_per_thread", [1, 2, 4])
+def test_bitwise_not_runtime(dtype, elements_per_thread):
+    bits = int(dtype.removeprefix("uint").removeprefix("int"))
+    mask = (1 << bits) - 1
+    signed = dtype.startswith("int")
+
+    def as_value(value):
+        return value - (1 << bits) if signed and value >= (1 << (bits - 1)) else value
+
+    patterns = [0, mask, 1, 1 << (bits - 1), (1 << (bits - 1)) - 1, mask // 3, 2 * (mask // 3), mask - 1]
+    values = patterns * (32 * elements_per_thread // len(patterns))
+    torch_dtype = getattr(torch, dtype)
+    a = torch.tensor([as_value(x) for x in values], dtype=torch_dtype, device="cuda")
+    expected = [as_value(x ^ mask) for x in values]
+    kernel = tilelang.compile(
+        make_bitwise_not(dtype, elements_per_thread),
+        out_idx=[1],
+        target="cuda",
+        execution_backend="tvm_ffi",
+    )
+    assert kernel(a).cpu().tolist() == expected


### PR DESCRIPTION
implement `PrintVecUnaryOp_` to fix #2993. Doing it through XOR seems more annoying because we'd have to find the equivalent of -1 to other unsigned dtypes. This seems more generally useful

Tested 8 dtypes:
- Signed: int8, int16, int32, int64
- Unsigned: uint8, uint16, uint32, uint64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `PrintVecUnaryOp_` to generate lane-by-lane vector unary operations in CUDA code.
- Fixed vectorized integer bitwise NOT for signed and unsigned `int8`, `int16`, `int32`, and `int64` types.
- Masked 8-bit results to prevent integer-promotion bits from affecting packed stores.
- Added code-generation and runtime regression tests for 1, 2, and 4 elements per thread.

## C++ style / lint notes

- The PR changes C++ code but does not alter rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step may report advisory findings. These warnings do not affect correctness or build behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->