### PR TITLE
Fix nvcc inff crash on fp8_e4m3/float4 reduce init

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -6053,6 +6053,21 @@ void CodeGenTileLangCUDA::VisitExpr_(const BroadcastNode *op,
   os << ')';
 }
 
+namespace {
+// Max finite magnitude for fp8/fp4 dtypes with no (or no non-finite)
+// infinity encoding, e.g. the e4m3 family and float4_e2m1fn.
+double MaxFiniteFp8Fp4(const DataType &dtype) {
+  if (dtype.is_float8_e4m3fnuz()) {
+    return 240.0;
+  }
+  if (dtype.is_float8_e4m3() || dtype.is_float8_e4m3fn()) {
+    return 448.0;
+  }
+  // float4_e2m1fn / float4_e2m1_unpacked
+  return 6.0;
+}
+} // namespace
+
 inline void PrintConst(const FloatImmNode *op, std::ostream &os,
                        CodeGenTileLangCUDA *p) { // NOLINT(*)
   // Type code is kBFloat/kFloat16
@@ -6115,9 +6130,17 @@ inline void PrintConst(const FloatImmNode *op, std::ostream &os,
       os << "::bitcast(0x7e)";
       return;
     }
+    // No literal spelling for non-finite values here (e.g. -inff/nanf are
+    // invalid identifiers); clamp to the format's max-finite magnitude.
+    double value = op->value;
+    if (std::isnan(value)) {
+      value = MaxFiniteFp8Fp4(op->dtype);
+    } else if (std::isinf(value)) {
+      value = std::copysign(MaxFiniteFp8Fp4(op->dtype), value);
+    }
     p->PrintType(op->dtype, os);
-    os << '(' << FlexibleHexFormat(op->value) << 'f';
-    os << "/*" << std::scientific << op->value << "*/";
+    os << '(' << FlexibleHexFormat(value) << 'f';
+    os << "/*" << std::scientific << value << "*/";
     os << ')';
     return;
   }

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -1134,6 +1134,38 @@ def test_reduce_packed_fp8_to_float16_absmax_runtime():
     torch.testing.assert_close(B, ref, atol=0, rtol=0)
 
 
+def _make_fp8_e4m3_reduce_kernel(reduce_fn, M, N):
+    @T.prim_func
+    def kernel(A: T.Tensor((M, N), T.float8_e4m3), B: T.Tensor((M,), T.float8_e4m3)):
+        with T.Kernel(1, threads=128):
+            src = T.alloc_fragment((M, N), T.float8_e4m3)
+            dst = T.alloc_fragment((M,), T.float8_e4m3)
+            T.copy(A, src)
+            reduce_fn(src, dst, dim=1)
+            T.copy(dst, B)
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(8, 9)
+@pytest.mark.parametrize(("reduce_fn", "torch_op"), [(T.reduce_max, "max"), (T.reduce_min, "min")], ids=["max", "min"])
+def test_reduce_fp8_e4m3_dst_runtime(reduce_fn, torch_op):
+    """reduce_max/reduce_min into a float8_e4m3 dst used to crash nvcc with
+    an undefined `inff` identifier (GH-2998)."""
+    if not hasattr(torch, "float8_e4m3fn"):
+        pytest.skip("torch.float8_e4m3fn is not available")
+
+    M, N = 32, 64
+    k = _compile(_make_fp8_e4m3_reduce_kernel(reduce_fn, M, N))
+
+    a = torch.rand(M, N, device="cuda").to(torch.float8_e4m3fn)
+    out = k(a)
+    # torch has no min/max reduction kernel for float8_e4m3fn; reduce in fp32.
+    ref = getattr(a.float(), torch_op)(dim=1).values
+    assert torch.allclose(out.float(), ref, atol=1e-1)
+
+
 @tilelang.testing.requires_cuda
 def test_reduce_packed_max_nan_propagate_uses_nan_intrinsics():
     k = _compile(_make_nan_reduce_kernel(T.reduce_max, 128, 128, T.float16, threads=256, nan_propagate=True))


### PR DESCRIPTION
## Problem / Cause

`T.reduce_max`/`reduce_min` into a float8_e4m3/float4 destination crashed nvcc with `identifier "inff" is undefined`. Reduce's init constant is built via `make_const(dtype, ±INFINITY)`, bypassing `T.infinity()`'s guard. e4m3/float4 have no infinity encoding, so `PrintConst` printed it raw as `inff`.

## Fix

Clamp non-finite fp8/fp4 constants to the format's max-finite magnitude before printing. Same class of fix as #2671 (e5m2), but a finite sentinel instead of a bitcast, since these formats have no non-finite bit pattern to bitcast to.

Fixes #2998

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Clamp non-finite FP8 and FP4 constants to valid maximum finite values in `PrintConst`.
- Prevent invalid `inff` literals during `T.reduce_max` and `T.reduce_min` initialization.
- Add SM8.9+ runtime tests for FP8 E4M3 reductions against FP32 references.
- Fixes issue `#2998`.

## C++ style / lint notes

- The change does not modify rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit runs in warning-only mode through CI.
- No blocking correctness or build issue is indicated by the style audit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->