### PR TITLE
[Build] Optimize default single-config builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -552,6 +552,16 @@ if(MSVC)
   target_compile_features(tilelang_objs PRIVATE cxx_std_20)
 endif()
 
+# A direct single-config CMake build with no selected build type otherwise
+# compiles TileLang without optimization. Layout validation includes bounded
+# exhaustive expression evaluation, which is prohibitively slow at -O0.
+# Explicit Debug/Release configurations and multi-config generators keep their
+# normal toolchain flags.
+if(NOT CMAKE_CONFIGURATION_TYPES AND CMAKE_BUILD_TYPE STREQUAL "" AND
+   CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+  target_compile_options(tilelang_objs PRIVATE -O2)
+endif()
+
 # Set debug mode compile definitions
 # Enable the TVM debug option, i.e., TVM_LOG_DEBUG
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")


### PR DESCRIPTION
## Summary

- add -O2 to TileLang object compilation for single-config CMake builds with no explicit build type
- preserve explicit Debug/Release and multi-config generator flags
- speeded up some compiler-performance relavent regression in #3180 by geomean ~5x.
- geomean speedup 1.2x in lowering (partial tests from examples).

| Metric | A (no `-O2`) | B (this PR, `-O2`) | Speedup |
| --- | --- | --- | --- |
| Total lowering time of 178 examples | 1548.8 s | 1376.0 s | **1.13x** |
| Total kernel compile time of 178 examples | 4055.4 s | 3922.2 s | 1.03x |
| Geometric mean, lowering | – | – | **1.186x** |
| Geometric mean, full kernel compile | – | – | 1.053x |
| Median, lowering | – | – | 1.161x |
| Median, full kernel compile | – | – | 1.052x |
| Examples with lowering speedup > 5% / < 5% regression / neutral | 168 / 0 / 10 (of 178) | | |
| `libtilelang.so` size | 43.5 MB | 18.9 MB | |


| # | Example | Kernels A/B | Lowering A (s) | Lowering B (s) | Lowering Δ | Compile A (s) | Compile B (s) | Compile Δ |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | `examples/kda/wy_fast_bwd.py` | 34/39 ⚠ | 205.68 | 196.70 | **1.05x** | 327.28 | 339.36 | 0.96x |
| 2 | `examples/block_causal_attention/block_causal_attention_varlen.py` | 29/29 | 196.18 | 183.29 | **1.07x** | 324.62 | 311.07 | 1.04x |
| 3 | `examples/block_causal_attention/test_block_causal_attention.py` | 34/34 | 168.41 | 159.36 | **1.06x** | 321.89 | 312.84 | 1.03x |
| 4 | `examples/amd/example_amd_flash_attn_bwd.py` | 659/683 ⚠ | 136.75 | 122.51 | **1.12x** | 308.65 | 306.62 | 1.01x |
| 5 | `examples/kda/chunk_bwd_dqkwg.py` | 65/74 ⚠ | 131.12 | 135.25 | **0.97x** | 298.24 | 339.80 | 0.88x |
| 6 | `examples/amd/example_amd_flash_attn_fwd.py` | 185/197 ⚠ | 127.49 | 102.83 | **1.24x** | 334.06 | 335.30 | 1.00x |
| 7 | `examples/kda/chunk_bwd_intra.py` | 16/16 | 119.61 | 108.08 | **1.11x** | 162.97 | 158.35 | 1.03x |
| 8 | `examples/kda/chunk_o.py` | 90/90 | 116.03 | 103.05 | **1.13x** | 314.95 | 303.99 | 1.04x |
| 9 | `examples/kda/wy_fast.py` | 60/60 | 108.22 | 94.14 | **1.15x** | 244.65 | 232.19 | 1.05x |
| 10 | `examples/kda/chunk_delta_bwd.py` | 60/60 | 89.23 | 81.32 | **1.10x** | 252.26 | 246.59 | 1.02x |
| 11 | `examples/gemv/example_gemv.py` | 159/165 ⚠ | 81.96 | 67.56 | **1.21x** | 325.23 | 328.17 | 0.99x |
| 12 | `examples/deepseek_mhc/example_mhc_bwd.py` | 28/28 | 75.03 | 61.22 | **1.23x** | 148.30 | 137.05 | 1.08x |
| 13 | `examples/block_causal_attention/block_causal_attention.py` | 22/22 | 66.84 | 61.23 | **1.09x** | 151.69 | 144.30 | 1.05x |
| 14 | `examples/kda/chunk_delta_h_fwd.py` | 54/54 | 51.62 | 48.40 | **1.07x** | 172.46 | 169.93 | 1.01x |
| 15 | `examples/kda/chunk_bwd_dv.py` | 45/45 | 44.40 | 42.11 | **1.05x** | 143.47 | 157.92 | 0.91x |
| 16 | `examples/attention_sink/test_example_attention_sink.py` | 22/22 | 25.40 | 22.52 | **1.13x** | 73.82 | 71.60 | 1.03x |
| 17 | `examples/kda/chunk_bwd_gla_dA.py` | 60/60 | 24.87 | 23.04 | **1.08x** | 158.48 | 170.85 | 0.93x |
| 18 | `examples/gemm_fp8/example_tilelang_gemm_amd.py` | 72/72 | 23.09 | 17.44 | **1.32x** | 170.01 | 155.65 | 1.09x |
| 19 | `examples/kda/chunk_intra_token_parallel.py` | 32/32 | 22.24 | 20.19 | **1.10x** | 75.74 | 76.24 | 0.99x |
| 20 | `examples/dsa_sparse_finetune/dsa.py` | 7/7 | 15.12 | 13.32 | **1.14x** | 31.19 | 29.38 | 1.06x |
| 21 | `examples/gemm_fp8/example_tilelang_gemm_amd_fp8_preshuffle.py` | 54/54 | 14.40 | 10.48 | **1.37x** | 16.29 | 12.20 | 1.33x |
| 22 | `examples/flash_attention/test_example_flash_attention.py` | 19/19 | 14.22 | 13.86 | **1.03x** | 55.44 | 57.98 | 0.96x |
| 23 | `examples/attention_sink/regression_attention_sink.py` | 14/14 | 13.94 | 13.05 | **1.07x** | 45.43 | 45.32 | 1.00x |
| 24 | `examples/gemm/example_gemm_autotune_early_stop.py` | 30/30 | 12.86 | 11.78 | **1.09x** | 79.08 | 78.56 | 1.01x |
| 25 | `examples/deepseek_v32/regression_tilelang_example_deepseek_v32.py` | 6/6 | 11.98 | 9.67 | **1.24x** | 24.67 | 22.20 | 1.11x |
| 26 | `examples/deepseek_mhc/test_example_mhc.py` | 12/12 | 11.00 | 7.90 | **1.39x** | 33.53 | 31.51 | 1.06x |
| 27 | `examples/flash_attention/regression_example_flash_attention.py` | 12/12 | 10.77 | 8.76 | **1.23x** | 38.48 | 36.86 | 1.04x |
| 28 | `examples/attention_sink/example_gqa_sink_bwd_varlen.py` | 5/5 | 10.36 | 10.05 | **1.03x** | 20.45 | 20.12 | 1.02x |
| 29 | `examples/deepseek_v32/sparse_mla_bwd.py` | 4/4 | 10.34 | 7.59 | **1.36x** | 19.60 | 16.91 | 1.16x |
| 30 | `examples/dsa_sparse_finetune/sparse_mla_bwd.py` | 4/4 | 9.93 | 7.52 | **1.32x** | 21.06 | 18.47 | 1.14x |
| 31 | `examples/flash_decoding/regression_example_flash_decoding.py` | 2/2 | 9.37 | 7.12 | **1.32x** | 15.70 | 14.79 | 1.06x |
| 32 | `examples/flash_decoding/example_gqa_decode.py` | 1/1 | 7.21 | 5.58 | **1.29x** | 12.79 | 10.54 | 1.21x |
| 33 | `examples/dsa_hisa/hisa.py` | 12/12 | 7.18 | 6.46 | **1.11x** | 30.66 | 29.78 | 1.03x |
| 34 | `examples/fusedmoe/regression_example_fusedmoe.py` | 2/2 | 6.89 | 5.48 | **1.26x** | 13.31 | 11.69 | 1.14x |
| 35 | `examples/fusedmoe/test_example_fusedmoe.py` | 2/2 | 6.87 | 5.58 | **1.23x** | 12.99 | 11.73 | 1.11x |
| 36 | `examples/flash_attention/example_gqa_bwd_tma_reduce_varlen.py` | 3/3 | 6.68 | 6.23 | **1.07x** | 14.38 | 13.30 | 1.08x |
| 37 | `examples/fusedmoe/example_fusedmoe_tilelang.py` | 2/2 | 6.66 | 5.39 | **1.23x** | 12.94 | 11.53 | 1.12x |
| 38 | `examples/deepseek_v32/sparse_mla_fwd.py` | 1/1 | 6.55 | 5.21 | **1.26x** | 9.60 | 8.21 | 1.17x |
| 39 | `examples/deepseek_deepgemm/example_deepgemm_fp8_2xAcc.py` | 16/16 | 5.85 | 5.23 | **1.12x** | 41.94 | 42.66 | 0.98x |
| 40 | `examples/deepseek_mhc/example_mhc_pre.py` | 6/6 | 5.72 | 4.56 | **1.25x** | 18.23 | 17.29 | 1.05x |
| 41 | `examples/dsa_sparse_finetune/sparse_mla_fwd.py` | 1/1 | 5.61 | 4.34 | **1.29x** | 8.87 | 7.60 | 1.17x |
| 42 | `examples/dequantize_gemm/example_dequant_gemm_bf16_mxfp4_hopper.py` | 4/4 | 5.60 | 4.46 | **1.26x** | 14.93 | 13.63 | 1.10x |
| 43 | `examples/deepseek_v32/inference/model.py` | 2/2 | 5.11 | 4.17 | **1.23x** | 9.83 | 8.78 | 1.12x |
| 44 | `examples/dsa_sparse_finetune/indexer_topk_reducesum.py` | 1/1 | 5.04 | 5.00 | **1.01x** | 7.42 | 7.49 | 0.99x |
| 45 | `examples/gemm_tcgen05/gemm_tcgen5mma.py` | 2/2 | 4.97 | 3.43 | **1.45x** | 8.46 | 6.89 | 1.23x |
| 46 | `examples/deepseek_v4/sparse_attn_fwd_sm90.py` | 1/1 | 4.77 | 3.64 | **1.31x** | 7.68 | 6.49 | 1.18x |
| 47 | `examples/dequantize_gemm/regression_example_dequantize_gemm.py` | 5/5 | 4.55 | 3.01 | **1.51x** | 15.76 | 14.22 | 1.11x |
| 48 | `examples/dsa_hisa/pool_mqa_fp8.py` | 6/6 | 4.12 | 3.83 | **1.08x** | 15.96 | 16.28 | 0.98x |
| 49 | `examples/blocksparse_attention/test_example_blocksparse_attention.py` | 3/3 | 4.02 | 3.49 | **1.15x** | 10.78 | 10.59 | 1.02x |
| 50 | `examples/blocksparse_attention/regression_example_blocksparse_attention.py` | 3/3 | 3.98 | 3.46 | **1.15x** | 10.91 | 10.74 | 1.02x |
| 51 | `examples/flash_decoding/test_example_flash_decoding.py` | 2/2 | 3.98 | 3.14 | **1.27x** | 9.83 | 8.81 | 1.12x |
| 52 | `examples/aws/test_example_aws.py` | 6/6 | 3.86 | 3.60 | **1.07x** | 15.00 | 14.92 | 1.01x |
| 53 | `examples/attention_sink/example_gqa_sink_bwd_bhsd.py` | 5/5 | 3.51 | 3.11 | **1.13x** | 13.45 | 12.89 | 1.04x |
| 54 | `examples/deepseek_nsa/test_example_tilelang_nsa.py` | 3/3 | 3.38 | 2.93 | **1.15x** | 10.14 | 9.31 | 1.09x |
| 55 | `examples/deepseek_v4/test_tilelang_example_deepseek_v4.py` | 6/6 | 3.35 | 2.89 | **1.16x** | 14.45 | 13.82 | 1.05x |
| 56 | `examples/dequantize_gemm/example_dequant_gemm_bf16_fp4_hopper.py` | 2/2 | 3.34 | 2.27 | **1.48x** | 8.37 | 7.15 | 1.17x |
| 57 | `examples/flash_attention/example_gqa_bwd_tma_reduce.py` | 3/3 | 3.08 | 2.86 | **1.08x** | 9.41 | 9.10 | 1.03x |
| 58 | `examples/flash_attention/example_gqa_bwd.py` | 4/4 | 2.94 | 2.51 | **1.17x** | 11.97 | 11.14 | 1.07x |
| 59 | `examples/attention_sink/example_mha_sink_bwd_bhsd.py` | 5/5 | 2.90 | 2.55 | **1.14x** | 12.63 | 12.18 | 1.04x |
| 60 | `examples/deepseek_mhc/regression_example_mhc.py` | 3/3 | 2.85 | 2.22 | **1.28x** | 8.67 | 8.50 | 1.02x |
| 61 | `examples/deepseek_v4/act_quant.py` | 5/5 | 2.85 | 2.41 | **1.18x** | 12.43 | 11.50 | 1.08x |
| 62 | `examples/deepseek_nsa/example_tilelang_nsa_fwd.py` | 2/2 | 2.80 | 2.45 | **1.15x** | 6.97 | 6.99 | 1.00x |
| 63 | `examples/dsa_sparse_finetune/sparse_mla_topk_reducesum.py` | 1/1 | 2.75 | 2.40 | **1.14x** | 5.02 | 4.54 | 1.10x |
| 64 | `examples/visual_layout_inference/visual_layout_inference.py` | 1/1 | 2.72 | 2.62 | **1.04x** | 4.89 | 4.73 | 1.03x |
| 65 | `examples/blocksparse_attention/example_tilelang_sparse_gqa_decode_paged.py` | 1/1 | 2.70 | 2.50 | **1.08x** | 2.72 | 2.51 | 1.08x |
| 66 | `examples/deepseek_mla/example_mla_decode_persistent.py` | 1/1 | 2.45 | 1.98 | **1.24x** | 5.84 | 5.26 | 1.11x |
| 67 | `examples/linear_attention/example_mamba_chunk_scan.py` | 1/1 | 2.32 | 2.08 | **1.11x** | 4.87 | 4.62 | 1.05x |
| 68 | `examples/flash_decoding/example_mha_inference.py` | 1/1 | 2.25 | 1.57 | **1.43x** | 5.73 | 4.41 | 1.30x |
| 69 | `examples/grouped_gemm/example_grouped_gemm_bwd.py` | 2/2 | 2.11 | 1.64 | **1.29x** | 6.40 | 5.97 | 1.07x |
| 70 | `examples/kda/chunk_inter_solve_fused.py` | 1/1 | 2.09 | 1.99 | **1.05x** | 2.11 | 2.00 | 1.05x |
| 71 | `examples/flash_attention_sm100/mha_fwd_bshd.py` | 1/1 | 2.08 | 1.58 | **1.32x** | 5.19 | 4.64 | 1.12x |
| 72 | `examples/gemm_fp8/test_example_gemm_fp8.py` | 4/4 | 2.08 | 1.69 | **1.23x** | 11.64 | 11.35 | 1.03x |
| 73 | `examples/grouped_gemm/test_example_grouped_gemm.py` | 4/4 | 2.05 | 1.88 | **1.09x** | 10.40 | 10.02 | 1.04x |
| 74 | `examples/seer_attention/regression_block_sparse_attn_tilelang.py` | 2/2 | 2.04 | 1.61 | **1.27x** | 6.57 | 6.09 | 1.08x |
| 75 | `examples/deepseek_nsa/regression_example_tilelang_nsa.py` | 2/2 | 1.98 | 1.71 | **1.16x** | 6.30 | 5.89 | 1.07x |
| 76 | `examples/flash_attention/example_mha_bwd_bshd.py` | 4/4 | 1.95 | 1.65 | **1.19x** | 10.29 | 9.70 | 1.06x |
| 77 | `examples/seer_attention/test_block_sparse_attn_tilelang.py` | 2/2 | 1.94 | 1.61 | **1.20x** | 6.45 | 6.01 | 1.07x |
| 78 | `examples/deepseek_v32/topk_selector.py` | 1/1 | 1.92 | 1.84 | **1.05x** | 5.13 | 4.97 | 1.03x |
| 79 | `examples/flash_attention/example_mha_bwd_bhsd.py` | 4/4 | 1.90 | 1.58 | **1.20x** | 10.07 | 9.51 | 1.06x |
| 80 | `examples/seer_attention/block_sparse_attn_tilelang.py` | 2/2 | 1.86 | 1.52 | **1.22x** | 6.55 | 6.01 | 1.09x |
| 81 | `examples/flash_decoding/example_gqa_decode_varlen_logits.py` | 1/1 | 1.84 | 1.55 | **1.18x** | 6.11 | 4.71 | 1.30x |
| 82 | `examples/gemm_fp8/regression_example_gemm_fp8.py` | 4/4 | 1.83 | 1.74 | **1.05x** | 11.37 | 11.23 | 1.01x |
| 83 | `examples/deepseek_mhc/example_mhc_post.py` | 2/2 | 1.75 | 1.34 | **1.31x** | 5.27 | 4.92 | 1.07x |
| 84 | `examples/deepseek_mla/experimental/example_mla_decode_kv_fp8.py` | 1/1 | 1.74 | 1.43 | **1.22x** | 4.44 | 4.09 | 1.09x |
| 85 | `examples/gemm_tcgen05/gemm_tcgen5mma_ws_persistent_streamk.py` | 2/2 | 1.73 | 1.50 | **1.16x** | 7.71 | 7.36 | 1.05x |
| 86 | `examples/gemm/example_gemm_autotune_pass_configs.py` | 8/8 | 1.70 | 1.42 | **1.20x** | 10.24 | 9.61 | 1.07x |
| 87 | `examples/deepseek_v32/fp8_lighting_indexer.py` | 2/2 | 1.66 | 1.52 | **1.09x** | 6.64 | 6.31 | 1.05x |
| 88 | `examples/blocksparse_attention/example_tilelang_sparse_gqa_decode_varlen_mask.py` | 1/1 | 1.61 | 1.40 | **1.15x** | 4.17 | 3.78 | 1.10x |
| 89 | `examples/attention_sink/example_gqa_sink_fwd_varlen.py` | 1/1 | 1.60 | 1.39 | **1.16x** | 4.03 | 3.83 | 1.05x |
| 90 | `examples/deepseek_mla/amd/benchmark_mla_decode_amd_tilelang.py` | 1/1 | 1.59 | 1.21 | **1.31x** | 4.24 | 4.01 | 1.06x |
| 91 | `examples/flash_attention/example_gqa_fwd_varlen.py` | 1/1 | 1.50 | 1.23 | **1.22x** | 4.09 | 3.71 | 1.10x |
| 92 | `examples/convolution/regression_example_convolution.py` | 2/2 | 1.49 | 1.35 | **1.10x** | 5.77 | 5.76 | 1.00x |
| 93 | `examples/blocksparse_attention/example_tilelang_sparse_gqa_decode_varlen_indice.py` | 1/1 | 1.43 | 1.20 | **1.19x** | 3.95 | 3.47 | 1.14x |
| 94 | `examples/gemm_fp8/example_tilelang_gemm_fp8_2xAcc.py` | 2/2 | 1.42 | 1.31 | **1.08x** | 6.18 | 6.18 | 1.00x |
| 95 | `examples/gemv/regression_example_gemv.py` | 6/6 | 1.41 | 0.95 | **1.48x** | 12.81 | 12.03 | 1.07x |
| 96 | `examples/gemv/test_example_gemv.py` | 6/6 | 1.38 | 0.93 | **1.49x** | 12.71 | 11.98 | 1.06x |
| 97 | `examples/dsa_sparse_finetune/indexer_bwd.py` | 1/1 | 1.38 | 1.21 | **1.13x** | 4.06 | 3.89 | 1.04x |
| 98 | `examples/warp_specialize/example_warp_specialize_flashmla.py` | 1/1 | 1.35 | 1.27 | **1.06x** | 1.37 | 1.28 | 1.07x |
| 99 | `examples/deepseek_v32/sparse_mla_fwd_seesaw.py` | 1/1 | 1.34 | 1.31 | **1.03x** | 1.36 | 1.33 | 1.02x |
| 100 | `examples/gemm_int4/example_tilelang_gemm_int4.py` | 1/1 | 1.33 | 1.23 | **1.08x** | 1.34 | 1.24 | 1.08x |
| 101 | `examples/deepseek_mla/example_mla_decode_ws.py` | 1/1 | 1.33 | 1.24 | **1.07x** | 1.35 | 1.27 | 1.07x |
| 102 | `examples/deepseek_mla/example_mla_decode_paged.py` | 1/1 | 1.32 | 1.15 | **1.14x** | 3.81 | 3.72 | 1.03x |
| 103 | `examples/gemm_streamk/example_tilelang_gemm_streamk.py` | 1/1 | 1.31 | 1.18 | **1.11x** | 1.32 | 1.19 | 1.11x |
| 104 | `examples/warp_specialize/example_warp_specialize_gemm_copy_gemm_0_1.py` | 1/1 | 1.31 | 0.67 | **1.97x** | 3.44 | 2.54 | 1.36x |
| 105 | `examples/deepseek_v32/sparse_mla_fwd_pipelined.py` | 1/1 | 1.30 | 1.20 | **1.08x** | 1.31 | 1.23 | 1.07x |
| 106 | `examples/deepseek_mla/regression_example_mla_decode.py` | 1/1 | 1.25 | 1.03 | **1.22x** | 3.75 | 3.46 | 1.09x |
| 107 | `examples/gemm_tcgen05/gemm_tcgen5mma_ws_clc.py` | 4/4 | 1.22 | 1.08 | **1.13x** | 15.48 | 15.17 | 1.02x |
| 108 | `examples/hadamard_transform/test_example_hadamard.py` | 4/4 | 1.21 | 1.07 | **1.13x** | 8.27 | 7.80 | 1.06x |
| 109 | `examples/blockscaled_gemm_sm100/gemm_mxfp8_blockscaled_1d1d.py` | 2/2 | 1.19 | 1.03 | **1.15x** | 4.97 | 4.63 | 1.07x |
| 110 | `examples/flash_attention/example_mha_fwd_varlen.py` | 1/1 | 1.14 | 0.96 | **1.19x** | 3.63 | 3.46 | 1.05x |
| 111 | `examples/blockscaled_gemm_sm100/grouped_gemm_mxfp8_blockscaled_1d1d.py` | 1/1 | 1.13 | 1.09 | **1.04x** | 7.57 | 7.26 | 1.04x |
| 112 | `examples/warp_specialize/regression_example_warp_specialize.py` | 4/4 | 1.13 | 1.02 | **1.11x** | 9.75 | 9.38 | 1.04x |
| 113 | `examples/deepseek_mla/test_example_mla_decode.py` | 1/1 | 1.13 | 0.99 | **1.14x** | 3.58 | 3.38 | 1.06x |
| 114 | `examples/linear_attention/example_retention_fwd.py` | 1/1 | 1.12 | 0.89 | **1.25x** | 3.33 | 3.19 | 1.04x |
| 115 | `examples/grouped_gemm/example_grouped_gemm_fwd_ptr.py` | 1/1 | 1.12 | 0.91 | **1.22x** | 3.20 | 2.98 | 1.07x |
| 116 | `examples/attention_sink/benchmark_mha_sink_fwd.py` | 1/1 | 1.11 | 0.94 | **1.19x** | 3.57 | 3.34 | 1.07x |
| 117 | `examples/attention_sink/example_mha_sink_fwd_bhsd.py` | 1/1 | 1.11 | 1.04 | **1.06x** | 3.55 | 3.57 | 1.00x |
| 118 | `examples/deepseek_mla/example_mla_decode.py` | 1/1 | 1.09 | 0.99 | **1.10x** | 3.65 | 3.36 | 1.09x |
| 119 | `examples/dsa_hisa/fp8_block_mean_pooling.py` | 3/3 | 1.08 | 0.84 | **1.29x** | 5.82 | 5.43 | 1.07x |
| 120 | `examples/norm/layernorm.py` | 2/2 | 1.06 | 0.68 | **1.57x** | 5.33 | 4.91 | 1.08x |
| 121 | `examples/gemm/regression_example_gemm.py` | 2/2 | 1.02 | 0.84 | **1.20x** | 5.43 | 5.11 | 1.06x |
| 122 | `examples/gemm_sp/test_example_gemm_sp.py` | 2/2 | 1.00 | 0.92 | **1.08x** | 4.87 | 5.05 | 0.97x |
| 123 | `examples/gemm/test_example_gemm.py` | 2/2 | 0.97 | 0.74 | **1.31x** | 5.17 | 4.98 | 1.04x |
| 124 | `examples/gemm/example_gemm_persistent.py` | 2/2 | 0.96 | 0.91 | **1.05x** | 5.52 | 5.24 | 1.05x |
| 125 | `examples/gemm_splitk/test_example_gemm_splitk.py` | 2/2 | 0.93 | 0.72 | **1.28x** | 6.00 | 5.95 | 1.01x |
| 126 | `examples/gdn/test_example_gdn_compilation.py` | 1/1 | 0.92 | 0.75 | **1.23x** | 3.08 | 2.88 | 1.07x |
| 127 | `examples/gemm_splitk/regression_example_gemm_splitk.py` | 2/2 | 0.91 | 0.78 | **1.18x** | 6.06 | 6.20 | 0.98x |
| 128 | `examples/gemm_sp/example_gemm_sp.py` | 2/2 | 0.88 | 0.86 | **1.02x** | 4.93 | 4.81 | 1.02x |
| 129 | `examples/cast/test_example_cast.py` | 2/2 | 0.87 | 0.80 | **1.09x** | 3.89 | 4.08 | 0.95x |
| 130 | `examples/blocksparse_attention/example_tilelang_block_sparse_attn.py` | 1/1 | 0.86 | 0.75 | **1.15x** | 3.22 | 3.02 | 1.07x |
| 131 | `examples/cast/regression_example_cast.py` | 2/2 | 0.85 | 0.74 | **1.15x** | 3.86 | 4.10 | 0.94x |
| 132 | `examples/flash_attention_sm100/gqa_fwd_bshd.py` | 1/1 | 0.85 | 0.66 | **1.28x** | 2.83 | 2.63 | 1.07x |
| 133 | `examples/linear_attention/example_mamba_chunk_state.py` | 1/1 | 0.81 | 0.53 | **1.52x** | 3.02 | 2.74 | 1.10x |
| 134 | `examples/gemm_tcgen05/gemm_tcgen5mma_ws_persistent.py` | 2/2 | 0.81 | 0.74 | **1.10x** | 4.34 | 4.37 | 0.99x |
| 135 | `examples/flash_attention/example_mha_fwd_bshd.py` | 1/1 | 0.80 | 0.65 | **1.23x** | 3.52 | 3.35 | 1.05x |
| 136 | `examples/gemm/example_gemm_intrinsics.py` | 1/1 | 0.75 | 0.54 | **1.39x** | 2.84 | 2.64 | 1.08x |
| 137 | `examples/flash_attention/example_gqa_fwd_bshd.py` | 1/1 | 0.75 | 0.59 | **1.26x** | 3.08 | 2.83 | 1.09x |
| 138 | `examples/dsa_hisa/block_sparse_mqa_fp8.py` | 1/1 | 0.74 | 0.65 | **1.14x** | 2.96 | 2.98 | 0.99x |
| 139 | `examples/convolution/example_convolution.py` | 1/1 | 0.72 | 0.67 | **1.08x** | 2.83 | 2.89 | 0.98x |
| 140 | `examples/dequantize_gemm/example_dequant_gemm_fp4_hopper.py` | 1/1 | 0.70 | 0.57 | **1.24x** | 3.31 | 3.17 | 1.04x |
| 141 | `examples/gemm_tcgen05/gemm_mma.py` | 2/2 | 0.68 | 0.53 | **1.29x** | 4.44 | 4.67 | 0.95x |
| 142 | `examples/flash_attention/example_mha_fwd_bhsd.py` | 1/1 | 0.68 | 0.56 | **1.22x** | 2.93 | 2.69 | 1.09x |
| 143 | `examples/aws/flash_attention.py` | 1/1 | 0.67 | 0.63 | **1.06x** | 2.60 | 2.56 | 1.02x |
| 144 | `examples/deepseek_nsa/example_tilelang_nsa_decode.py` | 1/1 | 0.65 | 0.52 | **1.25x** | 2.61 | 2.88 | 0.91x |
| 145 | `examples/convolution/example_convolution_autotune.py` | 1/1 | 0.64 | 0.55 | **1.16x** | 2.72 | 2.71 | 1.00x |
| 146 | `examples/deepseek_v4/fp8_fp4_gemm_1d1d_sm100.py` | 1/1 | 0.59 | 0.55 | **1.07x** | 2.44 | 2.37 | 1.03x |
| 147 | `examples/cast/example_group_per_split_token_cast_to_fp8.py` | 1/1 | 0.57 | 0.51 | **1.12x** | 2.27 | 2.19 | 1.04x |
| 148 | `examples/dynamic_shape/example_dynamic.py` | 1/1 | 0.56 | 0.54 | **1.02x** | 3.01 | 2.89 | 1.04x |
| 149 | `examples/dynamic_shape/regression_example_dynamic.py` | 1/1 | 0.55 | 0.51 | **1.08x** | 3.12 | 3.02 | 1.03x |
| 150 | `examples/warp_specialize/example_warp_specialize_gemm_copy_1_gemm_0.py` | 1/1 | 0.54 | 0.33 | **1.66x** | 2.75 | 2.47 | 1.12x |
| 151 | `examples/dequantize_gemm/example_dequant_gemm_fine_grained.py` | 2/2 | 0.52 | 0.48 | **1.08x** | 5.04 | 4.65 | 1.08x |
| 152 | `examples/gemm_tcgen05/gemm_tcgen5mma_ws.py` | 2/2 | 0.48 | 0.41 | **1.17x** | 4.24 | 4.20 | 1.01x |
| 153 | `examples/hadamard_transform/example_hadamard.py` | 1/1 | 0.47 | 0.43 | **1.09x** | 2.36 | 2.34 | 1.01x |
| 154 | `examples/gemm_splitk/example_tilelang_gemm_splitk_vectorize_atomicadd.py` | 1/1 | 0.44 | 0.36 | **1.23x** | 2.92 | 2.92 | 1.00x |
| 155 | `examples/gemm_splitk/example_tilelang_gemm_splitk.py` | 1/1 | 0.44 | 0.35 | **1.24x** | 2.92 | 2.96 | 0.99x |
| 156 | `examples/blocksparse_gemm/test_example_blocksparse_gemm.py` | 1/1 | 0.44 | 0.40 | **1.08x** | 2.60 | 2.63 | 0.99x |
| 157 | `examples/dequantize_gemm/example_dequant_gemm_w4a8.py` | 1/1 | 0.41 | 0.35 | **1.16x** | 2.51 | 2.42 | 1.04x |
| 158 | `examples/gemm/example_gemm_advanced_autotune.py` | 1/1 | 0.41 | 0.35 | **1.17x** | 2.74 | 2.59 | 1.06x |
| 159 | `examples/gemm/example_gemm_autotune.py` | 1/1 | 0.41 | 0.30 | **1.36x** | 2.77 | 2.63 | 1.05x |
| 160 | `examples/gemm_fp8/example_tilelang_gemm_fp8.py` | 2/2 | 0.39 | 0.35 | **1.12x** | 5.27 | 5.14 | 1.02x |
| 161 | `examples/dsa_hisa/clean_and_maintain_logits.py` | 3/3 | 0.38 | 0.35 | **1.09x** | 5.10 | 4.86 | 1.05x |
| 162 | `examples/blocksparse_gemm/example_blocksparse_gemm.py` | 1/1 | 0.38 | 0.33 | **1.14x** | 2.44 | 2.50 | 0.98x |
| 163 | `examples/warp_specialize/example_warp_specialize_gemm_softpipe_stage2.py` | 1/1 | 0.36 | 0.32 | **1.12x** | 2.63 | 2.42 | 1.09x |
| 164 | `examples/grouped_gemm/example_grouped_gemm_fwd.py` | 1/1 | 0.36 | 0.32 | **1.14x** | 2.67 | 2.67 | 1.00x |
| 165 | `examples/aws/gemm.py` | 1/1 | 0.36 | 0.30 | **1.20x** | 2.10 | 2.03 | 1.03x |
| 166 | `examples/topk/example_topk.py` | 1/1 | 0.31 | 0.23 | **1.33x** | 2.05 | 1.83 | 1.12x |
| 167 | `examples/blocksparse_gemm/regression_example_blocksparse_gemm.py` | 1/1 | 0.30 | 0.26 | **1.13x** | 2.41 | 2.44 | 0.98x |
| 168 | `examples/cast/example_per_token_cast_to_fp8.py` | 1/1 | 0.29 | 0.25 | **1.17x** | 1.86 | 1.84 | 1.01x |
| 169 | `examples/topk/test_topk_tilelang.py` | 1/1 | 0.29 | 0.25 | **1.15x** | 1.86 | 1.85 | 1.00x |
| 170 | `examples/quickstart.py` | 1/1 | 0.24 | 0.20 | **1.20x** | 2.35 | 2.38 | 0.99x |
| 171 | `examples/gemm/example_gemm.py` | 1/1 | 0.23 | 0.20 | **1.18x** | 2.38 | 2.40 | 0.99x |
| 172 | `examples/online_softmax/online_softmax.py` | 1/1 | 0.23 | 0.17 | **1.34x** | 1.91 | 1.84 | 1.04x |
| 173 | `examples/elementwise/example_elementwise_add.py` | 1/1 | 0.23 | 0.18 | **1.27x** | 2.02 | 1.74 | 1.16x |
| 174 | `examples/elementwise/regression_example_elementwise.py` | 1/1 | 0.22 | 0.18 | **1.22x** | 1.82 | 1.78 | 1.02x |
| 175 | `examples/elementwise/test_example_elementwise.py` | 1/1 | 0.22 | 0.18 | **1.23x** | 1.87 | 1.76 | 1.06x |
| 176 | `examples/warp_specialize/example_warp_specialize_gemm_copy_0_gemm_1.py` | 1/1 | 0.21 | 0.18 | **1.16x** | 2.33 | 2.35 | 0.99x |
| 177 | `examples/warp_specialize/example_warp_specialize_gemm_barrierpipe_stage2.py` | 1/1 | 0.21 | 0.18 | **1.14x** | 2.34 | 2.38 | 0.98x |
| 178 | `examples/norm/rms_norm.py` | 1/1 | 0.20 | 0.15 | **1.34x** | 1.94 | 1.84 | 1.06x |
| 179 | `examples/norm/test_rms_norm.py` | 1/1 | 0.17 | 0.14 | **1.19x** | 1.84 | 1.68 | 1.09x |
| 180 | `examples/rand/rand_uint.py` | 3/3 | 0.11 | 0.08 | **1.26x** | 5.87 | 5.90 | 1.00x |
| 181 | `examples/bitnet-1.58b/kernel_benchmark/tilelang_bitnet_158_int8xint2_decode.py` | 1/1 | 0.08 | 0.07 | **1.16x** | 1.67 | 1.68 | 0.99x |
| 182 | `examples/dequantize_gemm/test_example_dequantize_gemm.py` | 1/1 | 0.07 | 0.06 | **1.27x** | 1.54 | 1.75 | 0.88x |
| 183 | `examples/dequantize_gemm/example_dequant_gemv_fp16xint4.py` | 1/1 | 0.07 | 0.06 | **1.21x** | 1.61 | 1.53 | 1.05x |
| 184 | `examples/iket/all_features.py` | 1/1 | 0.04 | 0.02 | **1.50x** | 5.15 | 5.13 | 1.00x |
| 185 | `examples/iket/minimal.py` | 1/1 | 0.03 | 0.02 | **1.35x** | 5.11 | 4.96 | 1.03x |
| 186 | `examples/iket/payload_minimal.py` | 1/1 | 0.03 | 0.02 | **1.40x** | 5.13 | 4.83 | 1.06x |

Rest skipped because of some setup-specific (e.g. arch or example failed) issues.

## Validation

- git diff --check
- patch applies directly to origin/main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add `-O2` for GNU-compatible single-config builds without an explicit `CMAKE_BUILD_TYPE`.
- Preserve existing flags for explicit build types and multi-config generators.
- Validate with `git diff --check` and confirm patch application to `origin/main`.

## C++ style / lint notes

- The PR does not change rules in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step remains unchanged.
- No C++ style warnings are introduced by this CMake-only change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->