### PR TITLE
[BugFix][Metal] Emit BF16 vector types and constants correctly

### DIFF
--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -401,8 +401,15 @@ void CodeGenTileLangMetal::PrintType(DataType t,
       return;
     }
   } else if (t.is_bfloat16()) {
+    if (lanes == 3)
+      os << "packed_";
     os << "bfloat";
-    return;
+    if (lanes == 1)
+      return;
+    if (lanes >= 2 && lanes <= 4) {
+      os << lanes;
+      return;
+    }
   }
   LOG(FATAL) << "Cannot convert type " << t << " to Metal type";
 }
@@ -1696,6 +1703,8 @@ void CodeGenTileLangMetal::VisitExpr_(const CallNode *op,
 void CodeGenTileLangMetal::VisitExpr_(const FloatImmNode *op,
                                       std::ostream &os) { // NOLINT(*)
   std::ostringstream temp;
+  if (op->dtype.is_bfloat16())
+    temp << "bfloat(";
   if (std::isinf(op->value)) {
     if (op->value < 0) {
       temp << "-";
@@ -1705,11 +1714,13 @@ void CodeGenTileLangMetal::VisitExpr_(const FloatImmNode *op,
     temp << "NAN";
   } else {
     temp << std::scientific << op->value;
-    if (op->dtype.bits() == 32)
+    if (op->dtype.bits() == 32 || op->dtype.is_bfloat16())
       temp << 'f';
     else if (op->dtype.bits() == 16)
       temp << 'h';
   }
+  if (op->dtype.is_bfloat16())
+    temp << ")";
   MarkConst(temp.str());
   os << temp.str();
 }

--- a/testing/python/metal/test_metal_bf16_elementwise.py
+++ b/testing/python/metal/test_metal_bf16_elementwise.py
@@ -1,0 +1,105 @@
+"""BF16 scalar constants and short vectors must retain their Metal types."""
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+
+
+@tilelang.jit(target="metal", execution_backend="torch")
+def bf16_elementwise(size, add=False):
+    @T.prim_func
+    def main(A: T.Tensor((size,), "bfloat16"), B: T.Tensor((size,), "bfloat16")):
+        with T.Kernel(1, threads=128):
+            for i in T.Parallel(size):
+                B[i] = A[i] + T.bfloat16(1) if add else A[i]
+
+    return main
+
+
+@tilelang.jit(target="metal", execution_backend="torch")
+def bf16_sliced_copy(lanes):
+    # The vectorizer only widens power-of-two extents; explicit slices reach
+    # the three-lane (packed) vector type as well.
+    @T.prim_func
+    def main(A: T.Tensor((128 * lanes,), "bfloat16"), B: T.Tensor((128 * lanes,), "bfloat16")):
+        with T.Kernel(1, threads=128):
+            tid = T.get_thread_binding(0)
+            B[tid * lanes : tid * lanes + lanes] = A[tid * lanes : tid * lanes + lanes]
+
+    return main
+
+
+@tilelang.jit(target="metal", execution_backend="torch")
+def bf16_fill(value):
+    @T.prim_func
+    def main(B: T.Tensor((128,), "bfloat16")):
+        with T.Kernel(1, threads=128):
+            for i in T.Parallel(128):
+                B[i] = T.bfloat16(value)
+
+    return main
+
+
+def _source(program):
+    with tvm.target.Target("metal"):
+        return tilelang.lower(program, target="metal").kernel_source
+
+
+@pytest.mark.parametrize("size, metal_type", [(256, "bfloat2"), (512, "bfloat4"), (1024, "uint4")])
+def test_bf16_copy_vector_type(size, metal_type):
+    source = _source(bf16_elementwise.get_tir(size))
+    assert f"device {metal_type}*" in source
+
+
+@pytest.mark.parametrize("lanes, metal_type", [(2, "bfloat2"), (3, "packed_bfloat3"), (4, "bfloat4")])
+def test_bf16_sliced_copy_vector_type(lanes, metal_type):
+    source = _source(bf16_sliced_copy.get_tir(lanes))
+    assert f"device {metal_type}*" in source
+
+
+def test_bf16_constant_codegen():
+    source = _source(bf16_elementwise.get_tir(512, add=True))
+    assert "bfloat(1.000000e+00f)" in source
+    assert "1.000000e+00h" not in source
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize("size", [128, 256, 512, 1024])
+def test_bf16_copy_execution(size):
+    a = torch.arange(size, dtype=torch.float32).to(torch.bfloat16)
+    b = torch.full((size,), -1, dtype=torch.bfloat16, device="mps")
+    bf16_elementwise(size)(a.to("mps"), b)
+    torch.testing.assert_close(b.cpu(), a, rtol=0, atol=0)
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize("lanes", [2, 3, 4])
+def test_bf16_sliced_copy_execution(lanes):
+    size = 128 * lanes
+    a = torch.arange(size, dtype=torch.float32).to(torch.bfloat16)
+    b = torch.full((size,), -1, dtype=torch.bfloat16, device="mps")
+    bf16_sliced_copy(lanes)(a.to("mps"), b)
+    torch.testing.assert_close(b.cpu(), a, rtol=0, atol=0)
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize("size", [128, 256, 512])
+def test_bf16_add_execution(size):
+    a = torch.linspace(-2, 2, size).to(torch.bfloat16)
+    b = torch.empty_like(a, device="mps")
+    bf16_elementwise(size, add=True)(a.to("mps"), b)
+    torch.testing.assert_close(b.cpu(), a + 1, rtol=0, atol=0)
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize("value", [0.0, -0.0, 1.5, -1e30, float("inf"), -float("inf"), float("nan")])
+def test_bf16_constant_execution(value):
+    b = torch.empty(128, dtype=torch.bfloat16, device="mps")
+    bf16_fill(value)(b)
+    expected = torch.full((128,), value, dtype=torch.bfloat16)
+    actual = b.cpu()
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0, equal_nan=True)


### PR DESCRIPTION
## Problem

1. Metal codegen printed BF16 short vectors as the scalar type: a `bfloat16x4` value was declared `bfloat`, so vectorized BF16 copies and arithmetic failed MSL compilation or silently narrowed to one lane.
2. BF16 constants were emitted as IEEE-half literals (`half(...)`), so any BF16 constant, including the `-inf`/`inf` initializers used by reductions and masks, carried the wrong bit pattern or failed to type-check against BF16 operands.

Both are visible on any kernel that uses `T.Tensor(..., "bfloat16")` with a vectorized loop or a BF16 constant; the shader compiler rejects the source before execution.

## Change

`src/metal/codegen/codegen_metal.cc`:

1. Print BF16 vector types with their lane count (`bfloat2`, `bfloat4`), and the 3-lane form as `packed_bfloat3`, matching the existing FP16/FP32 vector printing.
2. Construct BF16 constants as `bfloat(...)`, including non-finite values, instead of half literals.

No lowering or pass changes; other targets are untouched.

## Tests

`testing/python/metal/test_metal_bf16_elementwise.py` checks the generated source for `bfloat2`, `packed_bfloat3`, `bfloat4` and the `bfloat(<value>f)` constant form (no device needed), and executes BF16 kernels on MPS against Torch: vectorized and explicitly sliced copies at widths 2/3/4, elementwise arithmetic, and finite and non-finite constants. The three-lane type is reached through a sliced access, since the vectorizer only widens power-of-two extents.

## Validation

Apple M4 Max, macOS 15.5 (24F74), Command Line Tools 16.4 / macOS SDK 15.5, Python 3.12.11, PyTorch 2.14.0, `TILELANG_DISABLE_CACHE=1`, native build of this branch on top of `main` (85fd8fc2).

- `python -m pytest testing/python/metal -q`: 62 passed, 3 skipped (the skips need Metal 4 hardware).
- `bash format.sh --files src/metal/codegen/codegen_metal.cc testing/python/metal/test_metal_bf16_elementwise.py`
- `pre-commit run --files ...`: clean. `git diff --check`: clean.

## Related

#2971 restricts BF16 numeric operations to `bfloat2` and keeps packed integer carriers for wider copies. This change is orthogonal: it fixes how BF16 vector types and constants are printed at all. If #2971 lands first, the vector-type part of this change reduces to the 3-lane packed form and the constant construction remains.
