### PR TITLE
[Metal] Unroll short constant loops by default

### DIFF
--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -666,7 +666,12 @@ void CodeGenTileLangMetal::VisitStmt_(const ForNode *op) {
     }
     return;
   }
-  if (ext_imm && ext_imm->value > 4) {
+  if (op->kind == tirx::ForKind::kUnrolled) {
+    // Loops the UnrollLoop pass marked for unrolling keep their loop form in
+    // TIR; the shader compiler unrolls them, as nvcc does for CUDA.
+    PrintIndent();
+    stream << "TILELANG_PRAGMA_UNROLL\n";
+  } else if (ext_imm && ext_imm->value > 4) {
     PrintIndent();
     stream << "#pragma clang loop unroll(disable)\n";
   }

--- a/testing/python/metal/test_metal_unroll_defaults.py
+++ b/testing/python/metal/test_metal_unroll_defaults.py
@@ -1,0 +1,76 @@
+"""Metal unrolls short constant loops by default.
+
+Apple's shader compiler does not unroll the loops TileLang emits on its own, so
+the Metal pipeline marks short constant loops as unrolled and the codegen emits
+``TILELANG_PRAGMA_UNROLL`` for them, unless the caller configures
+``tl.UnrollLoop``.
+"""
+
+import re
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+
+ROWS = 96
+WIDTH = 4
+ROLLED = {"tl.UnrollLoop": {"auto_max_step": 0, "auto_max_extent": 0, "explicit_unroll": False}}
+
+
+def row_sums():
+    @T.prim_func
+    def main(A: T.Tensor((ROWS, WIDTH), "float32"), B: T.Tensor((ROWS,), "float32")):
+        with T.Kernel(T.ceildiv(ROWS, 32), threads=32) as block:
+            i = block * 32 + T.get_thread_binding(0)
+            if i < ROWS:
+                B[i] = 0.0
+                # A carried dependence keeps the loop out of the vectorizer.
+                for j in T.serial(WIDTH):
+                    B[i] = B[i] + A[i, j] * (j + 1)
+
+    return main
+
+
+def kernel_body(pass_configs=None) -> str:
+    with tvm.target.Target("metal"), tvm.transform.PassContext(opt_level=3, config=pass_configs):
+        source = tilelang.lower(row_sums(), target="metal").kernel_source
+    return source[source.index("main_kernel(") :]
+
+
+def check(kernel) -> None:
+    a = torch.arange(ROWS * WIDTH, dtype=torch.float32, device="mps").reshape(ROWS, WIDTH)
+    b = torch.zeros(ROWS, device="mps")
+    kernel(a, b)
+    torch.mps.synchronize()
+    weights = torch.arange(1, WIDTH + 1, dtype=torch.float32)
+    torch.testing.assert_close(b.cpu(), (a.cpu() * weights).sum(1))
+
+
+UNROLLED_LOOP = re.compile(r"TILELANG_PRAGMA_UNROLL\s*\n\s*for \(")
+
+
+def test_short_constant_loops_are_unrolled_by_default():
+    body = kernel_body()
+    assert len(re.findall(r"\bfor \(", body)) == 1
+    assert UNROLLED_LOOP.search(body) is not None
+
+
+def test_caller_pass_configuration_takes_precedence():
+    body = kernel_body(ROLLED)
+    assert len(re.findall(r"\bfor \(", body)) == 1
+    assert UNROLLED_LOOP.search(body) is None
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize("pass_configs", [None, ROLLED], ids=["unrolled", "rolled"])
+def test_row_sums_execute(pass_configs):
+    kernel = tilelang.compile(row_sums(), target="metal", execution_backend="torch", pass_configs=pass_configs)
+    check(kernel)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/metal/pipeline.py
+++ b/tilelang/metal/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from tvm import IRModule, s_tir, tirx
+from tvm import transform as tvm_transform
 from tvm.target import Target
 
 import tilelang
@@ -13,6 +14,31 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     should_force_let_inline,
 )
 from tilelang.metal.transform import MetalFragmentToSimdgroup
+
+# Default loop unrolling for Metal. Apple's shader compiler does not unroll the
+# short constant loops TileLang emits around simdgroup matrix operations on its
+# own; a rolled loop keeps simdgroup fragments indexed by a runtime variable,
+# which forces them out of registers, and the affected kernels measured several
+# times slower. Mark short constant loops as unrolled so the Metal codegen emits
+# an unroll pragma for them, the same division of labor as CUDA's pipeline and
+# nvcc. An explicit ``tl.UnrollLoop`` pass configuration from the caller takes
+# precedence.
+METAL_UNROLL_LOOP = {"auto_max_step": 64, "auto_max_extent": 4, "explicit_unroll": False}
+
+
+def _unroll_loops(mod: IRModule, pass_ctx: tvm_transform.PassContext) -> IRModule:
+    if "tl.UnrollLoop" in pass_ctx.config:
+        return tilelang.transform.UnrollLoop()(mod)
+    config = dict(pass_ctx.config)
+    config["tl.UnrollLoop"] = METAL_UNROLL_LOOP
+    with tvm_transform.PassContext(
+        opt_level=pass_ctx.opt_level,
+        required_pass=list(pass_ctx.required_pass),
+        disabled_pass=list(pass_ctx.disabled_pass),
+        instruments=list(pass_ctx.instruments),
+        config=config,
+    ):
+        return tilelang.transform.UnrollLoop()(mod)
 
 
 def MetalPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
@@ -74,7 +100,7 @@ def MetalPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.VectorizeLoop(enable_vectorize=allow_vectorize(pass_ctx=pass_ctx))(mod)
     mod = tilelang.transform.StorageRewrite()(mod)
     mod = tilelang.transform.LoopUnswitching()(mod)
-    mod = tilelang.transform.UnrollLoop()(mod)
+    mod = _unroll_loops(mod, pass_ctx)
     mod = s_tir.transform.RenormalizeSplitPattern()(mod)
     mod = tirx.transform.Simplify()(mod)
     mod = tirx.transform.RemoveNoOp()(mod)


### PR DESCRIPTION
## Problem

The CUDA pipeline marks short constant loops for unrolling and nvcc unrolls them. On Metal, the pipeline ran `UnrollLoop` with the target-neutral defaults (no automatic unrolling) and the codegen emitted nothing for loops marked unrolled, and Apple's shader compiler does not unroll the loops TileLang emits around simdgroup matrix operations on its own. A rolled loop keeps simdgroup fragments indexed by a runtime variable, which forces them out of registers.

Measured on a 19-token Qwen3.5-4B FP32 prefill (simdgroup GEMM attention and projection kernels): 333 ms device time with the loops rolled, 56 ms with them unrolled, identical numerical results.

## Change

1. `tilelang/metal/pipeline.py`: run `UnrollLoop` with a Metal default (`auto_max_extent=4`, `auto_max_step=64`, pragma mode) unless the caller configured `tl.UnrollLoop` explicitly, in which case the caller's configuration is used unchanged.
2. `src/metal/codegen/codegen_metal.cc`: emit `TILELANG_PRAGMA_UNROLL` (the existing `clang loop unroll(full)` macro) for loops marked `kUnrolled`, the same division of labor as CUDA's pipeline and nvcc.

Loops stay loops in TIR. Explicit TIR-level unrolling was tried first and rejected: it trips `PointerValueTypeRewrite` on coalesced copies (`info.factor() % me->coeff == 0` check) in the existing GEMM codegen tests.

## Tests

`testing/python/metal/test_metal_unroll_defaults.py`: a kernel with a carried-dependence loop of extent 4 gets the pragma by default and executes correctly on MPS; an explicit `tl.UnrollLoop` configuration disabling unrolling is honored and the loop is emitted without the pragma.

## Validation

Apple M4 Max, macOS 15.5 (24F74), Command Line Tools 16.4 / macOS SDK 15.5, Python 3.12.11, PyTorch 2.14.0, `TILELANG_DISABLE_CACHE=1`, native build of this branch on top of `main` (85fd8fc2).

- `python -m pytest testing/python/metal -q`: 40 passed, 3 skipped (Metal 4 hardware); this includes every existing Metal codegen and GEMM test with the new default active.
- `bash format.sh --files <changed>`, `pre-commit run --files <changed>`, `git diff --check`: clean.

## Notes

This changes the default generated code for every Metal kernel with short constant loops. The existing Metal suite passes unchanged; the only measured effect is the speedup above. The limits are the ones that restored the measured kernels to their expected speed; they are not tuned beyond that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added Metal-specific automatic loop unrolling for loops with extents up to 4 and bodies up to 64 statements.
- Preserved explicit `tl.UnrollLoop` configurations, including disabled unrolling.
- Emitted `TILELANG_PRAGMA_UNROLL` for unrolled loops in Metal code generation.
- Added tests for default and disabled unrolling. Metal tests passed: 40 passed and 3 skipped.
- Improved Qwen3.5-4B FP32 prefill performance from 333 ms to 56 ms with identical results.

## C++ style / lint notes

- The PR changes C++ code in `codegen_metal.cc` but does not change a documented C++ API or declaration.
- The change adds pragma emission for unrolled Metal loops.
- The C++ API Style Audit is warning-only. No correctness or build issue is indicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->