### PR TITLE
[Metal][Cache] Cache torch-backend kernels instead of disabling the cache

### DIFF
--- a/docs/compiler_internals/metal_tilelang_development.md
+++ b/docs/compiler_internals/metal_tilelang_development.md
@@ -467,6 +467,7 @@ descriptor shape described in Section 1.3.
 | simdgroup GEMM | Implemented | Compatibility path, Section 3.2 |
 | simdgroup id / lane id lowering | Implemented | Also used by cooperative tensor kernels |
 | `const` / `__restrict` parameter emission | Implemented | Improves MSL alias information |
+| Torch backend kernel cache | Implemented | Entries hold the Metal source, kernel parameters, and launch metadata; reloads recreate the adapter without lowering |
 
 ### 5.5 Known Limitations and Roadmap
 
@@ -568,6 +569,8 @@ MLX-style swizzle is correct but is not currently the fastest default strategy.
 | Metal op lowering | `src/metal/op/gemm.cc`, `src/metal/op/utils.h` | `SelectInst`, validation, scope utilities |
 | Metal codegen | `src/metal/codegen/codegen_metal.cc`, `.h` | MSL emission |
 | TVM runtime | `3rdparty/tvm/src/runtime/metal/metal_module.mm` | guarded `MTLLanguageVersion4_0` selection |
+| Kernel cache | `tilelang/jit/adapter/torch/kernel_cache.py` | torch backend cache entries and launch metadata |
+| Cache tests | `testing/python/metal/test_metal_kernel_cache.py` | memory hits, disk reloads, fresh-process reloads, repair |
 | Runtime tests | `testing/python/metal/test_metal_gemm_v2.py` | Metal correctness |
 | Codegen tests | `testing/python/metal/test_metal_gemm_v2_linux.py` | source-level Metal codegen |
 | Simdgroup tests | `testing/python/metal/test_metal_simdgroup_store.py` | simdgroup direct store |

--- a/testing/python/metal/test_metal_cache.py
+++ b/testing/python/metal/test_metal_cache.py
@@ -3,11 +3,12 @@
 Covers two behaviors that previously made Metal support opaque:
 1. `@tilelang.jit` with no explicit `execution_backend` must resolve to the
    torch backend (Metal adapter) instead of `tvm_ffi`.
-2. The torch backend must not attempt to persist a compiled library to the disk
-   cache (it has no `libpath` artifact; `torch.mps.compile_shader` compiles the
-   MSL source in-process). Before the fix this raised
-   `AttributeError: 'MetalKernelAdapter' object has no attribute 'libpath'`
-   and logged "Error during atomic cache save" on every run.
+2. The torch backend has no library artifact (`torch.mps.compile_shader`
+   compiles the MSL source in-process). Saving its cache entry must neither
+   raise `AttributeError: 'MetalKernelAdapter' object has no attribute
+   'libpath'` nor log "Error during atomic cache save", and compiling a Metal
+   kernel must not disable caching for the rest of the process. Entry
+   contents and reloads are covered by `test_metal_kernel_cache.py`.
 """
 
 import logging
@@ -19,6 +20,7 @@ import tilelang.language as T
 import torch
 
 from tilelang.cache.kernel_cache import KernelCache
+from tilelang.env import env
 
 
 @tilelang.jit
@@ -66,8 +68,8 @@ def test_auto_backend_resolves_to_torch():
 
 
 @tilelang.testing.requires_metal
-def test_torch_backend_no_disk_cache_write():
-    """The torch backend must not write disk cache entries or log save errors."""
+def test_torch_backend_caches_without_save_errors_or_global_disable():
+    """The torch backend persists entries cleanly and leaves the cache state alone."""
     cache_logger = logging.getLogger("tilelang.cache.kernel_cache")
     records = []
     handler = logging.Handler()
@@ -75,6 +77,7 @@ def test_torch_backend_no_disk_cache_write():
     cache_logger.addHandler(handler)
     cache_logger.setLevel(logging.ERROR)
 
+    enabled_before = env.is_cache_enabled()
     cache_root = KernelCache._get_cache_root()
     before = set(os.listdir(cache_root)) if os.path.isdir(cache_root) else set()
 
@@ -82,16 +85,22 @@ def test_torch_backend_no_disk_cache_write():
         M, N, K = 64, 64, 64
         kernel = _matmul_gemm_auto(M, N, K, 16, 16, 8)
         _run_gemm(kernel, M, N, K)
-        # Second run in the same process: memory-cache hit, still no disk I/O.
+        # Second run in the same process: memory-cache hit.
         _run_gemm(kernel, M, N, K)
     finally:
         cache_logger.removeHandler(handler)
 
     error_messages = [r.getMessage() for r in records if r.levelno >= logging.ERROR]
     assert not any("Error during atomic cache save" in msg for msg in error_messages), error_messages
+    assert env.is_cache_enabled() == enabled_before, "compiling a Metal kernel must not change the cache state"
 
     after = set(os.listdir(cache_root)) if os.path.isdir(cache_root) else set()
-    assert after == before, f"torch backend wrote disk cache entries: {after - before}"
+    if enabled_before:
+        entry = getattr(kernel, "_tilelang_cache_path", None)
+        assert entry is not None and os.path.isdir(entry), "an enabled cache must persist the Metal entry"
+        assert os.path.exists(os.path.join(entry, "launch.json"))
+    else:
+        assert after == before, f"a disabled cache must not write entries: {after - before}"
 
 
 if __name__ == "__main__":

--- a/testing/python/metal/test_metal_kernel_cache.py
+++ b/testing/python/metal/test_metal_kernel_cache.py
@@ -1,0 +1,178 @@
+"""Kernel caching for the torch Metal backend.
+
+Compiled Metal kernels are cached like every other backend: a memory hit
+returns the same kernel, a disk hit in the same or a fresh process recreates
+the adapter from the cached source and launch metadata without lowering
+again, damaged entries are repaired by recompiling, and compiling a Metal
+kernel no longer disables caching for the rest of the process.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.cache import _dispatch_map
+from tilelang.env import env
+from tilelang.jit.kernel import JITKernel
+
+pytestmark = pytest.mark.skipif(not torch.backends.mps.is_available(), reason="PyTorch MPS device is required")
+
+SIZE = 96
+
+
+def affine(symbol: str):
+    @T.prim_func
+    def main(A: T.Tensor((SIZE,), "float32"), B: T.Tensor((SIZE,), "float32")):
+        with T.Kernel(T.ceildiv(SIZE, 32), threads=32) as block:
+            i = block * 32 + T.get_thread_binding(0)
+            if i < SIZE:
+                B[i] = A[i] * 2 + 1
+
+    return main.with_attr("global_symbol", symbol)
+
+
+def compile_metal(func):
+    return tilelang.compile(func, target="metal", execution_backend="torch")
+
+
+def run(kernel):
+    source = torch.arange(SIZE, dtype=torch.float32, device="mps")
+    output = torch.zeros(SIZE, device="mps")
+    kernel(source, output)
+    torch.mps.synchronize()
+    torch.testing.assert_close(output.cpu(), torch.arange(SIZE, dtype=torch.float32) * 2 + 1)
+
+
+@pytest.fixture
+def cache_root(tmp_path, monkeypatch):
+    monkeypatch.delenv("TILELANG_DISABLE_CACHE", raising=False)
+    original = env.TILELANG_CACHE_DIR
+    root = tmp_path / "tilelang-cache"
+    root.mkdir()
+    env.TILELANG_CACHE_DIR = str(root)
+    tilelang.enable_cache()
+    _dispatch_map["torch"]._memory_cache.clear()
+    try:
+        yield root
+    finally:
+        _dispatch_map["torch"]._memory_cache.clear()
+        env.TILELANG_CACHE_DIR = original
+
+
+@pytest.fixture
+def lowerings(monkeypatch):
+    """Count lowering passes; a cache hit must not lower again."""
+    calls = []
+    original = JITKernel._compile_artifact
+
+    def counting(self, *args, **kwargs):
+        calls.append(self)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(JITKernel, "_compile_artifact", counting)
+    return calls
+
+
+def test_memory_and_disk_hits_reuse_the_cached_source(cache_root, lowerings):
+    func = affine(f"affine_{uuid.uuid4().hex[:8]}")
+    first = compile_metal(func)
+    assert len(lowerings) == 1
+    assert env.is_cache_enabled(), "compiling a Metal kernel must not disable the cache"
+    run(first)
+
+    assert compile_metal(func) is first
+    assert len(lowerings) == 1
+
+    entry = Path(first._tilelang_cache_path)
+    assert entry.is_relative_to(cache_root)
+    for name in ("device_kernel.metal", "host_program.py", "params.json", "launch.json", "manifest.json"):
+        assert (entry / name).is_file(), name
+    metadata = json.loads((entry / "launch.json").read_text())
+    assert metadata == first.adapter.launch_metadata
+
+    _dispatch_map["torch"]._memory_cache.clear()
+    second = compile_metal(func)
+    assert len(lowerings) == 1, "a disk hit must not lower again"
+    assert second is not first
+    assert second.adapter.launch_metadata == first.adapter.launch_metadata
+    assert second.get_kernel_source() == first.get_kernel_source()
+    assert second.get_host_source() == first.get_host_source()
+    assert second.params == first.params
+    run(second)
+    assert compile_metal(func) is second
+
+
+def test_fresh_process_loads_the_entry_without_lowering(cache_root, lowerings):
+    symbol = f"affine_{uuid.uuid4().hex[:8]}"
+    first = compile_metal(affine(symbol))
+    assert len(lowerings) == 1
+    script = f"""
+import json, sys
+sys.path.insert(0, {str(Path(__file__).parent)!r})
+import torch
+import tilelang
+from tilelang.jit.kernel import JITKernel
+import test_metal_kernel_cache as fixture
+
+def refuse(self, *args, **kwargs):
+    raise AssertionError("cache miss: the kernel was lowered again")
+
+JITKernel._compile_artifact = refuse
+tilelang.enable_cache()
+kernel = fixture.compile_metal(fixture.affine({symbol!r}))
+fixture.run(kernel)
+print(json.dumps({{"launch": kernel.adapter.launch_metadata, "host": kernel.get_host_source()}}))
+"""
+    environment = {key: value for key, value in os.environ.items() if key != "TILELANG_DISABLE_CACHE"}
+    environment["TILELANG_CACHE_DIR"] = str(cache_root)
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, env=environment)
+    assert result.returncode == 0, result.stderr
+    loaded = json.loads(result.stdout.strip().splitlines()[-1])
+    assert loaded["launch"] == first.adapter.launch_metadata
+    assert loaded["host"] == first.get_host_source()
+
+
+def test_damaged_entries_are_recompiled_and_repaired(cache_root, lowerings):
+    func = affine(f"affine_{uuid.uuid4().hex[:8]}")
+    first = compile_metal(func)
+    entry = Path(first._tilelang_cache_path)
+    launch = entry / "launch.json"
+    launch.write_text("{not json")
+
+    _dispatch_map["torch"]._memory_cache.clear()
+    second = compile_metal(func)
+    assert len(lowerings) == 2, "a corrupted entry must be recompiled"
+    assert json.loads(launch.read_text()) == second.adapter.launch_metadata
+    run(second)
+
+    (entry / "params.json").unlink()
+    _dispatch_map["torch"]._memory_cache.clear()
+    third = compile_metal(func)
+    assert len(lowerings) == 3, "an incomplete entry must be recompiled"
+    assert (entry / "params.json").is_file()
+    run(third)
+
+
+def test_cached_kernel_keeps_the_public_call_contract(cache_root):
+    func = affine(f"affine_{uuid.uuid4().hex[:8]}")
+    compile_metal(func)
+    _dispatch_map["torch"]._memory_cache.clear()
+    kernel = compile_metal(func)
+    assert kernel.execution_backend == "torch"
+    assert kernel.artifact is None
+    assert "#include <metal_stdlib>" in kernel.get_kernel_source()
+    assert kernel.out_idx == []
+    run(kernel)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -385,22 +385,17 @@ class KernelCache:
         if verbose:
             self.logger.debug(f"Checking disk cache for kernel {get_prim_func_name(func, '<unknown>')}")
 
-        if execution_backend == "torch":
-            # Metal's torch backend does not support cache yet
-            env.disable_cache()
-            kernel = None
-        else:
-            # Disk loads can be expensive for large kernel sets; keep them outside
-            # the global cache lock so independent cache hits can proceed in parallel.
-            kernel = self._load_kernel_from_disk(
-                key,
-                backend_context,
-                out_idx,
-                pass_configs,
-                compile_flags,
-                func,
-                verbose,
-            )
+        # Disk loads can be expensive for large kernel sets; keep them outside
+        # the global cache lock so independent cache hits can proceed in parallel.
+        kernel = self._load_kernel_from_disk(
+            key,
+            backend_context,
+            out_idx,
+            pass_configs,
+            compile_flags,
+            func,
+            verbose,
+        )
         if kernel is not None:
             if verbose:
                 self.logger.debug(f"Found kernel in disk cache for {get_prim_func_name(func, '<unknown>')}")
@@ -598,6 +593,9 @@ class KernelCache:
                 self.logger.debug(f"Saving kernel parameters to disk: {params_path}")
             KernelCache._safe_write_file(params_path, "w", lambda file: file.write(dump_kernel_params(kernel.params)))
 
+            # Backends that relaunch from cached source persist their launch metadata
+            self._save_adapter_metadata_to_disk(kernel, staging_path, verbose)
+
             # Persist HIP kernel-resource-usage remarks
             usage = getattr(kernel, "_resource_usage", None) or {}
             if usage:
@@ -707,6 +705,7 @@ class KernelCache:
                 out_idx=out_idx,
                 pass_configs=pass_configs,
                 compile_flags=compile_flags,
+                adapter_metadata=self._load_adapter_metadata_from_disk(cache_path, verbose),
             )
         except Exception as err:
             self.logger.warning(
@@ -869,6 +868,14 @@ class KernelCache:
     def _set_adapter_cache_path(self, kernel: JITKernel, cache_path: str):
         return
 
+    def _save_adapter_metadata_to_disk(self, kernel: JITKernel, cache_path: str, verbose: bool = False):
+        """Persist launch metadata for adapters that relaunch from cached source."""
+        return
+
+    def _load_adapter_metadata_from_disk(self, cache_path: str, verbose: bool = False) -> dict | None:
+        """Read the launch metadata written by ``_save_adapter_metadata_to_disk``."""
+        return None
+
     def _build_kernel(
         self,
         func: Callable | None,
@@ -880,6 +887,7 @@ class KernelCache:
         out_idx: list[int] | None,
         pass_configs: dict | None,
         compile_flags: list[str] | str | None,
+        adapter_metadata: dict | None = None,
     ) -> JITKernel | None:
         # Check all required components and report specific failures
         missing_components = []
@@ -903,4 +911,5 @@ class KernelCache:
             pass_configs=pass_configs,
             compile_flags=compile_flags,
             backend_context=backend_context,
+            adapter_metadata=adapter_metadata,
         )

--- a/tilelang/jit/adapter/torch/kernel_cache.py
+++ b/tilelang/jit/adapter/torch/kernel_cache.py
@@ -1,4 +1,54 @@
+"""Disk cache entries for the torch Metal backend.
+
+The Metal source is compiled by ``torch.mps.compile_shader`` at load time, so
+an entry stores the generated source, the lowered host program (for
+inspection only), the kernel parameters, and the launch metadata the adapter
+needs to relaunch that source; there is no library file.
+"""
+
+import json
+import os
+
 from tilelang.cache.kernel_cache import KernelCache
+from tilelang.jit import JITKernel
 
 
-class TorchKernelCache(KernelCache): ...
+class TorchKernelCache(KernelCache):
+    device_kernel_path = "device_kernel.metal"
+    host_kernel_path = "host_program.py"
+    launch_path = "launch.json"
+
+    def _get_required_files(self, cache_path: str) -> list[str]:
+        return [
+            os.path.join(cache_path, self.params_path),
+            os.path.join(cache_path, self.launch_path),
+        ]
+
+    def _save_so_cubin_to_disk(self, kernel: JITKernel, cache_path: str, verbose: bool = False):
+        # The shader is compiled from the cached source; no library exists.
+        return
+
+    def _save_wrapper_kernel_code_to_disk(self, kernel: JITKernel, cache_path: str, verbose: bool = False):
+        # There is no host wrapper; keep the lowered host program so
+        # get_host_source() works for a kernel loaded from this entry.
+        host_kernel_path = os.path.join(cache_path, self.host_kernel_path)
+        if verbose:
+            self.logger.debug(f"Saving Metal host program to file: {host_kernel_path}")
+        KernelCache._safe_write_file(host_kernel_path, "w", lambda file: file.write(kernel.get_host_source()))
+
+    def _save_adapter_metadata_to_disk(self, kernel: JITKernel, cache_path: str, verbose: bool = False):
+        launch_path = os.path.join(cache_path, self.launch_path)
+        if verbose:
+            self.logger.debug(f"Saving Metal launch metadata to file: {launch_path}")
+        metadata = kernel.adapter.launch_metadata
+        KernelCache._safe_write_file(launch_path, "w", lambda file: json.dump(metadata, file, indent=2, sort_keys=True))
+
+    def _load_adapter_metadata_from_disk(self, cache_path: str, verbose: bool = False) -> dict | None:
+        launch_path = os.path.join(cache_path, self.launch_path)
+        if verbose:
+            self.logger.debug(f"Loading Metal launch metadata from file: {launch_path}")
+        with open(launch_path, encoding="utf-8") as file:
+            metadata = json.load(file)
+        if not isinstance(metadata, dict):
+            raise ValueError(f"Metal launch metadata at {launch_path} is not a JSON object")
+        return metadata

--- a/tilelang/jit/adapter/torch/metal.py
+++ b/tilelang/jit/adapter/torch/metal.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 from functools import wraps
 from collections.abc import Callable
+from typing import Any
 
 import torch
 from tvm import tirx
 
 from tilelang import tvm as tvm
 
-from ..base import BaseKernelAdapter
+from ..base import BaseKernelAdapter, CachedTextSource
 from tilelang.engine.param import KernelParam
 
 
@@ -41,9 +42,9 @@ class MetalKernelAdapter(BaseKernelAdapter):
             thread_extent = func.attrs["thread_extent"]
             for tag, extent in thread_extent.items():
                 if "threadIdx" in tag:
-                    self.block_info["xyz".index(tag[-1])] = extent
+                    self.block_info["xyz".index(tag[-1])] = int(extent)
                 elif "blockIdx" in tag:
-                    self.grid_info["xyz".index(tag[-1])] = extent
+                    self.grid_info["xyz".index(tag[-1])] = int(extent)
             break
         else:
             raise AssertionError(f"no kernel with name {func_name}")
@@ -53,6 +54,47 @@ class MetalKernelAdapter(BaseKernelAdapter):
 
     _kernel = None
 
+    @classmethod
+    def from_database(
+        cls,
+        params: list[KernelParam],
+        result_idx: list[int],
+        func_or_mod: tirx.PrimFunc | tvm.IRModule,
+        device_kernel_source: CachedTextSource,
+        launch_metadata: dict[str, Any],
+        host_kernel_source: CachedTextSource | None = None,
+        verbose: bool = False,
+    ):
+        """Recreate the adapter from cached Metal source and its launch metadata."""
+        adapter = cls.__new__(cls)
+        adapter._set_cached_text_source("kernel_global_source", "_kernel_global_source_path", device_kernel_source)
+        source = adapter._load_cached_text_source("kernel_global_source", "_kernel_global_source_path")
+        if source is None:
+            raise ValueError("cached Metal kernel source is unavailable")
+        adapter.kernel_global_source = source
+        if host_kernel_source is not None:
+            adapter._set_cached_text_source("host_kernel_source", "_host_kernel_source_path", host_kernel_source)
+        adapter.verbose = verbose
+        try:
+            adapter.kernel_name = str(launch_metadata["kernel_name"])
+            adapter.block_info = [int(extent) for extent in launch_metadata["block"]]
+            adapter.grid_info = [int(extent) for extent in launch_metadata["grid"]]
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError(f"invalid Metal launch metadata: {launch_metadata!r}") from error
+        if len(adapter.block_info) != 3 or len(adapter.grid_info) != 3:
+            raise ValueError(f"invalid Metal launch metadata: {launch_metadata!r}")
+        BaseKernelAdapter.__init__(adapter, func_or_mod, params=params, result_idx=result_idx)
+        return adapter
+
+    @property
+    def launch_metadata(self) -> dict[str, Any]:
+        """Plain data needed to relaunch the cached Metal source."""
+        return {
+            "kernel_name": self.kernel_name,
+            "block": [int(extent) for extent in self.block_info],
+            "grid": [int(extent) for extent in self.grid_info],
+        }
+
     def get_kernel_source(self, kernel_only: bool = True) -> str:
         if kernel_only:
             # Return just the kernel function body, stripping Metal
@@ -61,6 +103,13 @@ class MetalKernelAdapter(BaseKernelAdapter):
             if idx >= 0:
                 return self.kernel_global_source[idx:]
         return self.kernel_global_source
+
+    def get_host_source(self) -> str:
+        """The lowered host program of a kernel loaded from the cache."""
+        source = self._load_cached_text_source("host_kernel_source", "_host_kernel_source_path")
+        if source is None:
+            raise RuntimeError("the host program of this cached Metal kernel is unavailable")
+        return source
 
     def _convert_torch_func(self) -> Callable:
         if self._kernel is None:

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -163,9 +163,13 @@ class JITKernel(Generic[_P, _T]):
         pass_configs: dict[str, Any] | None = None,
         compile_flags: list[str] | None = None,
         backend_context: BackendContext | None = None,
+        adapter_metadata: dict[str, Any] | None = None,
     ):
         """
         Alternative constructor to create a TorchFunction directly from a database.
+
+        ``adapter_metadata`` carries backend-specific launch information for
+        adapters that relaunch from cached source instead of a library.
         """
         instance = cls(
             func=func,
@@ -189,6 +193,7 @@ class JITKernel(Generic[_P, _T]):
             kernel_lib_path=kernel_lib_path,
             pass_configs=pass_configs,
             compile_flags=compile_flags,
+            adapter_metadata=adapter_metadata,
         )
         instance.torch_function = instance.adapter.func
         return instance
@@ -413,6 +418,7 @@ class JITKernel(Generic[_P, _T]):
         kernel_lib_path: str,
         pass_configs: dict[str, Any] | None = None,
         compile_flags: list[str] | None = None,
+        adapter_metadata: dict[str, Any] | None = None,
     ) -> BaseKernelAdapter:
         target = self.target
         execution_backend = self.execution_backend
@@ -467,6 +473,19 @@ class JITKernel(Generic[_P, _T]):
                 pass_configs=pass_configs,
                 compile_flags=compile_flags,
             )
+        elif execution_backend == "torch":
+            assert is_metal_target(target)
+            if adapter_metadata is None:
+                raise ValueError("cached Metal kernels require their launch metadata")
+            adapter = MetalKernelAdapter.from_database(
+                params=params,
+                result_idx=result_idx,
+                func_or_mod=func_or_mod,
+                device_kernel_source=device_kernel_source,
+                launch_metadata=adapter_metadata,
+                host_kernel_source=host_kernel_source,
+                verbose=self.verbose,
+            )
         else:
             # Handle invalid backend.
             raise ValueError(f"Invalid execution backend: {execution_backend}")
@@ -519,13 +538,17 @@ class JITKernel(Generic[_P, _T]):
         """
         if self.execution_backend in {"cython", "nvrtc", "tvm_ffi", "cutedsl"}:
             return self.adapter.get_kernel_source(kernel_only=kernel_only)
-        return self.artifact.kernel_source
+        if self.artifact is not None:
+            return self.artifact.kernel_source
+        # Loaded from the kernel cache: the adapter holds the full module source.
+        return self.adapter.get_kernel_source(kernel_only=False)
 
     def get_host_source(self) -> str:
         """
         Returns the source code of the host function.
         """
-        if self.execution_backend in {"cython", "nvrtc", "tvm_ffi", "cutedsl"}:
+        if self.execution_backend in {"cython", "nvrtc", "tvm_ffi", "cutedsl"} or self.artifact is None:
+            # Kernels loaded from the cache have no artifact; the adapter keeps the host program.
             return self.adapter.get_host_source()
         assert self.artifact.host_mod is not None, "host_mod is not available"
         return str(self.artifact.host_mod)


### PR DESCRIPTION
## Problem

`KernelCache.cached` calls `env.disable_cache()` whenever a torch-backend Metal kernel is requested (#2856 introduced the skip because a Metal entry could not be reloaded: the adapter has no library artifact and no way to recreate itself from source). Two consequences:

```python
first = tilelang.compile(main, target="metal", execution_backend="torch")
second = tilelang.compile(main, target="metal", execution_backend="torch")
first is second        # False: lowered twice
env.is_cache_enabled() # False: every later compile in the process is uncached
```

## Change

1. `tilelang/jit/adapter/torch/kernel_cache.py`: an entry stores the generated Metal source, `params.json`, and `launch.json` (the adapter's launch metadata); there is no library file. `launch.json` is a required, hash-verified file.
2. `tilelang/jit/adapter/torch/metal.py`: `launch_metadata` (plain data) and `from_database`, which recreates the adapter from cached source and metadata and compiles the shader with `torch.mps.compile_shader`.
3. `tilelang/cache/kernel_cache.py`: remove the global disable; add two hooks, `_save_adapter_metadata_to_disk` and `_load_adapter_metadata_from_disk`, for backends that relaunch from cached source. Both default to no-ops, so other backends are unchanged.
4. `tilelang/jit/kernel.py`: thread `adapter_metadata` through `from_database`; `get_kernel_source` works for kernels loaded from the cache.
5. `testing/python/metal/test_metal_cache.py`: the test that asserted nothing is written now asserts that saving logs no errors and leaves the cache state alone.
6. `docs/compiler_internals/metal_tilelang_development.md`: rows for the cache and its tests.

## Tests

`testing/python/metal/test_metal_kernel_cache.py` (4 tests, isolated cache root): memory hit returns the same kernel and the cache stays enabled; disk hit in the same process recreates the kernel without lowering, with identical launch metadata and source; a fresh process reloads the entry with lowering forbidden; a corrupted `launch.json` and a missing `params.json` are recompiled and repaired; the reloaded kernel keeps the public call contract.

## Validation

Apple M4 Max, macOS 15.5 (24F74), Command Line Tools 16.4 / macOS SDK 15.5, Python 3.12.11, PyTorch 2.14.0, native build of this branch on top of `main` (85fd8fc2).

- `python -m pytest testing/python/metal -q`: 42 passed, 3 skipped, with the cache enabled and with `TILELANG_DISABLE_CACHE=1`.
- `bash format.sh --files <changed>`, `pre-commit run --files <changed>`, `git diff --check`: clean.

## Related

Supersedes the "skip disk cache for torch" part of #2856. The metadata format is owned by the adapter; #3196 persists its launch plan through the same hook, so whichever lands second needs a small metadata update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Enabled persistent kernel caching for the Torch Metal backend.
- Cached Metal source, kernel parameters, and validated launch metadata.
- Added adapter reconstruction through `torch.mps.compile_shader`.
- Preserved no-op cache metadata behavior for other backends.
- Added recovery for missing or corrupted cache files.
- Updated documentation and added coverage for memory, disk, fresh-process, repair, compatibility, and cache-state behavior.

## Validation

- 42 tests passed.
- 3 tests skipped when MPS was unavailable.
- Formatting, pre-commit checks, and diff validation passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->