### PR TITLE
[Metal] Implement fragment reductions through the shared planner

### DIFF
--- a/docs/compiler_internals/metal_tilelang_development.md
+++ b/docs/compiler_internals/metal_tilelang_development.md
@@ -640,3 +640,14 @@ Default benchmark:
 TILELANG_DISABLE_CACHE=1 python benchmark/matmul_metal/benchmark_matmul_metal.py \
   --m 4096 --n 4096 --k 4096 --warmup 10 --repeats 100
 ```
+
+## 6. Fragment Reductions
+
+Metal `T.reduce` uses the shared GPU reduction planner for logical fragment
+ownership, local accumulation, and thread reduction steps. The Metal backend
+emits SIMD-group shuffles, with threadgroup workspace and barriers for steps
+that cross SIMD groups. Such steps require the entire threadgroup to participate;
+partial threadgroup participation is rejected during lowering. Sum, max, min,
+absolute sum/max, bitwise reductions, and batched outputs use this path.
+
+Regression coverage is in `testing/python/metal/test_metal_reduce.py`.

--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -633,6 +633,12 @@ inline PrimExpr MakeUpdate(const ReduceOpNode &op, PrimExpr dst_val,
 } // namespace reduce
 
 template <typename Impl> struct ReduceLowerer {
+  // Some device languages require the thread index as an explicit argument.
+  static Array<PrimExpr> ThreadReduceArgs(const LowerArgs &, const Fragment &,
+                                          int) {
+    return {};
+  }
+
   static Stmt LowerLocal(const ReduceOpNode &op, const Buffer &src_buffer,
                          const Buffer &dst_buffer,
                          const LowerArgs &lower_args) {
@@ -1093,6 +1099,10 @@ template <typename Impl> struct ReduceLowerer {
               if (need_workspace) {
                 args.push_back(workspace);
               }
+              for (const auto &arg : Impl::ThreadReduceArgs(
+                       lower_args, red_layout, reducing_threads)) {
+                args.push_back(arg);
+              }
               phases.push_back(Evaluate(
                   Call(DataType::Handle(), builtin::call_extern(), args)));
 
@@ -1137,6 +1147,10 @@ template <typename Impl> struct ReduceLowerer {
               Array<PrimExpr> args = {StringImm(allreduce), ptr};
               if (need_workspace) {
                 args.push_back(workspace);
+              }
+              for (const auto &arg : Impl::ThreadReduceArgs(
+                       lower_args, red_layout, reducing_threads)) {
+                args.push_back(arg);
               }
               phases.push_back(Evaluate(
                   Call(DataType::Handle(), builtin::call_extern(), args)));
@@ -1220,6 +1234,10 @@ template <typename Impl> struct ReduceLowerer {
           PrimExpr workspace =
               lower_args.add_workspace(workspace_size, clear_buffer->dtype);
           thread_reduce_args.push_back(workspace);
+        }
+        for (const auto &arg :
+             Impl::ThreadReduceArgs(lower_args, red_layout, reducing_threads)) {
+          thread_reduce_args.push_back(arg);
         }
         auto call = Call(clear_buffer->dtype, builtin::call_extern(),
                          thread_reduce_args);

--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -2,6 +2,7 @@
  * \file metal/codegen/codegen_metal.cc
  */
 #include "codegen_metal.h"
+#include "reduce.h"
 
 #include <tvm/arith/analyzer.h>
 #include <tvm/ffi/reflection/registry.h>
@@ -113,6 +114,8 @@ std::string CodeGenTileLangMetal::Finish() {
   code << "#define TILELANG_PRAGMA_UNROLL _Pragma(\"clang loop "
           "unroll(full)\")\n";
   code << "using namespace metal;\n\n";
+  if (uses_allreduce_)
+    code << kMetalReduceSource;
   code << decl_stream.str();
   code << fwd_decl_stream.str();
   code << stream.str();
@@ -1336,7 +1339,12 @@ void CodeGenTileLangMetal::VisitExpr_(const CallNode *op,
         << "Only 8x8 matrix is supported, but got " << col_val << "x"
         << row_val;
   };
-  if (op->op.same_as(builtin::make_filled_simdgroup_matrix())) {
+  if (op->op.same_as(builtin::call_extern())) {
+    const auto *name = op->args[0].as<StringImmNode>();
+    if (name && name->value.find("tl::AllReduce<") == 0)
+      uses_allreduce_ = true;
+    CodeGenC::VisitExpr_(op, os);
+  } else if (op->op.same_as(builtin::make_filled_simdgroup_matrix())) {
     TVM_FFI_ICHECK_EQ(op->args.size(), 5);
     Var var = Downcast<Var>(op->args[0]);
     // Get the data type of the simdgroup matrix

--- a/src/metal/codegen/codegen_metal.h
+++ b/src/metal/codegen/codegen_metal.h
@@ -89,6 +89,7 @@ private:
   bool emitted_metal_simdgroup_id_{false};
   bool emitted_frag_lane_vars_{false};
   bool uses_cooperative_tensor_{false};
+  bool uses_allreduce_{false};
   bool needs_fragment_lane_vars_{false};
   int thread_index_bits_{32};
   int thread_work_dim_{0};

--- a/src/metal/codegen/reduce.h
+++ b/src/metal/codegen/reduce.h
@@ -1,0 +1,79 @@
+/*!
+ * \file metal/codegen/reduce.h
+ * \brief Self-contained Metal helpers for the shared GPU reduction lowerer.
+ */
+#ifndef TILELANG_METAL_CODEGEN_REDUCE_H_
+#define TILELANG_METAL_CODEGEN_REDUCE_H_
+
+namespace tvm {
+namespace codegen {
+
+constexpr const char *kMetalReduceSource = R"(
+namespace tl {
+struct SumOp {
+  template <typename T> T operator()(T x, T y) const { return x + y; }
+};
+struct MaxOp {
+  template <typename T> T operator()(T x, T y) const { return metal::max(x, y); }
+};
+struct MinOp {
+  template <typename T> T operator()(T x, T y) const { return metal::min(x, y); }
+};
+struct BitAndOp {
+  template <typename T> T operator()(T x, T y) const { return x & y; }
+};
+struct BitOrOp {
+  template <typename T> T operator()(T x, T y) const { return x | y; }
+};
+struct BitXorOp {
+  template <typename T> T operator()(T x, T y) const { return x ^ y; }
+};
+
+template <class Reducer, int Threads, int Scale, int ThreadOffset = 0,
+          int Batch = 1, int WorkspaceStride = 0>
+struct AllReduce {
+  template <typename T>
+  static T run(T value, uint thread_index) {
+    static_assert(Threads <= 32, "A cross-SIMD reduction needs shared storage");
+    for (int offset = Threads / 2; offset >= Scale; offset /= 2) {
+      value = Reducer()(value, simd_shuffle_xor(value, ushort(offset)));
+    }
+    return value;
+  }
+
+  template <typename T>
+  static T run(T value, threadgroup T *workspace, uint thread_index) {
+    for (int offset = Threads / 2; offset >= Scale; offset /= 2) {
+      if (offset >= 32) {
+        uint index = thread_index - ThreadOffset;
+        workspace[index] = value;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        value = Reducer()(value, workspace[index ^ offset]);
+        // All readers must finish before another reduction reuses the workspace.
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+      } else {
+        value = Reducer()(value, simd_shuffle_xor(value, ushort(offset)));
+      }
+    }
+    return value;
+  }
+
+  template <typename T>
+  static void run_batch(thread T *values, uint thread_index) {
+    for (int i = 0; i < Batch; ++i) values[i] = run(values[i], thread_index);
+  }
+
+  template <typename T>
+  static void run_batch(thread T *values, threadgroup T *workspace, uint thread_index) {
+    for (int i = 0; i < Batch; ++i) {
+      values[i] = run(values[i], workspace + i * WorkspaceStride, thread_index);
+    }
+  }
+};
+} // namespace tl
+)";
+
+} // namespace codegen
+} // namespace tvm
+
+#endif // TILELANG_METAL_CODEGEN_REDUCE_H_

--- a/src/metal/op/reduce.cc
+++ b/src/metal/op/reduce.cc
@@ -1,0 +1,83 @@
+/*!
+ * \file tl/metal/op/reduce.cc
+ * \brief Metal implementation for tl.reduce AllReduce lowering.
+ */
+
+#include "backend/common/op/reduce.h"
+
+#include "metal/target_utils.h"
+
+#include <sstream>
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+
+namespace metal {
+
+struct Reduce : backend::ReduceLowerer<Reduce> {
+  static Array<PrimExpr> ThreadReduceArgs(const LowerArgs &args,
+                                          const Fragment &layout, int threads) {
+    if (threads > 32) {
+      auto range = backend::reduce::ResolveAllReduceThreadRange(
+          layout, args.thread_bounds, args.target);
+      arith::Analyzer analyzer;
+      ICHECK(analyzer.CanProveEqual(range->min, args.thread_bounds->min) &&
+             analyzer.CanProveEqual(range->extent, args.thread_bounds->extent))
+          << "Metal reductions across SIMD groups require all block threads "
+             "to participate in the threadgroup barrier";
+    }
+    return {args.thread_index};
+  }
+
+  static bool SupportsFp16Bf16NanReduce(Target) { return false; }
+
+  static int GetPreferredVectorizedSize(const ReduceOpNode &, Target) {
+    return 1;
+  }
+
+  static std::string MakeBatchAllReduce(std::string reducer,
+                                        int reducing_threads, int scale,
+                                        PrimExpr thread_offset, PrimExpr,
+                                        int batch, int workspace_stride,
+                                        Target) {
+    std::stringstream ss;
+    ss << "tl::AllReduce<" << reducer << ", " << reducing_threads << ", "
+       << scale << ", " << thread_offset << ", " << batch << ", "
+       << workspace_stride << ">::run_batch";
+    return ss.str();
+  }
+
+  static std::string MakeScalarAllReduce(std::string reducer,
+                                         int reducing_threads, int scale,
+                                         PrimExpr thread_offset, PrimExpr,
+                                         Target) {
+    std::stringstream ss;
+    ss << "tl::AllReduce<" << reducer << ", " << reducing_threads << ", "
+       << scale << ", " << thread_offset << ">::run";
+    return ss.str();
+  }
+};
+
+} // namespace metal
+
+namespace {
+
+bool MatchMetalReduceTarget(Target target) { return TargetIsMetal(target); }
+
+bool RegisterMetalReduce() {
+  RegisterReduceImpl(ReduceImpl{
+      "metal.Reduce",
+      MatchMetalReduceTarget,
+      metal::Reduce::Lower,
+  });
+  return true;
+}
+
+const bool metal_reduce_registered = RegisterMetalReduce();
+
+} // namespace
+
+} // namespace tl
+} // namespace tvm

--- a/testing/python/metal/test_metal_reduce.py
+++ b/testing/python/metal/test_metal_reduce.py
@@ -1,0 +1,116 @@
+"""Metal lowering of portable fragment reductions."""
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+
+
+@tilelang.jit(target="metal", execution_backend="torch")
+def reduce_kernel(rows, cols, threads, kind, axis=1, clear=True, dtype="float32", strided=False, batch=1):
+    output_size = rows if axis == 1 else cols
+
+    @T.prim_func
+    def main(A: T.Tensor((rows, cols), dtype), B: T.Tensor((output_size,), dtype)):
+        with T.Kernel(1, threads=threads):
+            a = T.alloc_fragment((rows, cols), dtype)
+            b = T.alloc_fragment((output_size,), dtype)
+            if strided:
+                T.annotate_layout(
+                    {
+                        a: T.Fragment((rows, cols), forward_fn=lambda i, j: (j * rows + i, 0)),
+                        b: T.Fragment(
+                            (rows,), forward_thread_fn=lambda i, rep: i + rep * rows, forward_index_fn=lambda i: 0, replicate=cols
+                        ),
+                    }
+                )
+            T.copy(A, a)
+            if not clear:
+                T.fill(b, 2)
+            T.reduce(a, b, kind, dim=axis, clear=clear, batch=batch)
+            T.copy(b, B)
+
+    return main
+
+
+@pytest.mark.parametrize("threads, rows, cols", [(32, 4, 8), (128, 1, 128)])
+def test_reduce_codegen(threads, rows, cols):
+    program = reduce_kernel.get_tir(rows, cols, threads, "sum")
+    with tvm.target.Target("metal"):
+        source = tilelang.lower(program, target="metal").kernel_source
+    assert "simd_shuffle_xor" in source
+    assert "__syncthreads" not in source
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize("kind", ["sum", "max", "min", "abssum", "absmax"])
+@pytest.mark.parametrize(
+    "rows,cols,threads,axis,strided",
+    [
+        (4, 8, 32, 1, False),
+        (4, 8, 32, 1, True),
+        (4, 32, 128, 1, True),
+        (8, 256, 128, 1, False),
+        (128, 4, 128, 0, False),
+    ],
+)
+@pytest.mark.parametrize("clear", [True, False])
+def test_reduce_execution(kind, rows, cols, threads, axis, strided, clear):
+    a = torch.randn(rows, cols)
+    values = a.abs() if kind.startswith("abs") else a
+    if kind in ("sum", "abssum"):
+        expected = values.sum(axis)
+        if not clear:
+            expected += 2
+    elif kind in ("max", "absmax"):
+        expected = values.amax(axis)
+        if not clear:
+            expected = expected.clamp_min(2)
+    else:
+        expected = values.amin(axis)
+        if not clear:
+            expected = expected.clamp_max(2)
+    b = torch.empty_like(expected, device="mps")
+    reduce_kernel(rows, cols, threads, kind, axis, clear, strided=strided)(a.to("mps"), b)
+    torch.testing.assert_close(b.cpu(), expected, atol=2e-5, rtol=2e-5)
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize("dtype", ["float16", "int32"])
+def test_reduce_dtype(dtype):
+    a = torch.arange(128).reshape(4, 32).remainder(7).to(getattr(torch, dtype))
+    b = torch.empty(4, dtype=a.dtype, device="mps")
+    reduce_kernel(4, 32, 128, "sum", dtype=dtype)(a.to("mps"), b)
+    torch.testing.assert_close(b.cpu(), a.sum(1).to(a.dtype), atol=0, rtol=0)
+
+
+@tilelang.testing.requires_metal
+def test_reduce_batch():
+    a = torch.randn(8, 128)
+    b = torch.empty(8, device="mps")
+    reduce_kernel(8, 128, 128, "sum", batch=2)(a.to("mps"), b)
+    torch.testing.assert_close(b.cpu(), a.sum(1), atol=2e-5, rtol=2e-5)
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize("kind,op", [("bitand", torch.bitwise_and), ("bitor", torch.bitwise_or), ("bitxor", torch.bitwise_xor)])
+@pytest.mark.parametrize("clear", [True, False])
+def test_reduce_bitwise(kind, op, clear):
+    a = torch.randint(-128, 128, (4, 128), dtype=torch.int32)
+    expected = a[:, 0]
+    for column in a[:, 1:].unbind(1):
+        expected = op(expected, column)
+    if not clear:
+        expected = op(expected, 2)
+    b = torch.empty(4, dtype=torch.int32, device="mps")
+    reduce_kernel(4, 128, 128, kind, clear=clear, dtype="int32")(a.to("mps"), b)
+    torch.testing.assert_close(b.cpu(), expected, atol=0, rtol=0)
+
+
+def test_partial_cross_simd_reduce_rejected():
+    program = reduce_kernel.get_tir(1, 64, 128, "sum", strided=True)
+    with tvm.target.Target("metal"), pytest.raises(tvm.error.InternalError, match="require all block threads"):
+        tilelang.lower(program, target="metal")


### PR DESCRIPTION
## Problem

Metal has no lowering for `T.reduce_sum`, `T.reduce_max`, `T.reduce_min` and the supported bitwise reductions. Lowering a kernel with any of them on the Metal target fails with an unregistered-implementation error, so softmax, normalization and routing kernels cannot be written portably for Apple GPUs; each one has to hand-encode lane shuffles.

## Change

1. `src/backend/common/op/reduce.h`: the shared `ReduceLowerer` gains one hook, `ThreadReduceArgs`, returning extra arguments for the per-thread reduce intrinsic. The default returns nothing, so CUDA and ROCm lowering is unchanged.
2. `src/metal/op/reduce.cc`: a Metal lowerer on top of the shared planner. It passes the thread index through the hook and rejects cross-simdgroup reductions whose participating threads are not the whole threadgroup, because those need a threadgroup barrier that every thread must reach.
3. `src/metal/codegen/reduce.h`, `codegen_metal.cc/.h`: emit SIMD lane shuffles for intra-simdgroup steps and a threadgroup workspace with barriers for cross-simdgroup steps; accumulation and batched reductions are supported.
4. `docs/compiler_internals/metal_tilelang_development.md`: implemented-features row.

## Tests

`testing/python/metal/test_metal_reduce.py` executes sum/max/min and bitwise reductions on MPS against Torch references, in FP32 and BF16, with and without accumulation, batched over rows, across simdgroup boundaries, and checks that a partial-threadgroup cross-simdgroup reduction is rejected at lowering time.

## Validation

Apple M4 Max, macOS 15.5 (24F74), Command Line Tools 16.4 / macOS SDK 15.5, Python 3.12.11, PyTorch 2.14.0, `TILELANG_DISABLE_CACHE=1`, native build of this branch on top of `main` (85fd8fc2).

- `python -m pytest testing/python/metal -q`: 100 passed, 3 skipped (Metal 4 hardware).
- The CUDA and ROCm reduction translation units compile with the hook in place; those GPUs were not available here, so their execution coverage relies on CI.
- `bash format.sh --files <changed>`, `pre-commit run --files <changed>`, `git diff --check`: clean.

## Related

#2968 proposes a separate single-simdgroup butterfly `ReduceImpl` for Metal and moves helpers out of the common header. This change instead reuses the existing shared planner through one hook, and supports cross-simdgroup reductions. Happy to reconcile with the author of #2968; the two touch the same common header.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds Metal lowering for fragment reductions through the shared reduction planner.
- Supports sum, max, min, absolute, and bitwise reductions.
- Uses SIMD shuffles for intra-simdgroup reductions.
- Uses threadgroup workspace and barriers for cross-simdgroup reductions.
- Supports accumulation and batched reductions.
- Rejects unsafe partial-threadgroup reductions.
- Adds Metal reduction code generation and documentation.
- Adds MPS coverage for supported data types, batching, accumulation, SIMD boundaries, and invalid cases.

## C++ style / lint notes

- The PR changes C++ backend code and C++ headers.
- Review `docs/developer_guide/cpp_style.md` for applicable rules.
- The C++ API Style Audit (warning only) CI step is relevant.
- No correctness, build, or test issue is identified from the provided changes.
- Any TLCPP003/TLCPP004 findings are advisory unless they indicate a clear API, FFI, or maintainability risk.

## Validation

- 100 Metal tests passed on Apple M4 Max.
- 3 tests were skipped for Metal 4 hardware.
- Formatting, pre-commit checks, and whitespace validation passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->