### PR TITLE
[Metal] Lower scalar warp reductions to SIMD-group functions

### DIFF
--- a/docs/compiler_internals/metal_tilelang_development.md
+++ b/docs/compiler_internals/metal_tilelang_development.md
@@ -467,6 +467,7 @@ descriptor shape described in Section 1.3.
 | simdgroup GEMM | Implemented | Compatibility path, Section 3.2 |
 | simdgroup id / lane id lowering | Implemented | Also used by cooperative tensor kernels |
 | `const` / `__restrict` parameter emission | Implemented | Improves MSL alias information |
+| Scalar warp reductions | Implemented | `T.warp_reduce_sum/max/min/bitand/bitor` lower to `simd_sum/max/min/and/or`; per SIMD group, for float, half and integer scalars up to 32 bits |
 
 ### 5.5 Known Limitations and Roadmap
 

--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -1313,6 +1313,28 @@ bool CodeGenTileLangMetal::TryPrintSimdgroupIndexExpr(const CallNode *op,
   return true;
 }
 
+void CodeGenTileLangMetal::PrintSimdgroupReduce(const char *function,
+                                                bool integer_only,
+                                                const CallNode *op,
+                                                std::ostream &os) {
+  // tl.warp_reduce_* reduce one register value across the executing warp.
+  // Metal's SIMD-group functions have the same scope and result on every
+  // lane, so the call lowers directly. MSL provides them for float, half and
+  // the integer types up to 32 bits; there are no bfloat or 64-bit overloads.
+  TVM_FFI_ICHECK_EQ(op->args.size(), 1U);
+  DataType dtype = op->dtype;
+  bool integral = dtype.is_int() || dtype.is_uint();
+  bool floating = dtype.is_float() && !integer_only;
+  TVM_FFI_ICHECK(dtype.is_scalar() && dtype.bits() <= 32 &&
+                 (integral || floating))
+      << "Metal SIMD-group reduction " << function << " takes one scalar "
+      << (integer_only ? "integer" : "float, half or integer")
+      << " value of at most 32 bits, got " << dtype;
+  os << function << "(";
+  this->PrintExpr(op->args[0], os);
+  os << ")";
+}
+
 void CodeGenTileLangMetal::VisitExpr_(const CallNode *op,
                                       std::ostream &os) { // NOLINT(*)
   TVM_FFI_ICHECK(!op->op.as<GlobalVarNode>())
@@ -1336,7 +1358,17 @@ void CodeGenTileLangMetal::VisitExpr_(const CallNode *op,
         << "Only 8x8 matrix is supported, but got " << col_val << "x"
         << row_val;
   };
-  if (op->op.same_as(builtin::make_filled_simdgroup_matrix())) {
+  if (op->op.same_as(tl::warp_reduce_sum())) {
+    PrintSimdgroupReduce("simd_sum", false, op, os);
+  } else if (op->op.same_as(tl::warp_reduce_max())) {
+    PrintSimdgroupReduce("simd_max", false, op, os);
+  } else if (op->op.same_as(tl::warp_reduce_min())) {
+    PrintSimdgroupReduce("simd_min", false, op, os);
+  } else if (op->op.same_as(tl::warp_reduce_bitand())) {
+    PrintSimdgroupReduce("simd_and", true, op, os);
+  } else if (op->op.same_as(tl::warp_reduce_bitor())) {
+    PrintSimdgroupReduce("simd_or", true, op, os);
+  } else if (op->op.same_as(builtin::make_filled_simdgroup_matrix())) {
     TVM_FFI_ICHECK_EQ(op->args.size(), 5);
     Var var = Downcast<Var>(op->args[0]);
     // Get the data type of the simdgroup matrix

--- a/src/metal/codegen/codegen_metal.h
+++ b/src/metal/codegen/codegen_metal.h
@@ -70,6 +70,8 @@ private:
   bool TryPrintSimdgroupIndexExpr(const CallNode *op, std::ostream &os);
   void PrintSimdgroupIndexExpr(int64_t group_mask, int64_t group_shift,
                                std::ostream &os) const;
+  void PrintSimdgroupReduce(const char *function, bool integer_only,
+                            const CallNode *op, std::ostream &os);
   void EnsureFragmentLaneVars();
   void EnsureCooperativeTensorBuffer(const Var &var);
 

--- a/testing/python/metal/test_metal_warp_reduce.py
+++ b/testing/python/metal/test_metal_warp_reduce.py
@@ -1,0 +1,105 @@
+"""Metal lowering of scalar warp reductions to SIMD-group functions."""
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+
+REDUCERS = {
+    "sum": T.warp_reduce_sum,
+    "max": T.warp_reduce_max,
+    "min": T.warp_reduce_min,
+    "bitand": T.warp_reduce_bitand,
+    "bitor": T.warp_reduce_bitor,
+}
+METAL_FUNCTIONS = {
+    "sum": "simd_sum",
+    "max": "simd_max",
+    "min": "simd_min",
+    "bitand": "simd_and",
+    "bitor": "simd_or",
+}
+
+
+@tilelang.jit(target="metal", execution_backend="torch")
+def warp_reduce_kernel(kind, dtype, threads=32):
+    reduce = REDUCERS[kind]
+
+    @T.prim_func
+    def main(A: T.Tensor((threads,), dtype)):
+        with T.Kernel(1, threads=threads):
+            tid = T.get_thread_binding(0)
+            value = T.alloc_local([1], dtype)
+            value[0] = A[tid]
+            A[tid] = reduce(value[0])
+
+    return main
+
+
+def reference(kind, values):
+    if kind == "sum":
+        return values.sum()
+    if kind == "max":
+        return values.max()
+    if kind == "min":
+        return values.min()
+    result = values[0]
+    op = torch.bitwise_and if kind == "bitand" else torch.bitwise_or
+    for value in values[1:]:
+        result = op(result, value)
+    return result
+
+
+@pytest.mark.parametrize("kind", sorted(REDUCERS))
+def test_warp_reduce_codegen(kind):
+    dtype = "int32" if kind.startswith("bit") else "float32"
+    program = warp_reduce_kernel.get_tir(kind, dtype)
+    with tvm.target.Target("metal"):
+        source = tilelang.lower(program, target="metal").kernel_source
+    assert f"{METAL_FUNCTIONS[kind]}(" in source
+    assert "simd_shuffle" not in source
+    assert "threadgroup_barrier" not in source
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize("kind", ["sum", "max", "min"])
+@pytest.mark.parametrize("dtype", ["float32", "float16", "int32"])
+def test_warp_reduce_execution(kind, dtype):
+    torch_dtype = getattr(torch, dtype)
+    if dtype == "int32":
+        a = torch.randint(-1000, 1000, (32,), dtype=torch_dtype)
+    else:
+        a = torch.arange(32, dtype=torch.float32).sub(15.5).to(torch_dtype)
+    expected = torch.full_like(a, reference(kind, a.to(torch.float64) if dtype != "int32" else a).to(torch_dtype))
+    device = a.to("mps")
+    warp_reduce_kernel(kind, dtype)(device)
+    torch.testing.assert_close(device.cpu(), expected, atol=0, rtol=0)
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize("kind", ["bitand", "bitor"])
+def test_warp_reduce_bitwise(kind):
+    a = torch.randint(-128, 128, (32,), dtype=torch.int32)
+    expected = torch.full_like(a, reference(kind, a))
+    device = a.to("mps")
+    warp_reduce_kernel(kind, "int32")(device)
+    torch.testing.assert_close(device.cpu(), expected, atol=0, rtol=0)
+
+
+@tilelang.testing.requires_metal
+def test_warp_reduce_is_per_simdgroup():
+    a = torch.arange(64, dtype=torch.float32)
+    expected = torch.cat([torch.full((32,), a[:32].sum()), torch.full((32,), a[32:].sum())])
+    device = a.to("mps")
+    warp_reduce_kernel("sum", "float32", threads=64)(device)
+    torch.testing.assert_close(device.cpu(), expected, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("kind,dtype", [("sum", "int64"), ("max", "bfloat16"), ("bitand", "float32")])
+def test_warp_reduce_rejects_unsupported_scalars(kind, dtype):
+    program = warp_reduce_kernel.get_tir(kind, dtype)
+    with tvm.target.Target("metal"), pytest.raises(tvm.error.InternalError, match="SIMD-group reduction"):
+        tilelang.lower(program, target="metal")


### PR DESCRIPTION
## Problem

`T.warp_reduce_sum`, `warp_reduce_max`, `warp_reduce_min`, `warp_reduce_bitand` and `warp_reduce_bitor` are target-neutral language operations (`tilelang/language/reduce_op.py`, `src/op/builtin.cc`), but only the CUDA and HIP code generators lower them. On Metal the call reached `CodeGenC` unhandled and lowering failed:

```python
@T.prim_func
def main(A: T.Tensor((32,), "float32")):
    with T.Kernel(1, threads=32):
        tid = T.get_thread_binding(0)
        value = T.alloc_local([1], "float32")
        value[0] = A[tid]
        A[tid] = T.warp_reduce_sum(value[0])  # lowers on cuda/hip, fails on metal
```

Metal kernels that need a SIMD-group reduction of a register value therefore wrote `T.call_extern("float32", "simd_sum", x)`, which ties the kernel source to one target.

## Change

`src/metal/codegen/codegen_metal.cc`, `src/metal/codegen/codegen_metal.h`: handle the five `tl.warp_reduce_*` ops in the Metal call visitor and emit `simd_sum`, `simd_max`, `simd_min`, `simd_and`, `simd_or`. Metal's SIMD-group functions have the same scope (the executing 32-lane group) and the same result on every lane as the CUDA `tl::warp_reduce_*` templates, so the call lowers directly with no helper source.

MSL provides these functions for `float`, `half` and the integer types up to 32 bits only, and `__is_valid_simdgroup_type` rejects `bfloat`. The codegen checks the operand at lowering and fails with a message naming the function and dtype for 64-bit operands, `bfloat16`, and floating operands to the bitwise reductions, instead of leaving the failure to the shader compiler.

`docs/compiler_internals/metal_tilelang_development.md`: one row in the implemented-features table.

No lowering or pass changes; other targets are untouched.

## Tests

`testing/python/metal/test_metal_warp_reduce.py` (20 tests): generated source for each op uses the SIMD-group function and no shuffle or threadgroup barrier; execution on MPS for sum/max/min over float32, float16 and int32 and for bitand/bitor over int32 against exact Torch references; a 64-thread kernel reduces per SIMD group; and lowering rejects int64, bfloat16, and a float operand to `bitand`.

## Validation

Apple M4 Max, macOS 15.5 (24F74), Command Line Tools 16.4 / macOS SDK 15.5, Python 3.12.11, PyTorch 2.14.0, `TILELANG_DISABLE_CACHE=1`, native build of this branch on top of `main` (85fd8fc2).

- `python -m pytest testing/python/metal -q`: 58 passed, 3 skipped (Metal 4 hardware).
- `pre-commit run --files <changed>` and `git diff --check`: clean.
- CUDA/HIP code generators are not modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added Metal lowering for scalar `T.warp_reduce_sum`, `max`, `min`, `bitand`, and `bitor`.
- Added operand validation for supported scalar types and bit widths.
- Added tests for generated code, MPS execution, SIMD-group behavior, and invalid dtypes.
- Updated Metal compiler documentation.
- Validation passed: 58 tests passed and 3 skipped on Apple M4 Max.

## C++ style / lint notes

- The PR does not change rules in `docs/developer_guide/cpp_style.md`.
- CI runs the **C++ API Style Audit (warning only)** step.
- No correctness or build issues are indicated. Any audit findings remain warning-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->