### PR TITLE
[BugFix][CPU] Legalize BF16 arithmetic in the CPU pipeline

### DIFF
--- a/testing/python/cpu/test_tilelang_cpu_bf16_legalize.py
+++ b/testing/python/cpu/test_tilelang_cpu_bf16_legalize.py
@@ -1,0 +1,92 @@
+"""BF16 arithmetic is legalized before the CPU codegens see it.
+
+Host codegen legalizes BF16 storage to uint16 (``BF16StorageLegalize``), which
+assumes BF16 arithmetic was legalized earlier (``BF16ComputeLegalize``). The CPU
+pipeline did not run the latter, so any kernel whose lowering left a BF16
+conversion on a local buffer failed in storage legalization. The lowering tests
+reproduce that without a device for both CPU target kinds; the execution tests
+need an LLVM-enabled build.
+"""
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+from tvm import tirx
+
+
+def _widen(size):
+    @T.prim_func
+    def main(A: T.Tensor((size,), "bfloat16"), B: T.Tensor((size,), "float32")):
+        for i in T.Parallel(size):
+            B[i] = A[i].astype("float32") * T.float32(2)
+
+    return main
+
+
+def _tile_copy(size):
+    """The conversion comes from lowering a tile op, not from user arithmetic."""
+
+    @T.prim_func
+    def main(A: T.Tensor((size,), "bfloat16"), B: T.Tensor((size,), "float32")):
+        with T.Kernel(1, threads=1):
+            T.copy(A, B)
+
+    return main
+
+
+def _unlegalized(mod) -> list[str]:
+    """Conversions that storage legalization cannot have produced on purpose.
+
+    A cast to or from bfloat16 means the type survived; a cast between uint16
+    and a float means a BF16 conversion was left in place and now reads or
+    writes the raw bit pattern.
+    """
+    found = []
+
+    def visit(node):
+        if not isinstance(node, tirx.Cast):
+            return
+        source, target = str(node.value.dtype), str(node.dtype)
+        bf16 = source.startswith("bfloat16") or target.startswith("bfloat16")
+        bits = {source.split("x")[0], target.split("x")[0]} == {"uint16", "float32"}
+        if bf16 or bits:
+            found.append(f"{source} -> {target}")
+
+    for _, func in mod.functions.items():
+        tirx.stmt_functor.post_order_visit(func.body, visit)
+    return found
+
+
+@pytest.mark.parametrize("kind", ["c", "llvm"])
+@pytest.mark.parametrize("factory", [_widen, _tile_copy])
+def test_cpu_lowering_survives_storage_legalization(kind, factory):
+    from tilelang.backend.module import create_backend_context
+    from tilelang.engine.lower import lower_to_host_device_ir
+
+    context = create_backend_context(kind, None, "auto")
+    with tvm.transform.PassContext(), context.target:
+        host_mod, _, _, _, target_host = lower_to_host_device_ir(factory(8), context)
+        # What host codegen does next: without compute legalization this failed
+        # with "Cannot find var remap" or a uint16 store mismatch.
+        host_mod = tirx.transform.BindTarget(target_host)(host_mod)
+        legalized = tirx.transform.BF16StorageLegalize()(host_mod)
+    assert _unlegalized(legalized) == []
+
+
+@tilelang.testing.requires_llvm
+@pytest.mark.parametrize("factory,scale", [(_widen, 2), (_tile_copy, 1)])
+def test_llvm_bf16_widening_is_numerically_correct(factory, scale):
+    size = 64
+    kernel = tilelang.compile(factory(size), target="llvm")
+    a = torch.randn(size, dtype=torch.bfloat16)
+    b = torch.empty(size, dtype=torch.float32)
+    kernel(a, b)
+    torch.testing.assert_close(b, a.to(torch.float32) * scale, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/cpu/pipeline.py
+++ b/tilelang/cpu/pipeline.py
@@ -60,6 +60,10 @@ def CPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.Simplify()(mod)
     mod = tirx.transform.NarrowDataType(32)(mod)
     mod = tilelang.transform.FlattenBuffer()(mod)
+    # The CPU codegens have no native BF16. Host codegen legalizes BF16 storage
+    # to uint16, which requires BF16 arithmetic to have been legalized first;
+    # this is the point TVM's default pipeline runs it.
+    mod = tirx.transform.BF16ComputeLegalize()(mod)
     mod = tilelang.transform.ConfigIndexBitwidth()(mod)
     mod = tirx.transform.Simplify()(mod)
     mod = tilelang.transform.VectorizeLoop(enable_vectorize=allow_vectorize(pass_ctx=pass_ctx))(mod)


### PR DESCRIPTION
## Problem

BF16 kernels do not compile for the CPU backend. Any kernel whose lowering leaves a BF16 conversion on a local buffer (a vectorized `T.copy` from BF16 to FP32, a `DecoupleTypeCast` local, a pointwise kernel over a BF16 operand) fails in host codegen with `Cannot find var remap for A_local_cast_1` or `dtype mismatch on BufferStore: buffer's dtype is uint16 ... RHS's dtype is bfloat16`.

## Root cause

`host_codegen` in `tilelang/engine/lower.py` runs `BF16StorageLegalize` on the host module for every backend. That pass assumes `BF16ComputeLegalize` ran earlier, which is TVM's ordering (`python/tvm/s_tir/pipeline.py`: compute legalization right after `FlattenBuffer`, storage legalization after `MakePackedAPI`). No TileLang pipeline runs the compute pass. On GPU targets that is harmless because the device codegens emit BF16 natively and only the host stub is retyped. On the CPU backend the whole kernel is host code, so buffers become `uint16` with BF16 arithmetic still in place.

## Change

- `tilelang/cpu/pipeline.py`: run `tirx.transform.BF16ComputeLegalize()` in `CPUPassPipelineBody` immediately after `FlattenBuffer()`, TVM's own position, for both the `c` and `llvm` target kinds. The pass is target-gated inside TVM, so no other backend is affected.

Placing the pass earlier is wrong: run before `LowerTileOp` it breaks a BF16 `T.copy` (`Check failed: (load) is false`), and run before vectorization it leaves the legalized conversion scalar and duplicated per use.

## Tests

`testing/python/cpu/test_tilelang_cpu_bf16_legalize.py`:

- `test_cpu_lowering_survives_storage_legalization[{c,llvm} x {widen, tile_copy}]`: lowers through the CPU pipeline, then applies host codegen's `BindTarget` and `BF16StorageLegalize`, and asserts no cast to or from `bfloat16` and no cast between `uint16` and `float32` remains. Device-free.
- `test_llvm_bf16_widening_is_numerically_correct[{widen, tile_copy}]`: executes on LLVM and compares to torch, `rtol=0, atol=0`. Gated with `requires_llvm`.

## Validation

Apple M-series, macOS 15.

Metal-only build (`USE_METAL=ON`), this branch:

```
pytest testing/python/cpu testing/python/llvm    92 passed, 25 skipped (the skips are requires_llvm)
pytest testing/python/metal                       38 passed, 3 skipped
```

Build with `USE_METAL=ON USE_LLVM=ON` (LLVM 20.1.8), same change on our working branch:

```
pytest testing/python/cpu testing/python/llvm    120 passed (LLVM execution tests run, not skipped)
pytest testing/python/cpu/test_tilelang_cpu_bf16_legalize.py    all passed
```

Observed on the LLVM-enabled build and independent of this change: `testing/python/metal/test_metal_address_space.py::test_shared_alias_address_spaces_execute_on_metal[tvm_ffi]` segfaults, because `USE_LLVM=ON` makes `llvm` the default Metal host target and the `tvm_ffi` adapter JIT-compiles the host stub with it; the same test passes on a Metal-only build where the host target is `c`.

## Related

- A BF16 conversion bound to a variable (`b: T.float32 = T.Cast("float32", A[i])`, what the eager frontend emits for every assignment) still escapes legalization because `BF16ComputeLegalize` does not visit `Let` and `Bind` values. That is fixed in TileLang/tvm PR `[BugFix][TIRx] Legalize BF16 conversions inside Let and Bind values`; the test cases for bound values will come with the `3rdparty/tvm` bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Apply `tirx.transform.BF16ComputeLegalize()` in the CPU pass pipeline after `FlattenBuffer` for `c` and `llvm` targets.
- Add regression tests for CPU storage legalization and LLVM BF16 widening.
- Verify numerically correct LLVM widening results with PyTorch.
- CPU, LLVM, and Metal test suites passed. One unrelated Metal/LLVM host-target segmentation fault occurred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->