### PR TITLE
[Cleanup][Language] Remove dead T.Pipelined(sync/group) and T.gemm_sp(k_pack) parameters

### DIFF
--- a/src/ir.cc
+++ b/src/ir.cc
@@ -102,8 +102,6 @@ ForFrame ParallelFor(const Array<PrimExpr> &extents,
 ForFrame PipelinedFor(PrimExpr start, const PrimExpr &stop, int num_stages,
                       const Array<PrimExpr> &order,
                       const Array<PrimExpr> &stages,
-                      const Array<Array<PrimExpr>> &sync,
-                      const Array<Array<PrimExpr>> &groups,
                       const Map<String, Any> &annotations) {
   using namespace tvm::tirx;
   ObjectPtr<ForFrameNode> n = make_object<ForFrameNode>();
@@ -123,8 +121,6 @@ ForFrame PipelinedFor(PrimExpr start, const PrimExpr &stop, int num_stages,
       anno.Set("tl_pipeline_order", order);
     if (!stages.empty())
       anno.Set("tl_pipeline_stage", stages);
-    if (!groups.empty())
-      anno.Set("tl_pipeline_group", groups);
     Optional<PrimExpr> step =
         !steps.empty() ? steps[0] : Optional<PrimExpr>(std::nullopt);
     body = For(vars[0], doms[0]->min, doms[0]->extent, ForKind::kSerial, body,

--- a/tilelang/analysis/nested_loop_checker.py
+++ b/tilelang/analysis/nested_loop_checker.py
@@ -11,7 +11,7 @@ from tvm.tirx.transform import prim_func_pass
 def is_pipelined_for(op: For) -> bool:
     """Check if a for loop is pipelined."""
 
-    anno_keys = ["num_stages", "tl_pipeline_order", "tl_pipeline_stage", "tl_pipeline_group"]
+    anno_keys = ["num_stages", "tl_pipeline_order", "tl_pipeline_stage"]
     return any(key in op.annotations for key in anno_keys)
 
 

--- a/tilelang/language/experimental/gemm_sp_op.py
+++ b/tilelang/language/experimental/gemm_sp_op.py
@@ -29,7 +29,6 @@ def _gemm_sp_impl(
     transpose_B: bool = False,
     policy: GemmWarpPolicy = GemmWarpPolicy.Square,
     clear_accum: bool = False,
-    k_pack: int = 1,
     wg_wait: int = 0,
     annotations: dict | None = None,
 ) -> tirx.Call:
@@ -119,7 +118,10 @@ def _gemm_sp_impl(
         stride_b,
         offset_a,
         offset_b,
-        k_pack,
+        # k_pack call slot: parsed and validated on the C++ side but never
+        # consumed by any sparse-GEMM lowering; kept at 1 for protocol
+        # stability.
+        1,
         wg_wait,
         annotations=annotations,
     )
@@ -135,7 +137,6 @@ def gemm_sp(
     transpose_B: bool = False,
     policy: GemmWarpPolicy = GemmWarpPolicy.Square,
     clear_accum: bool = False,
-    k_pack: int = 1,
     wg_wait: int = 0,
     annotations: dict | None = None,
 ) -> tirx.Call:
@@ -158,7 +159,6 @@ def gemm_sp(
         transpose_B: Whether to transpose B. Defaults to False.
         policy: Warp partition policy. Defaults to GemmSPWarpPolicy.Square.
         clear_accum: Whether to zero the accumulator before computation. Defaults to False.
-        k_pack: Number of K dimensions packed per warp. Defaults to 1.
         wg_wait: Warp group wait count. Defaults to 0.
         annotations: Additional annotations.
 
@@ -176,7 +176,6 @@ def gemm_sp(
         transpose_B,
         policy,
         clear_accum,
-        k_pack,
         wg_wait,
         annotations=annotations,
     )
@@ -230,7 +229,6 @@ def wgmma_gemm_sp(
         transpose_B,
         policy,
         clear_accum,
-        1,
         -1,
         annotations=annotations,
     )
@@ -286,7 +284,6 @@ def tcgen05_gemm_sp(
         transpose_B,
         policy,
         clear_accum,
-        1,
         0,
         annotations=annotations,
     )

--- a/tilelang/language/loop.py
+++ b/tilelang/language/loop.py
@@ -115,8 +115,6 @@ def Pipelined(
     num_stages: int = 0,
     order: list[int] | None = None,
     stage: list[int] | None = None,
-    sync: list[list[int]] | None = None,
-    group: list[list[int]] | None = None,
     annotations: dict[str, Any] | None = None,
 ) -> frame.ForFrame:
     """Tools to construct pipelined for loop.
@@ -141,10 +139,6 @@ def Pipelined(
         Optional manual pipeline stage for each scheduled statement in the loop
         body. The list is aligned with ``order`` and follows the same statement
         counting rule.
-    sync : Optional[List[List[int]]]
-        Optional synchronization metadata for manual pipeline lowering.
-    group : Optional[List[List[int]]]
-        Optional producer grouping metadata for manual pipeline lowering.
     annotations : Optional[Dict[str, Any]]
         Additional loop annotations.
 
@@ -186,14 +180,10 @@ def Pipelined(
         order = []
     if stage is None:
         stage = []
-    if sync is None:
-        sync = []
-    if group is None:
-        group = []
     if annotations is None:
         annotations = {}
     # type: ignore[attr-defined] # pylint: disable=no-member
-    return _ffi_api.Pipelined(start, stop, num_stages, order, stage, sync, group, annotations)
+    return _ffi_api.Pipelined(start, stop, num_stages, order, stage, annotations)
 
 
 def serial(


### PR DESCRIPTION
An audit of the language surface (follow-up to #3186) found keyword parameters that are accepted but consumed by nothing in the compiler. Passing them silently did nothing; after this change they fail loudly with a `TypeError` at trace time.

- **`T.Pipelined(sync=...)`** — forwarded to `PipelinedFor`, which never turned it into an annotation; no `tl_pipeline_sync` key exists anywhere in the codebase.
- **`T.Pipelined(group=...)`** — attached as `tl_pipeline_group`, but no transform reads the value. The only sightings are the nested-loop checker listing the key and the warp-specialize pass stripping every `tl_pipeline_*` key by prefix. The key emission and the checker entry are removed together with the parameter.
- **`T.gemm_sp(k_pack=...)`** — parsed and range-checked on the C++ side (`src/op/gemm_sp.cc`) but never consumed by any sparse-GEMM lowering, unlike dense `T.gemm` where `k_pack` drives the ROCm MFMA path. The serialized call slot keeps the constant `1`, so the tile-op call protocol and the C++ parser are unchanged.

Deliberately **not** touched, with reasons established during the audit:
- `annotations=` on `fill`/`clear`/`cumsum`/`cummax`/`transpose`: alive at the Call-node level — `T.fill(..., annotations={T.WSID: ...})` feeds the warp-specialize scheduler, and the scan tests assert the annotations appear in the script.
- `T.gemm`'s `stride_a/b`, `offset_a/b` serialized slots: deprecated but kept for out-of-tree call-protocol compatibility.

Validation: native build; `./format.sh` and `git diff --check` clean; `testing/python/{language,transform,cpu,analysis}` plus the pipeline/warp-specialize/gemm_sp suites: **2080 passed, 47 skipped** (3 pre-existing fp16 `test_reduce` cases and the device-dependent `test_grid_sync` on this machine deselected, unrelated).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed unused `sync` and `group` parameters from `T.Pipelined`.
- Removed unused `k_pack` from `T.gemm_sp`.
- Removed `tl_pipeline_group` emission and nested-loop detection.
- Preserved the sparse GEMM protocol slot with constant `1`.
- Preserved existing operation annotations and deprecated `T.gemm` stride and offset slots.
- Validation passed: native build, formatting and whitespace checks, and 2080 tests with 47 skipped.

## C++ style / lint notes

- The PR changes a C++ API declaration in `src/ir.cc`.
- It does not change rules documented in `docs/developer_guide/cpp_style.md`.
- The `C++ API Style Audit (warning only)` CI step remains applicable.
- No correctness, build, or test issues were identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->