### PR TITLE
[CUDA] Fuse exact FP4 to FP8 conversion through FP32

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -1706,6 +1706,51 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
   bool cast_sat = get_bool_anno("sat", true);
   Optional<PrimExpr> cast_rbits = get_expr_anno("rbits");
 
+  // The FP32 intermediate preserves every E2M1 value, including signed zero.
+  // Emit packed E4M3 encodings directly for this exact conversion chain.
+  const auto *inner_cast = op->value.as<CastNode>();
+  if (inner_cast && op->annotations.empty() &&
+      inner_cast->annotations.empty() && from_ty.is_float() &&
+      from_ty.bits() == 32 && inner_cast->value.dtype().is_float4_e2m1fn() &&
+      (target_ty.is_float8_e4m3() || target_ty.is_float8_e4m3fn())) {
+    DataType packed_ty = inner_cast->value.dtype();
+    int lanes = packed_ty.lanes();
+    if (lanes == 1) {
+      this->PrintType(target_ty, os);
+      os << "::bitcast(static_cast<uint8_t>(__tl_cvt_e2m1x4_to_e4m3x4(("
+         << PrintExpr(inner_cast->value) << ").__x)))";
+      return;
+    }
+    if (lanes == 2 || lanes == 4 || lanes == 8 || lanes == 16 || lanes == 32) {
+      std::string packed = SSAGetID(PrintExpr(inner_cast->value), packed_ty);
+      std::string result = name_supply_->FreshName("fp8_cast");
+      PrintIndent();
+      PrintType(target_ty, stream);
+      stream << " " << result << ";\n";
+      for (int first_lane = 0; first_lane < lanes; first_lane += 4) {
+        std::string converted = name_supply_->FreshName("fp8_bits");
+        PrintIndent();
+        stream << "uint32_t " << converted << " = __tl_cvt_e2m1x4_to_e4m3x4("
+               << "reinterpret_cast<const uint8_t*>(&" << packed << ")["
+               << first_lane / 2 << "]";
+        if (first_lane + 2 < lanes) {
+          stream << " | (uint16_t(reinterpret_cast<const uint8_t*>(&" << packed
+                 << ")[" << first_lane / 2 + 1 << "]) << 8)";
+        }
+        stream << ");\n";
+        for (int lane = first_lane; lane < first_lane + 4 && lane < lanes;
+             ++lane) {
+          PrintIndent();
+          stream << "reinterpret_cast<uint8_t*>(&" << result << ")[" << lane
+                 << "] = static_cast<uint8_t>(" << converted << " >> "
+                 << (lane - first_lane) * 8 << ");\n";
+        }
+      }
+      os << result;
+      return;
+    }
+  }
+
   // Scalar fp8 <-> half via the __tl_cvt helpers; the default cast detours
   // through fp32.
   if (from_ty.is_scalar() && cast_round.empty() && target_ty.is_float16() &&

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -1717,7 +1717,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
     int lanes = packed_ty.lanes();
     if (lanes == 1) {
       this->PrintType(target_ty, os);
-      os << "::bitcast(static_cast<uint8_t>(__tl_cvt_e2m1x4_to_e4m3x4(("
+      os << "::bitcast(static_cast<uint8_t>(ConvertE2M1x4ToE4M3x4(("
          << PrintExpr(inner_cast->value) << ").__x)))";
       return;
     }
@@ -1730,7 +1730,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
       for (int first_lane = 0; first_lane < lanes; first_lane += 4) {
         std::string converted = name_supply_->FreshName("fp8_bits");
         PrintIndent();
-        stream << "uint32_t " << converted << " = __tl_cvt_e2m1x4_to_e4m3x4("
+        stream << "uint32_t " << converted << " = ConvertE2M1x4ToE4M3x4("
                << "reinterpret_cast<const uint8_t*>(&" << packed << ")["
                << first_lane / 2 << "]";
         if (first_lane + 2 < lanes) {

--- a/src/tl_templates/cuda/cuda_fp4.h
+++ b/src/tl_templates/cuda/cuda_fp4.h
@@ -127,7 +127,7 @@ template <typename V, typename... Ts> TL_DEVICE V make_fp4_vec(Ts... lanes) {
 
 // E2M1 magnitudes are exactly representable in E4M3. Each register table
 // contains four magnitude encodings; the second permutation spreads signs.
-TL_DEVICE uint32_t __tl_cvt_e2m1x4_to_e4m3x4(uint16_t packed) {
+TL_DEVICE uint32_t ConvertE2M1x4ToE4M3x4(uint16_t packed) {
   uint32_t magnitude = __byte_perm(0x3c383000, 0x4c484440, packed & 0x7777);
   uint32_t signs = (__byte_perm(packed, packed >> 4, 0x5140) & 0x08080808) << 4;
   return magnitude | signs;

--- a/src/tl_templates/cuda/cuda_fp4.h
+++ b/src/tl_templates/cuda/cuda_fp4.h
@@ -125,6 +125,14 @@ template <typename V, typename... Ts> TL_DEVICE V make_fp4_vec(Ts... lanes) {
 }
 } // namespace tl
 
+// E2M1 magnitudes are exactly representable in E4M3. Each register table
+// contains four magnitude encodings; the second permutation spreads signs.
+TL_DEVICE uint32_t __tl_cvt_e2m1x4_to_e4m3x4(uint16_t packed) {
+  uint32_t magnitude = __byte_perm(0x3c383000, 0x4c484440, packed & 0x7777);
+  uint32_t signs = (__byte_perm(packed, packed >> 4, 0x5140) & 0x08080808) << 4;
+  return magnitude | signs;
+}
+
 // ============================================================================
 // FP4 <-> Half Precision Conversions
 // ============================================================================

--- a/testing/python/language/test_tilelang_language_vectorized_cast.py
+++ b/testing/python/language/test_tilelang_language_vectorized_cast.py
@@ -187,7 +187,7 @@ def test_fp4_fp32_fp8_codegen(lanes, destination):
     func = func.with_attr("global_symbol", "fp4_fp8_cast")
     func = func.with_attr("calling_conv", tvm.ir.CallingConv.DEVICE_KERNEL_LAUNCH)
     source = build(tvm.IRModule({"fp4_fp8_cast": func}), tvm.target.Target("cuda")).inspect_source()
-    assert source.count("__tl_cvt_e2m1x4_to_e4m3x4(") == max(1, lanes // 4)
+    assert source.count("ConvertE2M1x4ToE4M3x4(") == max(1, lanes // 4)
     assert "__tl_cvt_fp4x2_to_float2" not in source
     assert "__nv_cvt_float2_to_fp8x2" not in source
 
@@ -198,7 +198,7 @@ def test_fp4_fp32_fp8_codegen(lanes, destination):
             annotated = tirx.Cast(destination + suffix, intermediate, annotations if annotation_owner == "outer" else None)
             annotated_func = func.with_body(tirx.Evaluate(annotated))
             annotated_source = build(tvm.IRModule({"fp4_fp8_cast": annotated_func}), tvm.target.Target("cuda")).inspect_source()
-            assert "__tl_cvt_e2m1x4_to_e4m3x4" not in annotated_source
+            assert "ConvertE2M1x4ToE4M3x4" not in annotated_source
             assert "__tl_cvt_fp4x2_to_float2" in annotated_source
             assert "__nv_cvt_float2_to_fp8x2" in annotated_source
 
@@ -224,7 +224,7 @@ def test_fp4_fp32_fp8_exact(lanes):
     # Every four-nibble word exercises magnitude, sign, and lane ordering.
     elements = 65536 * 4
     kernel = tilelang.compile(fp4_fp32_fp8_kernel(elements, lanes), pass_configs={"tirx.disable_vectorize": lanes == 1})
-    assert "__tl_cvt_e2m1x4_to_e4m3x4" in kernel.get_kernel_source()
+    assert "ConvertE2M1x4ToE4M3x4" in kernel.get_kernel_source()
     words = torch.arange(65536, dtype=torch.int32, device="cuda")[:, None]
     packed = ((words >> torch.tensor([0, 8], device="cuda")) & 255).to(torch.uint8).flatten()
     nibbles = ((words >> torch.tensor([0, 4, 8, 12], device="cuda")) & 15).flatten().long()

--- a/testing/python/language/test_tilelang_language_vectorized_cast.py
+++ b/testing/python/language/test_tilelang_language_vectorized_cast.py
@@ -2,6 +2,8 @@ import pytest
 import torch
 import tilelang.testing
 import tilelang.language as T
+from tilelang import tvm
+from tvm import tirx
 
 
 @tilelang.jit
@@ -169,6 +171,71 @@ def test_vectorized_cast_fp4(src_dtype, dst_dtype, check_str, lanes):
 )
 def test_vectorized_cast_fp8_bf16(src_dtype, dst_dtype, check_str, lanes):
     run_vectorized_cast(src_dtype, dst_dtype, check_str, lanes)
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("lanes", [1, 2, 4, 8, 16, 32])
+@pytest.mark.parametrize("destination", ["float8_e4m3", "float8_e4m3fn"])
+def test_fp4_fp32_fp8_codegen(lanes, destination):
+    build = tvm.get_global_func("target.build.tilelang_cuda_without_compile", allow_missing=True)
+    if build is None:
+        pytest.skip("TileLang was built without the CUDA code generator")
+    suffix = f"x{lanes}" if lanes > 1 else ""
+    value = tirx.Var("value", "float4_e2m1fn" + suffix)
+    converted = tirx.Cast(destination + suffix, tirx.Cast("float32" + suffix, value))
+    func = tirx.PrimFunc([value], tirx.Evaluate(converted))
+    func = func.with_attr("global_symbol", "fp4_fp8_cast")
+    func = func.with_attr("calling_conv", tvm.ir.CallingConv.DEVICE_KERNEL_LAUNCH)
+    source = build(tvm.IRModule({"fp4_fp8_cast": func}), tvm.target.Target("cuda")).inspect_source()
+    assert source.count("__tl_cvt_e2m1x4_to_e4m3x4(") == max(1, lanes // 4)
+    assert "__tl_cvt_fp4x2_to_float2" not in source
+    assert "__nv_cvt_float2_to_fp8x2" not in source
+
+    if lanes == 2:
+        for annotation_owner in ("inner", "outer"):
+            annotations = {"sat": tirx.IntImm("bool", 1)}
+            intermediate = tirx.Cast("float32" + suffix, value, annotations if annotation_owner == "inner" else None)
+            annotated = tirx.Cast(destination + suffix, intermediate, annotations if annotation_owner == "outer" else None)
+            annotated_func = func.with_body(tirx.Evaluate(annotated))
+            annotated_source = build(tvm.IRModule({"fp4_fp8_cast": annotated_func}), tvm.target.Target("cuda")).inspect_source()
+            assert "__tl_cvt_e2m1x4_to_e4m3x4" not in annotated_source
+            assert "__tl_cvt_fp4x2_to_float2" in annotated_source
+            assert "__nv_cvt_float2_to_fp8x2" in annotated_source
+
+
+def fp4_fp32_fp8_kernel(elements, lanes):
+    tile = 128 * lanes
+
+    @T.prim_func
+    def main(A: T.Tensor((elements,), "float4_e2m1fn"), B: T.Tensor((elements,), "float8_e4m3fn")):
+        with T.Kernel(elements // tile, threads=128) as block:
+            for i in T.Parallel(tile):
+                index = block * tile + i
+                B[index] = T.Cast("float8_e4m3fn", T.Cast("float32", A[index]))
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(8, 9)
+@pytest.mark.skipif(not hasattr(torch, "float4_e2m1fn_x2"), reason="PyTorch packed FP4 dtype is unavailable")
+@pytest.mark.parametrize("lanes", [1, 2, 4, 8])
+def test_fp4_fp32_fp8_exact(lanes):
+    # Every four-nibble word exercises magnitude, sign, and lane ordering.
+    elements = 65536 * 4
+    kernel = tilelang.compile(fp4_fp32_fp8_kernel(elements, lanes), pass_configs={"tirx.disable_vectorize": lanes == 1})
+    assert "__tl_cvt_e2m1x4_to_e4m3x4" in kernel.get_kernel_source()
+    words = torch.arange(65536, dtype=torch.int32, device="cuda")[:, None]
+    packed = ((words >> torch.tensor([0, 8], device="cuda")) & 255).to(torch.uint8).flatten()
+    nibbles = ((words >> torch.tensor([0, 4, 8, 12], device="cuda")) & 15).flatten().long()
+    values = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+        device="cuda",
+    )
+    expected = values[nibbles].to(torch.float8_e4m3fn).view(torch.uint8)
+    output = torch.empty(elements, dtype=torch.float8_e4m3fn, device="cuda")
+    kernel(packed.view(torch.float4_e2m1fn_x2), output)
+    assert torch.equal(output.view(torch.uint8), expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

The [DeepSeek V4.1 expert GEMM](https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash/blob/dba1be0a40aa45a94ad051997016db3960a90277/inference/kernel.py#L477-L559) converts E2M1 weights through FP32 into E4M3 on every K tile. Every E2M1 value, including signed zero, has an exact E4M3 encoding.

## Implementation

I fuse this unannotated CUDA cast chain into two `__byte_perm` operations per four elements. The code handles scalars and vector widths 2, 4, 8, 16, and 32. Explicit cast annotations retain their existing lowering. The conversion uses registers and adds no global or shared-memory allocation.

## Validation

- Native source-generation tests cover both E4M3 dtype spellings, all supported widths, and explicit annotations.
- The [upstream H100 job](https://github.com/tile-ai/tilelang/actions/runs/34607356388/job/103289438636) passed the source-generation cases and all four exhaustive PyTorch runtime cases. Each runtime case checks every packed four-nibble word against an independent encoding table. The subsequent helper rename preserves the generated CUDA operations; the renamed source-generation cases and CUDA compilation pass.
- The extracted GEMM produces identical BF16 outputs in every configuration below. An independent sampled CPU reference also passes.
- Project hooks pass for all three contribution files. Current-head CUDA, ROCm, Metal, and CuTeDSL CI checks pass.

## H100 performance

The benchmark uses the linked GEMM with `T.symbolic` adapted to `T.dynamic`: 128 threads, tiles of 32 by 128 by 32, two pipeline stages, 10,240 bytes of shared memory, FP32 accumulation, and BF16 output. The consumer pins TileLang 0.1.8; the benchmark uses compiler `c629fe5e` and this patch. Baseline CUDA source matches the unmodified compiler's output.

Both variants run on the same H100 80 GB HBM3 with CUDA 13.0, targeting `sm_90a`, and use identical inputs and power-of-two scales. Each graph contains 100 calls. Values are per-call medians from ten retained alternating-order CUDA-event measurements after warmup.

| M | N | K | Baseline (µs) | This PR (µs) |
|---:|---:|---:|---:|---:|
| 1 | 2,304 | 5,120 | 547.94 | 108.65 |
| 8 | 2,304 | 5,120 | 549.32 | 108.59 |
| 32 | 2,304 | 5,120 | 550.15 | 111.02 |
| 128 | 2,304 | 5,120 | 551.82 | 107.71 |
| 512 | 2,304 | 5,120 | 717.30 | 224.21 |
| 2,048 | 2,304 | 5,120 | 2,069.77 | 641.31 |
| 1 | 5,120 | 2,304 | 245.17 | 45.85 |
| 8 | 5,120 | 2,304 | 245.16 | 45.60 |
| 32 | 5,120 | 2,304 | 244.54 | 46.31 |
| 128 | 5,120 | 2,304 | 292.08 | 70.83 |
| 512 | 5,120 | 2,304 | 586.63 | 157.61 |
| 2,048 | 5,120 | 2,304 | 1,760.22 | 591.92 |

Register usage is 128 for the baseline and 156 for this PR; both have zero spills. These measurements cover the complete extracted GEMM under graph replay. Blackwell execution and complete-model serving remain unverified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fuses the default CUDA `FP4 E2M1 → FP32 → FP8 E4M3` conversion into direct `__tl_cvt` intrinsics.
- Supports scalar values and vector widths 2, 4, 8, 16, and 32.
- Preserves explicitly annotated cast behavior.
- Registers the conversion as CUDA-vectorizable.
- Adds source-generation and exhaustive packed-value correctness tests.
- Uses registers without global or shared-memory allocations.

## Performance

- H100 expert GEMM measurements show 2.97x–5.38x speedups across twelve configurations.
- The fused path produces no spills.
- Register usage increases from 128 to 156 registers.

## C++ style / lint notes

- The PR changes C++ code and a CUDA kernel template.
- It does not modify rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains relevant.
- No correctness or build issue is identified in the supplied evidence.
- TLCPP003/TLCPP004 findings are advisory and should not block merging without a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
