### PR TITLE
[BugFix][Language] Make T.clamp propagate NaN

### DIFF
--- a/testing/python/language/test_tilelang_language_clamp.py
+++ b/testing/python/language/test_tilelang_language_clamp.py
@@ -115,6 +115,60 @@ def test_clamp():
     run_clamp_value_range(1024, 128, T.float32)
 
 
+CLAMP_NAN_DTYPES = [
+    T.float16,
+    T.bfloat16,
+    T.float32,
+    T.float64,
+    T.float8_e4m3,
+    T.float8_e5m2,
+]
+
+
+def clamp_nan_kernel(N, block_N, dtype):
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        C: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), threads=block_N) as bx:
+            for i in T.Parallel(block_N):
+                C[bx * block_N + i] = T.clamp(A[bx * block_N + i], T.cast(-1.0, dtype), T.cast(1.0, dtype))
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", CLAMP_NAN_DTYPES)
+def test_clamp_propagates_nan(dtype):
+    """``T.clamp`` must propagate ``NaN`` the way ``torch.clamp`` does.
+
+    ``T.clamp`` composes ``T.min(T.max(...))``, and on CUDA those lower to the
+    ``fmaxf``/``fminf`` family, which returns the non-``NaN`` operand. Without an
+    explicit re-injection a ``NaN`` input silently becomes ``min_val``.
+    """
+    import torch
+
+    N = 32
+    kernel = tilelang.compile(clamp_nan_kernel(N, N, dtype))
+    torch_dtype = dtype.as_torch()
+
+    a = torch.linspace(-2.0, 2.0, N, device="cuda", dtype=torch.float32)
+    a[7] = float("nan")
+    a = a.to(torch_dtype)
+
+    # Caller-allocated output: rebuilding a torch tensor from an fp8 DLPack
+    # tensor is not supported on every torch version.
+    C = torch.empty(N, device="cuda", dtype=torch_dtype)
+    kernel(a, C)
+    got = C.float()
+
+    assert torch.isnan(got[7]).item(), f"T.clamp dropped NaN for {dtype}: got {got[7].item()} instead of NaN"
+    ref = torch.clamp(a.float(), -1.0, 1.0)
+    finite = ~torch.isnan(ref)
+    torch.testing.assert_close(got[finite], ref[finite], atol=0, rtol=0)
+
+
 FP8_OPS = {
     "max": lambda a, b, dtype: T.max(a, b),
     "min": lambda a, b, dtype: T.min(a, b),

--- a/tilelang/language/customize.py
+++ b/tilelang/language/customize.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from tilelang._typing import ShapeType, DType, BufferLikeType
 import tilelang.language as T
-from tvm import arith
+from tvm import DataType, DataTypeCode, arith
 from tvm.tirx import PrimExpr, Buffer, op
 from tilelang.utils.language import bits_product, prim_expr_equal, retrieve_buffer_and_offset
 from .atomic import atomic_max, atomic_min, atomic_add, atomic_addx2, atomic_addx4, atomic_load, atomic_or, atomic_store  # noqa: F401
@@ -41,8 +41,23 @@ def dp4a(A: BufferLikeType, B: BufferLikeType, C: BufferLikeType) -> PrimExpr:
     )
 
 
+_NON_FLOAT_TYPE_CODES = (
+    DataTypeCode.INT,
+    DataTypeCode.UINT,
+    DataTypeCode.BOOL,
+    DataTypeCode.HANDLE,
+)
+
+
 def clamp(dst: PrimExpr, min_val: PrimExpr, max_val: PrimExpr) -> PrimExpr:
     """Clamps the input value dst between [min_val, max_val]
+
+    A ``NaN`` input yields ``NaN``, matching ``torch.clamp`` and ``numpy.clip``.
+    ``T.max``/``T.min`` lower to the CUDA ``fmaxf``/``fminf`` family, which return
+    the non-``NaN`` operand, so the composition below would otherwise replace a
+    ``NaN`` with ``min_val`` silently. Only floating-point dtypes can hold a
+    ``NaN``, and ``tir.isnan`` is not implemented for every one of them, so the
+    predicate is evaluated on an ``fp32`` cast, which preserves ``NaN``.
 
     Args:
         dst: Input value to be clamped
@@ -52,9 +67,10 @@ def clamp(dst: PrimExpr, min_val: PrimExpr, max_val: PrimExpr) -> PrimExpr:
     Returns:
         Value clamped to the specified range
     """
-    dst = T.max(dst, min_val)  # Ensure value is not less than minimum
-    dst = T.min(dst, max_val)  # Ensure value is not greater than maximum
-    return dst
+    clamped = T.min(T.max(dst, min_val), max_val)
+    if DataType(dst.dtype).type_code in _NON_FLOAT_TYPE_CODES:
+        return clamped
+    return T.if_then_else(T.isnan(T.cast(dst, "float32")), dst, clamped)
 
 
 def reshape(src: Buffer, shape: ShapeType) -> Buffer:


### PR DESCRIPTION
## Summary

Fixes #3024.

`T.clamp` was `T.min(T.max(x, lo), hi)`. On CUDA those lower to the `fmaxf`/`fminf` family, which returns the *non*-NaN operand, so `T.clamp(NaN, lo, hi)` silently returned `lo` — a wrong value with no error — where `torch.clamp` and `numpy.clip` both propagate `NaN`:

```
T.clamp : [-1.0, 1.0, 0.5, -1.0]
torch   : [nan, 1.0, 0.5, -1.0]
```

The composition now re-injects an input `NaN`:

```python
clamped = T.min(T.max(dst, min_val), max_val)
if DataType(dst.dtype).type_code in _NON_FLOAT_TYPE_CODES:
    return clamped
return T.if_then_else(T.isnan(T.cast(dst, "float32")), dst, clamped)
```

Two details worth flagging:

- `tir.isnan` is implemented for only a subset of the float dtypes — it raises `InternalError: Data type bfloat16 not supported for isnan op` for `bfloat16`, `float8_e4m3` and `float8_e5m2`. The predicate is therefore evaluated on an `fp32` cast, which preserves `NaN`, instead of on `dst` directly. Without that, the naive `T.isnan(dst)` version breaks the four existing fp8 clamp tests.
- Dtypes that cannot hold a `NaN` skip the guard, so integer kernels are unchanged and do not grow an int→float cast.

`T.max`/`T.min` themselves are deliberately untouched. As the issue notes, their `fmaxf`/`fminf` behaviour is arguable for softmax-style `m_i = T.max(m_i, ...)` accumulators, and whether they should propagate is a separate call; this PR fixes `clamp`, which has no such excuse because it is specified against `torch.clamp`/`numpy.clip`.

## Test plan

Added `test_clamp_propagates_nan` to `testing/python/language/test_tilelang_language_clamp.py`, parametrized over `float16`, `bfloat16`, `float32`, `float64`, `float8_e4m3` and `float8_e5m2`. Each case puts one `NaN` in the input and asserts it survives, then checks the finite elements exactly against `torch.clamp`.

Hardware: NVIDIA A100-PCIE-40GB (sm80), CUDA 12.8, torch 2.8.0+cu128, tilelang 0.1.14 wheel. The issue reported on sm_89; this reproduces and fixes identically on sm80, which is consistent with the claim that the behaviour comes from the `fmaxf`/`fminf` semantics rather than anything architecture-specific.

A/B on the same machine, same test file:

| | result |
|---|---|
| before the fix | `6 failed, 11 passed` — the new test fails for all six dtypes; the 11 pre-existing tests pass |
| after the fix | `17 passed` |

I also ran a probe outside the test file to confirm the guard does not disturb the integer paths: `T.clamp` on `int32`, `int8` and `uint8` still compiles and matches `torch.clamp` exactly.

`ruff check` and `ruff format --check` are clean on both changed files.

## Notes

- Not a regression: `clamp` has had this body since #192, as the issue reports.
- The five shipped fp8 quantization examples that call `T.clamp` (`examples/cast/example_per_token_cast_to_fp8.py`, `example_group_per_split_token_cast_to_fp8.py`, `examples/deepseek_v32/inference/kernel.py`, `examples/deepseek_v4/act_quant.py`) call it on `fp32` values before casting to `fp8`, so they now surface a `NaN` instead of quantizing it to `fp8_min`. Their shipped tests use finite inputs and are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed `T.clamp` to propagate floating-point `NaN` values.
- Preserved finite-value clamping and existing integer behavior.
- Added regression coverage for fp16, bf16, fp32, fp64, and supported FP8 types.
- Verified finite outputs against `torch.clamp`.
- Kept `T.min` and `T.max` unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->