### PR TITLE
[BugFix][CUDA] Lower a kernel-body assert to a device-legal check

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -5292,6 +5292,26 @@ void CodeGenTileLangCUDA::VisitStmt_(const AllocBufferNode *op) {
   RegisterHandleType(op->buffer->data.get(), alloc_dtype);
 }
 
+void CodeGenTileLangCUDA::VisitStmt_(const AssertStmtNode *op) {
+  // Every function this codegen emits is a __global__ kernel, so a tirx
+  // AssertStmt has to lower to the device-legal helper. The inherited CodeGenC
+  // visitor streams a host-only TVMFFI error call plus `return -1`, neither of
+  // which is valid inside a kernel.
+  std::string cond = PrintExpr(op->condition);
+  this->PrintIndent();
+  if (op->message_parts.empty()) {
+    stream << "device_assert(" << cond << ");\n";
+    return;
+  }
+  std::string joined_msg;
+  for (const auto &part : op->message_parts) {
+    joined_msg += part->value;
+  }
+  stream << "device_assert_with_msg(" << cond << ", ";
+  PrintEscapedCString(joined_msg, stream);
+  stream << ");\n";
+}
+
 void CodeGenTileLangCUDA::VisitStmt_(const EvaluateNode *op) {
   if (is_const_int(op->value))
     return;

--- a/src/cuda/codegen/codegen_cuda.h
+++ b/src/cuda/codegen/codegen_cuda.h
@@ -59,6 +59,7 @@ public:
   void VisitExpr_(const MinNode *op, std::ostream &os) final;
   void VisitExpr_(const MaxNode *op, std::ostream &os) final;
   void VisitExpr_(const NotNode *op, std::ostream &os) final;
+  void VisitStmt_(const AssertStmtNode *op) final;
   void VisitStmt_(const EvaluateNode *op) final;
   void VisitStmt_(const AllocBufferNode *op) final;
   void VisitStmt_(const AttrStmtNode *op) final;

--- a/testing/python/debug/test_device_assert.py
+++ b/testing/python/debug/test_device_assert.py
@@ -16,5 +16,49 @@ def test_device_assert_no_trigger():
     profiler.run_once()
 
 
+def test_kernel_body_assert_compiles_and_runs():
+    """A plain ``assert`` in a kernel body must lower to a device-legal check.
+
+    The TVMScript parser turns it into a ``tirx.AssertStmt``. The CUDA codegen used
+    to fall through to the inherited host visitor for that node, which streams a
+    ``TVMFFIErrorSetRaisedFromCStrParts`` call, a host-only symbol, plus
+    ``return -1`` into the ``__global__`` kernel, so the kernel failed to build.
+    """
+    import torch
+
+    @T.prim_func
+    def program(A: T.Tensor((128,), "float32"), B: T.Tensor((128,), "float32")):
+        with T.Kernel(1, threads=128):
+            tid = T.get_thread_binding()
+            assert tid < 128, "oob thread"
+            B[tid] = A[tid] + T.float32(1)
+
+    jit_kernel = tilelang.compile(program, out_idx=[1])
+    a = torch.arange(128, dtype=torch.float32, device="cuda")
+    b = jit_kernel(a)
+    assert torch.equal(b, a + 1)
+
+
+def test_kernel_body_assert_without_message_compiles():
+    """The message-less form takes the same ``AssertStmt`` path.
+
+    The parser attaches a default message part, so it does not reach the
+    message-less branch of the base visitor either.
+    """
+    import torch
+
+    @T.prim_func
+    def program(A: T.Tensor((128,), "float32"), B: T.Tensor((128,), "float32")):
+        with T.Kernel(1, threads=128):
+            tid = T.get_thread_binding()
+            assert tid < 128
+            B[tid] = A[tid] + T.float32(2)
+
+    jit_kernel = tilelang.compile(program, out_idx=[1])
+    a = torch.arange(128, dtype=torch.float32, device="cuda")
+    b = jit_kernel(a)
+    assert torch.equal(b, a + 2)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

Fixes #3019.

A plain `assert` in a kernel body is a first-class TVMScript statement: the parser lowers it to a `tirx.AssertStmt`. `CodeGenTileLangCUDA` did not override the `AssertStmt` visitor, so it inherited `CodeGenC`'s, which streams a **host-only** error-reporting call into the emitted kernel:

```cuda
extern "C" __global__ void __launch_bounds__(128, 1) main_kernel(...) {
    if (!((bool)1)) {
      const char* __tvm_assert_parts[1] = {"oob thread"};
      TVMFFIErrorSetRaisedFromCStrParts("RuntimeError", __tvm_assert_parts, 1);
      return -1;
    }
    ...
```

`TVMFFIErrorSetRaisedFromCStrParts` has no `__device__` definition, so nvcc rejects the file with `identifier "TVMFFIErrorSetRaisedFromCStrParts" is undefined`, and `return -1` returns a value from a `void` kernel. A valid kernel simply refused to build.

The CUDA backend now overrides the visitor and lowers the statement to the device-legal helpers that already exist and that the `T.device_assert` intrinsic path uses (`src/tl_templates/cuda/debug.h`, `TL_DEVICE void device_assert` / `device_assert_with_msg`):

```cpp
void CodeGenTileLangCUDA::VisitStmt_(const AssertStmtNode *op) {
  std::string cond = PrintExpr(op->condition);
  this->PrintIndent();
  if (op->message_parts.empty()) {
    stream << "device_assert(" << cond << ");\n";
    return;
  }
  std::string joined_msg;
  for (const auto &part : op->message_parts) {
    joined_msg += part->value;
  }
  stream << "device_assert_with_msg(" << cond << ", ";
  PrintEscapedCString(joined_msg, stream);
  stream << ");\n";
}
```

Why the override cannot misroute a host-side assert: `CodeGenTileLangCUDA::PrintFuncPrefix` unconditionally emits `extern "C" __global__ `, so every function this codegen produces is a device kernel. Host code is emitted by the separate `codegen_c_host.cc`, which keeps its own `AssertStmt` visitor (and so does the CPU backend, `codegen_c.cc`).

Note the message-less form (`assert cond`) takes the same path — the parser attaches a default message part, so it never reaches the base visitor's device-legal `else` branch either. Both forms are fixed here.

## Test plan

Added two tests to `testing/python/debug/test_device_assert.py`, next to the existing `T.device_assert` coverage: one with a message, one without. Each compiles the kernel, runs it and checks the result.

Hardware: NVIDIA A100-PCIE-40GB (sm80), CUDA 12.8, tilelang built from source at `66c003c` (the C++ change has to be compiled, so the pip wheel cannot exercise it).

A/B, same machine, same source tree:

| case | before | after |
|---|---|---|
| `assert cond, "oob thread"` | build fails: `TVMFFIErrorSetRaisedFromCStrParts` undefined | compiles and runs, result matches |
| `assert cond` (no message) | build fails: same symbol | compiles and runs, result matches |
| control: `T.device_assert(cond, "oob thread")` | compiles and runs | compiles and runs |

Regressions run on the same build:

- `testing/python/debug/` — 130 passed, 1 skipped
- `testing/python/issue/test_tilelang_issue_2307.py` — 1 passed
- `testing/python/jit/` — 49 passed, 23 skipped, 5 failed. All five failures are in `test_tilelang_jit_nvrtc.py` and are environmental: they abort before compiling anything with `ValueError: Execution backend 'nvrtc' requires extra dependencies and is not available now. Try one of: tvm_ffi, cython.`
- `testing/python/language/test_tilelang_language_frontend_v2.py` — 185 passed
- `ruff check` and `ruff format --check` clean on the changed Python file; `clang-format` (repo `.clang-format`, LLVM style) reports no changes on either C++ file

## Notes

- Not a regression: the inherited visitor has been unguarded for device targets across the releases the issue tested; the emitted host symbol changed with the tvm-ffi migration, the defect did not.
- The sibling backends already handle this — `CodeGenTileLangPY` (`codegen_py.cc`) and the CPU/host codegens have their own `AssertStmt` overrides — so the CUDA backend was the one missing the guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Override CUDA lowering for `AssertStmtNode`.
- Emit device-safe `device_assert` and `device_assert_with_msg` calls.
- Prevent host-only symbols and invalid `return -1` statements in CUDA kernels.
- Add CUDA regression tests for assertions with and without messages.

## C++ style / lint notes

- The PR changes C++ code but does not modify `docs/developer_guide/cpp_style.md`.
- The repository includes a warning-only `C++ API Style Audit` CI step.
- Current audit findings and test execution results were not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->