### PR TITLE
[BugFix][Metal] Use unique host launch temporaries

### DIFF
--- a/src/backend/common/codegen/codegen_c_host.cc
+++ b/src/backend/common/codegen/codegen_c_host.cc
@@ -288,16 +288,21 @@ void CodeGenCHost::PrintCallPacked(const tvm::tirx::CallNode *op) {
   std::string metal_result;
   if (is_in_metal_context) {
     metal_result = name_supply_->FreshName("metal_ret");
+    std::string serial_queue = name_supply_->FreshName("serial_queue");
+    std::string command_buffer = name_supply_->FreshName("command_buffer");
+    std::string set_stream = name_supply_->FreshName("set_stream");
     this->PrintLine("__block int ", metal_result, " = 0;");
-    this->PrintLine("auto serialQueue = torch::mps::get_dispatch_queue();");
-    this->PrintLine("dispatch_sync(serialQueue, ^() {");
+    this->PrintLine("auto ", serial_queue,
+                    " = torch::mps::get_dispatch_queue();");
+    this->PrintLine("dispatch_sync(", serial_queue, ", ^() {");
     metal_scope = this->BeginScope();
 
-    this->PrintLine("const id<MTLCommandBuffer> commandBuffer = "
-                    "torch::mps::get_command_buffer();");
-    this->PrintLine(
-        "const auto f = tvm::ffi::Function::GetGlobal(\"metal.SetStream\");");
-    this->PrintLine("(*f)(static_cast<TVMStreamHandle>(commandBuffer));");
+    this->PrintLine("const id<MTLCommandBuffer> ", command_buffer,
+                    " = torch::mps::get_command_buffer();");
+    this->PrintLine("const auto ", set_stream,
+                    " = tvm::ffi::Function::GetGlobal(\"metal.SetStream\");");
+    this->PrintLine("(*", set_stream, ")(static_cast<TVMStreamHandle>(",
+                    command_buffer, "));");
   }
 
   this->PrintIndent();

--- a/testing/python/metal/test_metal_host_multi_launch.py
+++ b/testing/python/metal/test_metal_host_multi_launch.py
@@ -1,0 +1,35 @@
+import re
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+@T.prim_func
+def two_launches(source: T.Tensor((1,), T.float32), output: T.Tensor((2,), T.float32)):
+    with T.Kernel(1, threads=1):
+        output[0] = source[0]
+    with T.Kernel(1, threads=1):
+        output[1] = source[0] + 1
+
+
+def test_metal_host_codegen_uses_unique_launch_temporaries():
+    artifact = tilelang.lower(
+        two_launches,
+        target="metal",
+        target_host="c",
+        enable_host_codegen=True,
+        enable_device_compile=False,
+    )
+    host_source = artifact.rt_mod.inspect_source()
+
+    declarations = re.findall(
+        r"(?:auto|id<MTLCommandBuffer>) (serial_queue\w*|command_buffer\w*|set_stream\w*) =",
+        host_source,
+    )
+    assert len(declarations) == 6
+    assert len(set(declarations)) == 6
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Problem

A Metal host function containing more than one packed kernel launch redeclares the same queue, command-buffer, and stream-setter locals for every launch. The generated host source therefore fails to compile for a multi-kernel `PrimFunc`.

## Root cause

The Metal path in `CodeGenCHost::PrintCallPacked` used fixed C++ local names even though every packed call is emitted into the same host-function scope.

## Change

- Allocate the queue, command-buffer, and stream-setter names through the code generator's `NameSupply`.
- Add a regression that lowers two `T.Kernel` regions into one Metal host entrypoint and verifies that all six launch temporaries are unique.

## Tests

- Rebuilt TileLang with `USE_METAL=ON USE_CUDA=OFF USE_ROCM=OFF` from this branch's exact source.
- `pytest -q testing/python/metal/test_metal_host_multi_launch.py`: 1 passed.
- Remaining Metal suite: 19 passed, 3 skipped.
- `pre-commit run --files ...` and `git diff --check`: passed.

## Validation

Validated on Apple Metal. Two existing upstream codegen-expectation files were excluded from the directory run because they independently fail against upstream `main` by expecting non-scalarized simdgroup fill/store source.

## Related

This is a host-codegen correctness fix. It does not introduce a new launch API or change kernel semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Generate unique Metal host launch temporary names with `NameSupply`.
- Prevent name collisions across multiple packed kernel launches.
- Add a regression test for two Metal kernel launches.
- Preserve launch APIs and kernel semantics.

## Validation

- Apple Metal tests passed.
- Remaining Metal tests passed.
- Pre-commit checks passed.
- `git diff --check` passed.

## C++ style / lint notes

- The PR does not modify `docs/developer_guide/cpp_style.md`.
- The documented rules allow generated Metal source to follow Metal and C naming conventions.
- The “C++ API Style Audit (warning only)” CI step applies.
- No correctness or build issues are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->