### PR TITLE
[BugFix][Metal] Respect GEMM buffer region offsets

### DIFF
--- a/testing/python/metal/test_metal_gemm_region_offsets.py
+++ b/testing/python/metal/test_metal_gemm_region_offsets.py
@@ -1,0 +1,49 @@
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+import torch
+from tilelang import tvm
+
+
+@T.prim_func
+def region_gemm(
+    a: T.Tensor((48, 48), T.float16),
+    b: T.Tensor((80, 48), T.float16),
+    output: T.Tensor((32, 32), T.float32),
+):
+    with T.Kernel(1, threads=128):
+        a_shared = T.alloc_shared((48, 48), T.float16)
+        b_shared = T.alloc_shared((80, 48), T.float16)
+        accum = T.alloc_fragment((32, 32), T.float32)
+        T.copy(a, a_shared)
+        T.copy(b, b_shared)
+        T.clear(accum)
+        T.gemm(a_shared[8:40, 16:48], b_shared[24:56, 8:40], accum, transpose_B=True)
+        T.copy(accum, output)
+
+
+def test_region_offsets_lower_for_transposed_rhs():
+    with tvm.transform.PassContext(), tvm.target.Target("metal"):
+        tilelang.lower(region_gemm, target="metal")
+
+
+@tilelang.testing.requires_metal
+def test_region_offsets_address_physical_buffer_axes():
+    compiled = tilelang.compile(
+        region_gemm,
+        out_idx=[],
+        target="metal",
+        target_host="c",
+        execution_backend="tvm_ffi",
+    )
+    a = torch.randn((48, 48), dtype=torch.float16, device="mps")
+    b = torch.randn((80, 48), dtype=torch.float16, device="mps")
+    output = torch.empty((32, 32), dtype=torch.float32, device="mps")
+    compiled(a, b, output)
+    torch.mps.synchronize()
+    expected = a[8:40, 16:48].float() @ b[24:56, 8:40].float().T
+    torch.testing.assert_close(output.cpu(), expected.cpu(), rtol=2e-2, atol=2e-2)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/metal/intrinsics/metal_macro_generator.py
+++ b/tilelang/metal/intrinsics/metal_macro_generator.py
@@ -119,19 +119,19 @@ class MPSIntrinEmitter:
         use_cooperative_tensor = self.use_cooperative_tensor
 
         warp_m, _ = self._get_warp_indices()
-        buffer, extra, offset_m, offset_k, stride = self._parse_buffer_nd(A_shared_buf)
+        buffer, extra, offset_row, offset_col, stride = self._parse_buffer_nd(A_shared_buf)
         if self.a_stride_override is not None:
             stride = self.a_stride_override
 
         @T.macro
-        def _warp_ldmatrix_a(A_local_buf, buffer, offset_m, offset_k, stride, warp_m, ki):
+        def _warp_ldmatrix_a(A_local_buf, buffer, offset_row, offset_col, stride, warp_m, ki):
             for i in T.serial(warp_rows):
                 if a_transposed:
-                    row_idx = offset_k + ki * micro_size_k
-                    col_idx = offset_m + warp_m * warp_row_tiles + i * micro_size_x
+                    row_idx = offset_row + ki * micro_size_k
+                    col_idx = offset_col + warp_m * warp_row_tiles + i * micro_size_x
                 else:
-                    row_idx = offset_m + warp_m * warp_row_tiles + i * micro_size_x
-                    col_idx = offset_k + ki * micro_size_k
+                    row_idx = offset_row + warp_m * warp_row_tiles + i * micro_size_x
+                    col_idx = offset_col + ki * micro_size_k
                 ptr = T.access_ptr(buffer[extra + (row_idx, col_idx)], "r")
                 if use_cooperative_tensor:
                     T.cooperative_tensor_load(
@@ -158,7 +158,7 @@ class MPSIntrinEmitter:
                         T.bool(a_transposed),
                     )
 
-        return _warp_ldmatrix_a(A_local_buf, buffer, offset_m, offset_k, stride, warp_m, ki)
+        return _warp_ldmatrix_a(A_local_buf, buffer, offset_row, offset_col, stride, warp_m, ki)
 
     def ldmatrix_b(self, B_local_buf, B_shared_buf: Buffer | BufferRegion, ki, k_inner: int = 0):
         """Load matrix B tiles from memory into simdgroup/cooperative tensor buffers."""
@@ -171,19 +171,19 @@ class MPSIntrinEmitter:
         use_cooperative_tensor = self.use_cooperative_tensor
 
         _, warp_n = self._get_warp_indices()
-        buffer, extra, offset_k, offset_n, stride = self._parse_buffer_nd(B_shared_buf)
+        buffer, extra, offset_row, offset_col, stride = self._parse_buffer_nd(B_shared_buf)
         if self.b_stride_override is not None:
             stride = self.b_stride_override
 
         @T.macro
-        def _warp_ldmatrix_b(B_local_buf, buffer, offset_k, offset_n, stride, warp_n, ki):
+        def _warp_ldmatrix_b(B_local_buf, buffer, offset_row, offset_col, stride, warp_n, ki):
             for j in T.serial(warp_cols):
                 if b_transposed:
-                    row_idx = offset_n + warp_n * warp_col_tiles + j * micro_size_y
-                    col_idx = offset_k + ki * micro_size_k
+                    row_idx = offset_row + warp_n * warp_col_tiles + j * micro_size_y
+                    col_idx = offset_col + ki * micro_size_k
                 else:
-                    row_idx = offset_k + ki * micro_size_k
-                    col_idx = offset_n + warp_n * warp_col_tiles + j * micro_size_y
+                    row_idx = offset_row + ki * micro_size_k
+                    col_idx = offset_col + warp_n * warp_col_tiles + j * micro_size_y
                 ptr = T.access_ptr(buffer[extra + (row_idx, col_idx)], "r")
                 if use_cooperative_tensor:
                     T.cooperative_tensor_load(
@@ -210,7 +210,7 @@ class MPSIntrinEmitter:
                         T.bool(b_transposed),
                     )
 
-        return _warp_ldmatrix_b(B_local_buf, buffer, offset_k, offset_n, stride, warp_n, ki)
+        return _warp_ldmatrix_b(B_local_buf, buffer, offset_row, offset_col, stride, warp_n, ki)
 
     def mma(self, A_local_buf, B_local_buf, C_local_buf, k_inner: int = 0):
         """Perform matrix multiply-accumulate: C += A * B."""


### PR DESCRIPTION
## Problem

Metal GEMM loads can address the wrong elements when `T.gemm` receives sliced `BufferRegion` operands, particularly when an operand is transposed.

## Root cause

The Metal intrinsic emitter assigned semantic M/K or K/N names to the physical row and column offsets before applying the transpose mapping. For transposed operands this swapped the meaning of the region offsets.

## Change

- Preserve offsets as physical row and column coordinates when parsing a `BufferRegion`.
- Apply transpose semantics only when constructing the final matrix-load indices.
- Add lowering and Metal execution regressions using nonzero offsets on both operands and a transposed RHS.

## Tests

- Rebuilt TileLang with `USE_METAL=ON USE_CUDA=OFF USE_ROCM=OFF` from this branch's exact source.
- `pytest -q testing/python/metal/test_metal_gemm_region_offsets.py`: 2 passed.
- Remaining Metal suite: 20 passed, 3 skipped.
- `pre-commit run --files ...` and `git diff --check`: passed.

## Validation

Executed on Apple Metal and compared the sliced GEMM result against PyTorch. Two existing upstream codegen-expectation files were excluded from the directory run because they independently fail against upstream `main`.

## Related

Independent of the runtime-valid-M GEMM extension; this fixes ordinary `BufferRegion` addressing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed Metal GEMM addressing for sliced `BufferRegion` operands.
- Preserved physical row and column offsets during buffer-region parsing.
- Applied transpose semantics when generating matrix-load indices for transposed RHS operands.
- Added lowering and Metal execution regression tests for nonzero offsets on both operands.

## Validation

- Passed 2 targeted tests.
- Passed 20 additional Metal tests.
- Skipped 3 Metal tests.
- Passed pre-commit checks and `git diff --check`.
- Compared results with PyTorch on Apple Metal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->