### PR TITLE
[BugFix][Metal] Preserve narrow reinterpret widths

### DIFF
--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -1674,12 +1674,16 @@ void CodeGenTileLangMetal::VisitExpr_(const CallNode *op,
          << " + __i] = __ct_c[__i]; }";
     }
   } else if (op->op.same_as(builtin::reinterpret())) {
-    // generate as_type<TYPE>(ARG)
+    // Metal applies C integer promotion to narrow integer expressions. Cast
+    // the expression back to its TIR dtype before as_type so a uint16 bitwise
+    // expression remains a legal half bitcast rather than becoming int.
     os << "(as_type<";
     this->PrintType(op->dtype, os);
-    os << ">(";
+    os << ">((";
+    this->PrintType(op->args[0].dtype(), os);
+    os << ")(";
     this->PrintExpr(op->args[0], os);
-    os << "))";
+    os << ")))";
   } else if (op->op.same_as(builtin::handle_add_byte_offset())) {
     TVM_FFI_ICHECK_EQ(op->args.size(), 2U);
     std::string addr_space = GetAddrSpaceOf(op->args[0]);

--- a/testing/python/metal/test_metal_reinterpret.py
+++ b/testing/python/metal/test_metal_reinterpret.py
@@ -1,0 +1,44 @@
+import struct
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+import torch
+
+
+@T.prim_func
+def reinterpret_kernel(source: T.Tensor((2,), T.uint8), output: T.Tensor((1,), T.float16)):
+    with T.Kernel(1, threads=1):
+        bits = T.cast(source[0], T.uint16)
+        bits |= T.cast(source[1], T.uint16) << 8
+        output[0] = T.reinterpret(bits, T.float16)
+
+
+def test_reinterpret_preserves_the_tir_source_width_in_metal():
+    artifact = tilelang.lower(
+        reinterpret_kernel,
+        target="metal",
+        enable_host_codegen=False,
+        enable_device_compile=False,
+    )
+    assert "as_type<half>((ushort)(" in artifact.kernel_source
+
+
+@tilelang.testing.requires_metal
+def test_reinterpret_narrow_integer_expression():
+    compiled = tilelang.compile(
+        reinterpret_kernel,
+        out_idx=[],
+        target="metal",
+        target_host="c",
+        execution_backend="tvm_ffi",
+    )
+    source = torch.tensor(list(struct.pack("<e", 1.5)), dtype=torch.uint8, device="mps")
+    output = torch.empty((1,), dtype=torch.float16, device="mps")
+    compiled(source, output)
+    torch.mps.synchronize()
+    torch.testing.assert_close(output.cpu(), torch.tensor([1.5], dtype=torch.float16))
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Problem

Reinterpreting a narrow integer expression on Metal can generate an incorrect or illegal bitcast. For example, combining two `uint8` values into `uint16` and reinterpreting the result as `float16` is widened by C integer promotion before `as_type` sees it.

## Root cause

Metal codegen emitted `as_type<T>(expression)` without restoring the expression to its TIR source dtype. C integer promotion can therefore change the bit width of narrow integer expressions while leaving TIR's dtype unchanged.

## Change

- Cast the reinterpret operand to its declared TIR dtype immediately before emitting Metal `as_type`.
- Add source-lowering and Metal execution regressions for a promoted `uint16` bitwise expression reinterpreted as `float16`.

## Tests

- Rebuilt TileLang with `USE_METAL=ON USE_CUDA=OFF USE_ROCM=OFF` from this branch's exact source.
- `pytest -q testing/python/metal/test_metal_reinterpret.py`: 2 passed.
- Remaining Metal suite: 20 passed, 3 skipped.
- `pre-commit run --files ...` and `git diff --check`: passed.

## Validation

Executed through the native TVM-FFI Metal path on Apple Metal and recovered the expected `float16` value from its two source bytes. Two existing upstream codegen-expectation files were excluded from the directory run because they independently fail against upstream `main`.

## Related

The fork carries a separate Torch Metal adapter argument-binding fix; the regression deliberately uses TVM-FFI so this codegen fix remains independently testable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserve narrow TIR widths in Metal `as_type` reinterpret code generation.
- Add source-lowering and MPS execution tests for `uint16` to `float16` reinterpretation.

## C++ style / lint notes

- The change touches C++, but it does not modify a rule documented in `docs/developer_guide/cpp_style.md`.
- The repository runs the **C++ API Style Audit (warning only)** CI step.
- No new warning-only style issue is reported. Correctness and build checks remain separate from advisory audit findings.

## Tests

- Metal reinterpret tests passed.
- The remaining Metal suite passed with the specified skips and exclusions.
- Pre-commit checks passed.
- `git diff --check` passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->