### PR TITLE
[Metal] Support 32-bit integer atomic add

### DIFF
--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -1673,6 +1673,27 @@ void CodeGenTileLangMetal::VisitExpr_(const CallNode *op,
          << "; __i++) " << c_var << "[" << c_idx << " * " << c_elems
          << " + __i] = __ct_c[__i]; }";
     }
+  } else if (op->op.same_as(tl::atomic_add_elem_op()) ||
+             op->op.same_as(tl::atomic_add_ret_elem_op())) {
+    TVM_FFI_ICHECK_GE(op->args.size(), 2U);
+    DataType value_dtype = op->args[1].dtype();
+    TVM_FFI_ICHECK(value_dtype.is_scalar() && value_dtype.bits() == 32 &&
+                   (value_dtype.is_int() || value_dtype.is_uint()))
+        << "Metal scalar atomic add supports int32 and uint32, got "
+        << value_dtype;
+    const char *atomic_type =
+        value_dtype.is_int() ? "atomic_int" : "atomic_uint";
+    const std::string address_space = GetAddrSpaceOf(op->args[0]);
+    TVM_FFI_ICHECK(address_space == "device" || address_space == "threadgroup")
+        << "Metal scalar atomic add requires device or threadgroup storage, "
+           "got "
+        << address_space;
+    os << "atomic_fetch_add_explicit(reinterpret_cast<" << address_space << " "
+       << atomic_type << " *>(";
+    this->PrintExpr(op->args[0], os);
+    os << "), ";
+    this->PrintExpr(op->args[1], os);
+    os << ", memory_order_relaxed)";
   } else if (op->op.same_as(builtin::reinterpret())) {
     // generate as_type<TYPE>(ARG)
     os << "(as_type<";

--- a/testing/python/metal/test_metal_int32_atomics.py
+++ b/testing/python/metal/test_metal_int32_atomics.py
@@ -1,0 +1,56 @@
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+import torch
+
+
+@T.prim_func
+def histogram(
+    indices: T.Tensor((64,), "int32"),
+    counts: T.Tensor((4,), "int32"),
+    positions: T.Tensor((64,), "int32"),
+):
+    with T.Kernel(1, threads=64):
+        lane = T.get_thread_binding(0)
+        shared = T.alloc_shared((4,), "int32")
+        if lane < 4:
+            shared[lane] = 0
+        T.sync_threads()
+        bucket = indices[lane]
+        positions[lane] = T.atomic_add(shared[bucket], 1, return_prev=True)
+        T.sync_threads()
+        if lane < 4:
+            counts[lane] = shared[lane]
+
+
+def test_int32_atomic_add_lowers_to_metal_atomic_fetch_add():
+    artifact = tilelang.lower(
+        histogram,
+        target="metal",
+        enable_host_codegen=False,
+        enable_device_compile=False,
+    )
+    assert "atomic_fetch_add_explicit" in artifact.kernel_source
+    assert "threadgroup atomic_int" in artifact.kernel_source
+
+
+@tilelang.testing.requires_metal
+def test_threadgroup_atomic_add_returns_previous_value():
+    indices = torch.arange(64, dtype=torch.int32, device="mps") % 4
+    counts = torch.empty(4, dtype=torch.int32, device="mps")
+    positions = torch.empty(64, dtype=torch.int32, device="mps")
+    compiled = tilelang.compile(
+        histogram,
+        out_idx=[],
+        target="metal",
+        target_host="c",
+        execution_backend="tvm_ffi",
+    )
+    compiled(indices, counts, positions)
+    torch.mps.synchronize()
+    torch.testing.assert_close(counts.cpu(), torch.full((4,), 16, dtype=torch.int32))
+    assert sorted(positions.cpu().tolist()) == sorted(list(range(16)) * 4)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Problem

Metal cannot lower scalar signed or unsigned 32-bit `T.atomic_add` operations, including the form that returns the previous value. Portable kernels requiring integer counters or slot allocation therefore fail during Metal code generation.

## Change

- Lower scalar `int32` and `uint32` atomic-add calls to Metal `atomic_fetch_add_explicit`.
- Preserve device versus threadgroup address space in the atomic pointer cast.
- Use relaxed ordering, matching the operation's existing reduction semantics.
- Reject unsupported widths, types, and storage scopes explicitly.
- Add source-lowering and Metal execution regressions covering threadgroup atomics and returned prior values.

## Tests

- Rebuilt TileLang with `USE_METAL=ON USE_CUDA=OFF USE_ROCM=OFF` from this branch's exact source.
- `pytest -q testing/python/metal/test_metal_int32_atomics.py`: 2 passed.
- Remaining Metal suite: 20 passed, 3 skipped.
- `pre-commit run --files ...` and `git diff --check`: passed.

## Validation

Executed a contended threadgroup histogram on Apple Metal and verified both final counts and the set of returned prior positions. Two existing upstream codegen-expectation files were excluded from the directory run because they independently fail against upstream `main`.

## Related

This adds a missing Metal realization of the existing target-neutral atomic operation; it does not add a Metal-specific language API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added Metal support for scalar signed and unsigned 32-bit `T.atomic_add`.
- Returned the previous value with relaxed `atomic_fetch_add_explicit`.
- Preserved `device` and `threadgroup` address spaces.
- Rejected unsupported types, widths, and storage scopes.
- Added source-lowering and Metal execution regressions.

## C++ style / lint notes

- The PR does not change the rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit is warning-only.
- Dedicated tests, the Metal suite, pre-commit checks, and whitespace checks passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->