### PR TITLE
[Runtime] Add native packed-function argument binding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,6 +402,7 @@ file(GLOB TILE_LANG_SRCS
 # Always include CPU-safe runtime helpers
 list(APPEND TILE_LANG_SRCS
   src/runtime/error_helpers.cc
+  src/runtime/bound_function.cc
 )
 # Track if the user explicitly selected a backend via cache options.
 set(TILELANG_BACKEND_USER_SELECTED OFF)

--- a/src/runtime/bound_function.cc
+++ b/src/runtime/bound_function.cc
@@ -1,0 +1,116 @@
+/* Native partial application for packed runtime functions. */
+#include "support/check.h"
+
+#include <tvm/ffi/container/array.h>
+#include <tvm/ffi/function.h>
+#include <tvm/ffi/reflection/registry.h>
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+namespace tvm {
+namespace tl {
+
+using namespace ffi;
+
+namespace {
+
+class BoundFramePool {
+public:
+  BoundFramePool(Function callee, int64_t parameter_count,
+                 Array<int64_t> static_indices, Array<Any> static_values,
+                 Array<int64_t> dynamic_indices)
+      : callee_(std::move(callee)), static_values_(std::move(static_values)),
+        dynamic_indices_(std::move(dynamic_indices)),
+        template_frame_(parameter_count) {
+    for (int64_t i = 0; i < static_indices.size(); ++i)
+      template_frame_[static_indices[i]] = static_values_[i];
+  }
+
+  void Invoke(PackedArgs dynamic_args, Any *result) {
+    ICHECK(dynamic_args.size() == dynamic_indices_.size())
+        << "bound function received the wrong number of dynamic arguments";
+
+    std::vector<AnyView> frame = Acquire();
+    for (int64_t i = 0; i < dynamic_indices_.size(); ++i)
+      frame[dynamic_indices_[i]] = dynamic_args[i];
+
+    try {
+      callee_.CallPacked(frame.data(), static_cast<int32_t>(frame.size()),
+                         result);
+    } catch (...) {
+      Release(std::move(frame));
+      throw;
+    }
+    Release(std::move(frame));
+  }
+
+private:
+  std::vector<AnyView> Acquire() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (available_.empty())
+      return template_frame_;
+    std::vector<AnyView> frame = std::move(available_.back());
+    available_.pop_back();
+    return frame;
+  }
+
+  void Release(std::vector<AnyView> frame) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    available_.push_back(std::move(frame));
+  }
+
+  Function callee_;
+  // Own the values referenced by static AnyViews for the pool's full lifetime.
+  Array<Any> static_values_;
+  Array<int64_t> dynamic_indices_;
+  std::vector<AnyView> template_frame_;
+  std::mutex mutex_;
+  std::vector<std::vector<AnyView>> available_;
+};
+
+} // namespace
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  reflection::GlobalDef().def_packed(
+      "tilelang.runtime.bind_packed_function", [](PackedArgs args, Any *ret) {
+        ICHECK(args.size() == 5)
+            << "bind_packed_function expects function, parameter count, static "
+               "indices, static values, and dynamic indices";
+        Function callee = args[0].cast<Function>();
+        int64_t parameter_count = args[1].cast<int64_t>();
+        Array<int64_t> static_indices = args[2].cast<Array<int64_t>>();
+        Array<Any> static_values = args[3].cast<Array<Any>>();
+        Array<int64_t> dynamic_indices = args[4].cast<Array<int64_t>>();
+
+        ICHECK(parameter_count >= 0);
+        ICHECK(static_indices.size() == static_values.size());
+        std::vector<bool> occupied(parameter_count, false);
+        for (int64_t index : static_indices) {
+          ICHECK(index >= 0 && index < parameter_count);
+          ICHECK(!occupied[index]);
+          occupied[index] = true;
+        }
+        for (int64_t index : dynamic_indices) {
+          ICHECK(index >= 0 && index < parameter_count);
+          ICHECK(!occupied[index]);
+          occupied[index] = true;
+        }
+        for (bool slot : occupied)
+          ICHECK(slot);
+
+        auto pool = std::make_shared<BoundFramePool>(
+            std::move(callee), parameter_count, std::move(static_indices),
+            std::move(static_values), std::move(dynamic_indices));
+        *ret =
+            Function::FromPacked([pool](PackedArgs dynamic_args, Any *result) {
+              pool->Invoke(dynamic_args, result);
+            });
+      });
+}
+
+} // namespace tl
+} // namespace tvm

--- a/testing/python/runtime/test_tilelang_runtime_argument_binding.py
+++ b/testing/python/runtime/test_tilelang_runtime_argument_binding.py
@@ -1,0 +1,32 @@
+import pytest
+import tilelang  # noqa: F401
+import tvm_ffi
+
+
+def _callee():
+    tvm_ffi.register_global_func(
+        "testing.tilelang.bound_function.sum",
+        f=lambda first, second, third: first + second + third,
+        override=True,
+    )
+    return tvm_ffi.get_global_func("testing.tilelang.bound_function.sum")
+
+
+def test_native_binding_builds_a_complete_stable_argument_frame():
+    callee = _callee()
+    bind = tvm_ffi.get_global_func("tilelang.runtime.bind_packed_function")
+
+    bound = bind(callee, 3, [0, 2], [10, 30], [1])
+
+    assert bound(2) == 42
+    assert bound(3) == 43
+
+
+def test_native_binding_rejects_an_incomplete_or_overlapping_abi():
+    callee = _callee()
+    bind = tvm_ffi.get_global_func("tilelang.runtime.bind_packed_function")
+
+    with pytest.raises(Exception, match="Check failed"):
+        bind(callee, 3, [0], [10], [1])
+    with pytest.raises(Exception, match="Check failed"):
+        bind(callee, 3, [0], [10], [0, 1, 2])

--- a/tilelang/jit/adapter/base.py
+++ b/tilelang/jit/adapter/base.py
@@ -99,6 +99,9 @@ class BaseKernelAdapter(ABC):
     def __call__(self, *args: Any, **kwds: Any) -> Any:
         return self.func(*args, **kwds)
 
+    def bind(self, static: dict[int, Any], dynamic_indices: tuple[int, ...]) -> Callable[..., Any]:
+        raise NotImplementedError(f"execution backend {type(self).__name__} does not provide native argument binding")
+
     def get_kernel_source(self, kernel_only: bool = True) -> str:
         if kernel_only:
             return self.mod.imports[0].inspect_source()

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -14,6 +14,7 @@ import sys
 import threading
 
 import torch
+import tvm_ffi
 from tilelang import tvm
 from tvm import runtime, tirx
 from tvm.target import Target
@@ -300,6 +301,40 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
             return [tensor_list[i] for i in self.result_idx]
 
         return func
+
+    def bind(self, static: dict[int, Any], dynamic_indices: tuple[int, ...]) -> Callable[..., Any]:
+        """Create a stable argument frame for a caller-allocated-output ABI."""
+        if self.result_idx:
+            raise ValueError("partial binding requires caller-allocated outputs")
+        parameter_count = len(self.params)
+        dynamic_set = set(dynamic_indices)
+        if len(dynamic_set) != len(dynamic_indices):
+            raise ValueError("dynamic argument slots must be unique")
+        if set(static) & dynamic_set:
+            raise ValueError("static and dynamic argument slots overlap")
+        if set(static) | dynamic_set != set(range(parameter_count)):
+            raise ValueError("bound argument slots must cover the complete ABI")
+        executable = self._get_executable()
+        # Resolve the packed entrypoint while binding.  Besides removing a
+        # per-invocation module lookup, target runtimes such as Metal use
+        # function resolution to create and cache the native pipeline state.
+        # Compilation therefore remains outside the bound invocation path.
+        # A fresh compilation retains ``runtime.Executable`` while a cache hit
+        # loads its already-jitted runtime module. Resolve the same packed main
+        # entrypoint for both representations before native partial binding.
+        if isinstance(executable, runtime.Executable):
+            entrypoint = executable.jit().main
+        else:
+            entrypoint = executable.get_function("main", query_imports=True)
+        factory = tvm_ffi.get_global_func("tilelang.runtime.bind_packed_function")
+        static_indices = tuple(sorted(static))
+        return factory(
+            entrypoint,
+            parameter_count,
+            list(static_indices),
+            [static[index] for index in static_indices],
+            list(dynamic_indices),
+        )
 
     def _convert_ffi_callee_allocated_output_func(self) -> Callable[..., Any]:
         """Create a Torch callable whose outputs are allocated by TVM-FFI."""

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -211,6 +211,14 @@ class JITKernel(Generic[_P, _T]):
         """
         return self.torch_function(*args, **kwds)
 
+    def bind(self, static: dict[int, Any], dynamic_indices: tuple[int, ...]):
+        """Bind stable ABI slots once and expose only invocation-varying slots.
+
+        The adapter owns argument validation and frame construction so clients
+        do not rebuild or reinterpret immutable tensor arguments on hot calls.
+        """
+        return self.adapter.bind(static, dynamic_indices)
+
     def _compile_and_create_adapter(
         self,
         tilelang_func: PrimFunc,


### PR DESCRIPTION
## Problem

Long-lived compiled programs repeatedly receive many immutable arguments, such as model weights, alongside a small set of invocation-varying arguments. Reconstructing and interpreting the complete packed ABI in Python on every call adds avoidable launch overhead.

## Change

- Add a generic runtime function that partially binds indexed packed-function arguments.
- Validate that static and dynamic slots are unique, disjoint, in range, and cover the complete ABI.
- Materialize static slots into reusable native frames and update only dynamic slots on warm calls.
- Use a concurrency-safe frame pool so simultaneous calls do not share mutable argument storage.
- Resolve the compiled entrypoint once at bind time.
- Expose binding through the TVM-FFI adapter and `JITKernel.bind` for caller-allocated-output ABIs.

## Tests

- Rebuilt TileLang with `USE_METAL=ON USE_CUDA=OFF USE_ROCM=OFF` from this branch's exact source.
- `pytest -q testing/python/runtime/test_tilelang_runtime_argument_binding.py`: 2 passed.
- `pre-commit run --files ...` and `git diff --check`: passed.

## Validation

Verified repeated calls reuse the same static slots while accepting new dynamic values, and verified incomplete and overlapping ABI descriptions are rejected.

## Related

The backend-capability PR advertises whether a selected execution backend provides this facility and should land after this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add native partial binding for packed-function arguments.
- Validate slot uniqueness, bounds, disjointness, and complete ABI coverage.
- Reuse static arguments in concurrency-safe native frame pools.
- Update dynamic arguments on each invocation.
- Expose binding through the TVM-FFI adapter and `JITKernel.bind`.
- Add tests for repeated calls, static reuse, dynamic updates, and invalid ABI mappings.

## C++ style / lint notes

- The PR adds a C++ runtime source file and updates the build.
- It does not modify the rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) runs in CI. Any findings are advisory unless they indicate a correctness, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->