### PR TITLE
[Backend] Expose backend capability contracts

### DIFF
--- a/testing/python/backend/test_tilelang_backend_module.py
+++ b/testing/python/backend/test_tilelang_backend_module.py
@@ -121,3 +121,22 @@ def test_create_backend_context_binds_compile_state():
 
     with pytest.raises(AttributeError):
         context.target = tvm.target.Target("llvm")
+
+
+def test_backend_context_exposes_lowering_and_execution_capabilities():
+    context = create_backend_context("metal", "c", "tvm_ffi")
+
+    assert context.capabilities.subgroup_width == 32
+    assert context.capabilities.max_threads_per_group == 1024
+    assert context.capabilities.shared_memory_bytes == 32768
+    assert context.capabilities.supports("subgroup_exchange")
+    assert context.capabilities.native_multi_launch
+    assert context.capabilities.native_argument_binding
+    assert context.capabilities.max_kernels_per_program is None
+
+
+def test_capability_fingerprint_changes_with_execution_contract():
+    context = create_backend_context("metal", "c", "tvm_ffi")
+    torch_context = create_backend_context("metal", "c", "torch")
+
+    assert context.capabilities.fingerprint != torch_context.capabilities.fingerprint

--- a/tilelang/backend/__init__.py
+++ b/tilelang/backend/__init__.py
@@ -2,6 +2,7 @@ from .pass_pipeline import PassPipeline  # noqa: F401
 from .device_codegen import DeviceCodegen  # noqa: F401
 from .host_codegen import HostCodegen, HostCodegenHook  # noqa: F401
 from .execution_backend import ExecutionBackendSpec  # noqa: F401
+from .capabilities import BackendCapabilities, MatrixInstruction  # noqa: F401
 from .module import (  # noqa: F401
     BackendContext,
     BackendModule,

--- a/tilelang/backend/capabilities.py
+++ b/tilelang/backend/capabilities.py
@@ -1,0 +1,112 @@
+"""Behavioral capabilities of one resolved TileLang backend context."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, replace
+
+from tvm.target import Target
+
+
+@dataclass(frozen=True, slots=True)
+class MatrixInstruction:
+    m: int
+    n: int
+    k: int
+    input_dtype: str
+    accumulation_dtype: str
+
+
+@dataclass(frozen=True, slots=True)
+class BackendCapabilities:
+    """Target-neutral facts that may legally affect program lowering."""
+
+    subgroup_width: int
+    max_threads_per_group: int
+    shared_memory_bytes: int
+    supported_dtypes: frozenset[str]
+    matrix_instructions: tuple[MatrixInstruction, ...] = ()
+    features: frozenset[str] = frozenset()
+    native_multi_launch: bool = False
+    native_argument_binding: bool = False
+    max_kernels_per_program: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.subgroup_width <= 0 or self.max_threads_per_group <= 0:
+            raise ValueError("backend thread geometry must be positive")
+        if self.shared_memory_bytes < 0 or not self.supported_dtypes:
+            raise ValueError("backend storage capabilities are invalid")
+        if self.max_kernels_per_program is not None and self.max_kernels_per_program <= 0:
+            raise ValueError("max_kernels_per_program must be positive")
+
+    def supports(self, feature: str) -> bool:
+        return feature in self.features
+
+    @property
+    def fingerprint(self) -> str:
+        payload = repr(
+            (
+                self.subgroup_width,
+                self.max_threads_per_group,
+                self.shared_memory_bytes,
+                tuple(sorted(self.supported_dtypes)),
+                self.matrix_instructions,
+                tuple(sorted(self.features)),
+                self.native_multi_launch,
+                self.native_argument_binding,
+                self.max_kernels_per_program,
+            )
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()[:20]
+
+    def with_execution(
+        self,
+        *,
+        native_multi_launch: bool,
+        native_argument_binding: bool,
+        max_kernels_per_program: int | None,
+    ) -> BackendCapabilities:
+        return replace(
+            self,
+            native_multi_launch=native_multi_launch,
+            native_argument_binding=native_argument_binding,
+            max_kernels_per_program=max_kernels_per_program,
+        )
+
+
+DEFAULT_DTYPES = frozenset(
+    {
+        "bool",
+        "uint8",
+        "uint16",
+        "uint32",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "float16",
+        "bfloat16",
+        "float32",
+    }
+)
+
+
+def target_limits(
+    target: Target,
+    *,
+    subgroup_width: int,
+    matrix_instructions: tuple[MatrixInstruction, ...] = (),
+    features: frozenset[str] = frozenset(),
+    supported_dtypes: frozenset[str] = DEFAULT_DTYPES,
+) -> BackendCapabilities:
+    """Read common limits from a normalized target with backend-owned fallbacks."""
+
+    attrs = target.attrs
+    return BackendCapabilities(
+        subgroup_width=int(attrs.get("thread_warp_size", subgroup_width)),
+        max_threads_per_group=int(attrs.get("max_threads_per_block", attrs.get("max_num_threads", 1))),
+        shared_memory_bytes=int(attrs.get("max_shared_memory_per_block", 0)),
+        supported_dtypes=supported_dtypes,
+        matrix_instructions=matrix_instructions,
+        features=features,
+    )

--- a/tilelang/backend/execution_backend.py
+++ b/tilelang/backend/execution_backend.py
@@ -22,6 +22,9 @@ class ExecutionBackendSpec:
     supports_target: TargetPredicate | None = None
     enable_host_codegen: bool = False
     enable_device_compile: bool = False
+    native_multi_launch: bool = False
+    native_argument_binding: bool = False
+    max_kernels_per_program: int | None = None
 
     def matches(self, target: Target) -> bool:
         return True if self.supports_target is None else self.supports_target(target)

--- a/tilelang/backend/module.py
+++ b/tilelang/backend/module.py
@@ -11,12 +11,14 @@ from tvm import IRModule
 from tvm.target import Target
 
 if TYPE_CHECKING:
+    from tilelang.backend.capabilities import BackendCapabilities
     from tilelang.backend.device_codegen import DeviceCodegen
     from tilelang.backend.execution_backend import ExecutionBackendSpec
     from tilelang.backend.host_codegen import HostCodegen, HostCodegenHook
     from tilelang.backend.pass_pipeline import PassPipeline
 
 BackendCallback = Callable[..., object]
+CapabilityProvider = Callable[[Target], "BackendCapabilities"]
 TargetPredicate = Callable[[Target], bool]
 _T = TypeVar("_T")
 
@@ -34,6 +36,7 @@ class BackendModule:
     pipelines: Mapping[str, PassPipeline]
     device_codegens: Mapping[str, DeviceCodegen]
     execution_backends: tuple[ExecutionBackendSpec, ...]
+    capabilities: CapabilityProvider
     supports_target: TargetPredicate | None = None
     host_codegens: Mapping[str, HostCodegen] = field(default_factory=dict)
     host_codegen_hooks: Mapping[str, tuple[HostCodegenHook, ...]] = field(default_factory=dict)
@@ -207,6 +210,18 @@ class BackendContext:
         """Return the selected backend module name."""
 
         return self.module.name
+
+    @property
+    def capabilities(self) -> BackendCapabilities:
+        """Return capabilities for this exact target and execution pairing."""
+
+        target_capabilities = self.module.capabilities(self.target)
+        execution = self.execution_backend
+        return target_capabilities.with_execution(
+            native_multi_launch=execution.native_multi_launch,
+            native_argument_binding=execution.native_argument_binding,
+            max_kernels_per_program=execution.max_kernels_per_program,
+        )
 
     def lower(self, mod: IRModule) -> IRModule:
         """Run the selected backend's lowering pipeline."""

--- a/tilelang/cpu/backend.py
+++ b/tilelang/cpu/backend.py
@@ -1,11 +1,17 @@
 """CPU backend manifest."""
 
 from tilelang.backend.device_codegen import DeviceCodegen
+from tilelang.backend.capabilities import target_limits
 from tilelang.backend.host_codegen import STANDARD_HOST_CODEGENS
 from tilelang.backend.pass_pipeline import PassPipeline
 from tilelang.backend.module import BackendModule, register_backend
 
 from . import codegen, execution_backend, pipeline
+
+
+def _capabilities(target):
+    return target_limits(target, subgroup_width=1)
+
 
 BACKEND = register_backend(
     BackendModule(
@@ -25,5 +31,6 @@ BACKEND = register_backend(
         },
         host_codegens=STANDARD_HOST_CODEGENS,
         execution_backends=execution_backend.EXECUTION_BACKENDS,
+        capabilities=_capabilities,
     )
 )

--- a/tilelang/cpu/execution_backend.py
+++ b/tilelang/cpu/execution_backend.py
@@ -11,5 +11,11 @@ def _is_c_target(target: Target) -> bool:
 
 EXECUTION_BACKENDS = [
     ExecutionBackendSpec("cython", supports_target=_is_c_target),
-    ExecutionBackendSpec("tvm_ffi", enable_host_codegen=True, enable_device_compile=True),
+    ExecutionBackendSpec(
+        "tvm_ffi",
+        enable_host_codegen=True,
+        enable_device_compile=True,
+        native_multi_launch=True,
+        native_argument_binding=True,
+    ),
 ]

--- a/tilelang/cuda/backend.py
+++ b/tilelang/cuda/backend.py
@@ -5,6 +5,7 @@ import re
 from tvm import tirx
 
 from tilelang.backend.device_codegen import DeviceCodegen
+from tilelang.backend.capabilities import MatrixInstruction, target_limits
 from tilelang.backend.host_codegen import STANDARD_HOST_CODEGENS
 from tilelang.backend.module import BackendModule, register_backend
 from tilelang.contrib import nvcc
@@ -12,6 +13,19 @@ from tilelang.env import CUTLASS_INCLUDE_DIR, TILELANG_TEMPLATE_PATH, env
 from tilelang.transform import PassConfigKey
 
 from . import codegen, execution_backend, pipeline
+
+
+def _capabilities(target):
+    return target_limits(
+        target,
+        subgroup_width=32,
+        matrix_instructions=(
+            MatrixInstruction(16, 16, 16, "float16", "float32"),
+            MatrixInstruction(16, 16, 16, "bfloat16", "float32"),
+        ),
+        features=frozenset({"async_copy", "subgroup_exchange", "atomic.add.float32", "atomic.add.int32"}),
+    )
+
 
 _CUDA_GLOBAL_KERNEL_PATTERN = re.compile(r'(?:extern\s+"C"\s+)?__global__\s+void\s+(?:__launch_bounds__\([^\)]*\)\s+)?(\w+)')
 
@@ -134,6 +148,7 @@ BACKEND = register_backend(
             )
         },
         execution_backends=execution_backend.CUDA_EXECUTION_BACKENDS,
+        capabilities=_capabilities,
         host_codegens=STANDARD_HOST_CODEGENS,
         callbacks={
             "tilelang_callback_cuda_validate": tilelang_callback_cuda_validate,

--- a/tilelang/cuda/cutedsl_backend.py
+++ b/tilelang/cuda/cutedsl_backend.py
@@ -1,9 +1,23 @@
 """CuTeDSL backend manifest sharing the CUDA lowering pipeline."""
 
 from tilelang.backend.device_codegen import DeviceCodegen
+from tilelang.backend.capabilities import MatrixInstruction, target_limits
 from tilelang.backend.module import BackendModule, register_backend
 
 from . import codegen, execution_backend, pipeline
+
+
+def _capabilities(target):
+    return target_limits(
+        target,
+        subgroup_width=32,
+        matrix_instructions=(
+            MatrixInstruction(16, 16, 16, "float16", "float32"),
+            MatrixInstruction(16, 16, 16, "bfloat16", "float32"),
+        ),
+        features=frozenset({"async_copy", "subgroup_exchange", "atomic.add.float32", "atomic.add.int32"}),
+    )
+
 
 BACKEND = register_backend(
     BackendModule(
@@ -19,5 +33,6 @@ BACKEND = register_backend(
             )
         },
         execution_backends=execution_backend.CUTEDSL_EXECUTION_BACKENDS,
+        capabilities=_capabilities,
     )
 )

--- a/tilelang/cuda/execution_backend.py
+++ b/tilelang/cuda/execution_backend.py
@@ -26,6 +26,8 @@ CUDA_EXECUTION_BACKENDS = [
         "tvm_ffi",
         enable_host_codegen=True,
         enable_device_compile=True,
+        native_multi_launch=True,
+        native_argument_binding=True,
     ),
     ExecutionBackendSpec("nvrtc", is_available=_is_nvrtc_available),
     ExecutionBackendSpec("cython"),

--- a/tilelang/metal/backend.py
+++ b/tilelang/metal/backend.py
@@ -1,11 +1,25 @@
 """Metal backend manifest."""
 
 from tilelang.backend.device_codegen import DeviceCodegen
+from tilelang.backend.capabilities import MatrixInstruction, target_limits
 from tilelang.backend.host_codegen import HostCodegenHook, STANDARD_HOST_CODEGENS
 from tilelang.backend.pass_pipeline import PassPipeline
 from tilelang.backend.module import BackendModule, register_backend
 
 from . import codegen, execution_backend, pipeline
+
+
+def _capabilities(target):
+    return target_limits(
+        target,
+        subgroup_width=32,
+        matrix_instructions=(
+            MatrixInstruction(8, 8, 8, "float16", "float32"),
+            MatrixInstruction(8, 8, 8, "bfloat16", "float32"),
+        ),
+        features=frozenset({"subgroup_exchange"}),
+    )
+
 
 BACKEND = register_backend(
     BackendModule(
@@ -21,6 +35,7 @@ BACKEND = register_backend(
         },
         host_codegen_hooks={"metal": (HostCodegenHook("metal_context", codegen.mark_host_metal_context),)},
         execution_backends=execution_backend.EXECUTION_BACKENDS,
+        capabilities=_capabilities,
         host_codegens=STANDARD_HOST_CODEGENS,
     )
 )

--- a/tilelang/metal/execution_backend.py
+++ b/tilelang/metal/execution_backend.py
@@ -8,5 +8,11 @@ from tilelang.backend.execution_backend import ExecutionBackendSpec
 # for Metal. tvm_ffi remains available as an explicit opt-in.
 EXECUTION_BACKENDS = [
     ExecutionBackendSpec("torch"),
-    ExecutionBackendSpec("tvm_ffi", enable_host_codegen=True, enable_device_compile=True),
+    ExecutionBackendSpec(
+        "tvm_ffi",
+        enable_host_codegen=True,
+        enable_device_compile=True,
+        native_multi_launch=True,
+        native_argument_binding=True,
+    ),
 ]

--- a/tilelang/metal/target.py
+++ b/tilelang/metal/target.py
@@ -58,7 +58,13 @@ def _metal_target_config(enable_metal4: bool) -> dict[str, object]:
     keys = ["metal", "gpu"]
     if enable_metal4:
         keys.append("metal4")
-    return {"kind": "metal", "keys": keys}
+    return {
+        "kind": "metal",
+        "keys": keys,
+        "thread_warp_size": 32,
+        "max_threads_per_block": 1024,
+        "max_shared_memory_per_block": 32768,
+    }
 
 
 def _detect_metal_target() -> Target | str | None:

--- a/tilelang/rocm/backend.py
+++ b/tilelang/rocm/backend.py
@@ -1,14 +1,27 @@
 from __future__ import annotations
 
 from tilelang.backend.device_codegen import DeviceCodegen
+from tilelang.backend.capabilities import MatrixInstruction, target_limits
 from tilelang.backend.host_codegen import STANDARD_HOST_CODEGENS
 from tilelang.backend.pass_pipeline import PassPipeline
 from tilelang.backend.module import BackendModule, register_backend
 from tilelang.contrib import hipcc
 from tilelang.env import TILELANG_TEMPLATE_PATH
-from tilelang.rocm.target import target_get_mcpu
+from tilelang.rocm.target import target_get_mcpu, target_get_warp_size
 
 from . import codegen, execution_backend, pipeline
+
+
+def _capabilities(target):
+    return target_limits(
+        target,
+        subgroup_width=target_get_warp_size(target),
+        matrix_instructions=(
+            MatrixInstruction(16, 16, 16, "float16", "float32"),
+            MatrixInstruction(16, 16, 16, "bfloat16", "float32"),
+        ),
+        features=frozenset({"subgroup_exchange", "atomic.add.float32", "atomic.add.int32"}),
+    )
 
 
 def tilelang_callback_hip_compile(code, target):
@@ -39,6 +52,7 @@ BACKEND = register_backend(
             )
         },
         execution_backends=execution_backend.EXECUTION_BACKENDS,
+        capabilities=_capabilities,
         host_codegens=STANDARD_HOST_CODEGENS,
         callbacks={"tilelang_callback_hip_compile": tilelang_callback_hip_compile},
     )

--- a/tilelang/rocm/execution_backend.py
+++ b/tilelang/rocm/execution_backend.py
@@ -4,6 +4,12 @@ from tilelang.backend.execution_backend import ExecutionBackendSpec
 
 
 EXECUTION_BACKENDS = [
-    ExecutionBackendSpec("tvm_ffi", enable_host_codegen=True, enable_device_compile=True),
+    ExecutionBackendSpec(
+        "tvm_ffi",
+        enable_host_codegen=True,
+        enable_device_compile=True,
+        native_multi_launch=True,
+        native_argument_binding=True,
+    ),
     ExecutionBackendSpec("cython"),
 ]

--- a/tilelang/webgpu/backend.py
+++ b/tilelang/webgpu/backend.py
@@ -1,12 +1,18 @@
 """WebGPU backend manifest."""
 
 from tilelang.backend.device_codegen import DeviceCodegen
+from tilelang.backend.capabilities import target_limits
 from tilelang.backend.execution_backend import ExecutionBackendSpec
 from tilelang.backend.host_codegen import STANDARD_HOST_CODEGENS
 from tilelang.backend.pass_pipeline import PassPipeline
 from tilelang.backend.module import BackendModule, register_backend
 
 from . import codegen, pipeline
+
+
+def _capabilities(target):
+    return target_limits(target, subgroup_width=1)
+
 
 BACKEND = register_backend(
     BackendModule(
@@ -20,7 +26,16 @@ BACKEND = register_backend(
                 build_without_compile=codegen.build_webgpu,
             )
         },
-        execution_backends=(ExecutionBackendSpec("tvm_ffi", enable_host_codegen=True, enable_device_compile=True),),
+        execution_backends=(
+            ExecutionBackendSpec(
+                "tvm_ffi",
+                enable_host_codegen=True,
+                enable_device_compile=True,
+                native_multi_launch=True,
+                native_argument_binding=True,
+            ),
+        ),
+        capabilities=_capabilities,
         host_codegens=STANDARD_HOST_CODEGENS,
     )
 )


### PR DESCRIPTION
## Problem

Compiler clients need target and execution facts that legitimately affect lowering and scheduling, but TileLang does not expose one resolved capability contract. Clients otherwise have to infer behavior from backend names, inspect internals, or maintain duplicate target tables.

## Change

- Add immutable backend capability and matrix-instruction records.
- Report subgroup width, thread and shared-memory limits, supported dtypes, matrix instructions, behavioral features, and native execution facilities.
- Attach a capability provider to every backend manifest.
- Merge target capabilities with the selected execution backend in `BackendContext`.
- Add a stable capability fingerprint suitable for compilation-cache keys.
- Normalize Metal target limits so they are available through the same target mechanism as other backends.

## Tests

- Rebuilt TileLang with `USE_METAL=ON USE_CUDA=OFF USE_ROCM=OFF` from this branch's exact source.
- `pytest -q testing/python/backend/test_tilelang_backend_module.py`: 18 passed.
- `pre-commit run --files ...` and `git diff --check`: passed.

## Validation

Verified that a resolved Metal/TVM-FFI context reports both target and execution capabilities and that changing the execution backend changes the capability fingerprint.

## Related

Depends conceptually on the native packed-function argument-binding PR because the TVM-FFI execution specification advertises that facility. It should be reviewed and landed after that PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds resolved backend capability contracts for compiler clients.

## Changes

- Adds immutable `BackendCapabilities` and `MatrixInstruction` records.
- Exposes target limits, supported data types, matrix instructions, features, and execution capabilities.
- Attaches capability providers to CPU, CUDA, ROCm, Metal, and WebGPU backend modules.
- Merges target capabilities with the selected execution backend in `BackendContext`.
- Adds capability fingerprints for compilation-cache keys.
- Adds native multi-launch and argument-binding flags to execution backend specifications.
- Normalizes Metal target limits through the common target mechanism.

## Validation

- Added backend context and capability fingerprint tests.
- Passed 18 backend module tests.
- Passed pre-commit checks.
- Completed successful Metal builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->