### PR TITLE
[Metal] Support runtime-valid GEMM rows

### DIFF
--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -76,6 +76,7 @@ void RegisterGemmImpl(GemmImpl impl) {
  *      M (Int), N (Int), K (Int), policy (Int), clear_accum (Bool),
  *      (optional) mbar (BufferLoad or const-0 placeholder),
  *      cCoord_y (PrimExpr), cCoord_x (PrimExpr),
+ *      (optional) valid_m (PrimExpr), or
  *      (optional, blockscaled) SFA, SFB regions, k_start (PrimExpr)]
  *   Backend lowering knobs (k_pack, wg_wait) ride in the annotations map.
  */
@@ -101,6 +102,7 @@ Gemm::Gemm(Array<PrimExpr> args, Map<String, ObjectRef> annotations) {
   node->k_ = args[7].as<IntImm>().value()->value;
   node->policy_ = GemmWarpPolicy(args[8].as<IntImm>().value()->value);
   node->clearAccum_ = args[9].as<PrimExpr>().value();
+  node->validM_ = IntImm(DataType::Int(32), node->m_);
   // k_pack rides in the annotations (a ROCm MFMA/WMMA lowering knob set by
   // the ROCm dialect), not in the positional call protocol.
   if (auto val = annotations.Get("k_pack")) {
@@ -131,13 +133,11 @@ Gemm::Gemm(Array<PrimExpr> args, Map<String, ObjectRef> annotations) {
   }
   node->cCoords_ = Array<PrimExpr>(
       {args[11].as<PrimExpr>().value(), args[12].as<PrimExpr>().value()});
-  if (args.size() > 13) {
+  if (args.size() == 14) {
+    node->validM_ = args[13].as<PrimExpr>().value();
+  } else if (args.size() > 13) {
     node->sfaRegion_ = NormalizeToBufferRegion(args[13]);
-  }
-  if (args.size() > 14) {
     node->sfbRegion_ = NormalizeToBufferRegion(args[14]);
-  }
-  if (args.size() > 15) {
     node->sfKStart_ = args[15].as<PrimExpr>().value();
   }
   node->annotations_ = annotations;

--- a/src/op/gemm.h
+++ b/src/op/gemm.h
@@ -108,6 +108,9 @@ public:
   bool transA_, transB_;
   int m_, n_, k_;
   PrimExpr clearAccum_ = const_false();
+  // Runtime-valid prefix of the static M tile. Backends predicate whole
+  // instruction rows outside [0, validM_); the physical tile remains static.
+  PrimExpr validM_;
   tirx::BufferLoad mbar_; // mbar is optional, only used for TCGEN5MMA
   Array<PrimExpr> cCoords_;
   // k_pack please ref to bitblas/tl/mfma_macro_generator.py::k_pack
@@ -138,6 +141,7 @@ public:
         .def_ro("n", &GemmNode::n_)
         .def_ro("k", &GemmNode::k_)
         .def_ro("clearAccum", &GemmNode::clearAccum_)
+        .def_ro("validM", &GemmNode::validM_)
         .def_ro("mbar", &GemmNode::mbar_)
         .def_ro("cCoords", &GemmNode::cCoords_)
         .def_ro("kPack", &GemmNode::kPack_)

--- a/testing/python/metal/test_metal_gemm_valid_m.py
+++ b/testing/python/metal/test_metal_gemm_valid_m.py
@@ -1,0 +1,79 @@
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+import pytest
+import torch
+from tilelang import tvm
+
+
+M, N, K = 64, 32, 16
+
+
+@T.prim_func
+def partial_m_gemm(
+    a: T.Tensor((M, K), T.float16),
+    b: T.Tensor((K, N), T.float16),
+    output: T.Tensor((M, N), T.float32),
+    valid_m: T.int32,
+):
+    with T.Kernel(1, threads=128):
+        a_shared = T.alloc_shared((M, K), T.float16)
+        b_shared = T.alloc_shared((K, N), T.float16)
+        accum = T.alloc_fragment((M, N), T.float32)
+        T.copy(a, a_shared)
+        T.copy(b, b_shared)
+        T.fill(accum, -7.0)
+        T.gemm(a_shared, b_shared, accum, clear_accum=True, valid_m=valid_m)
+        T.copy(accum, output)
+
+
+def test_runtime_valid_m_is_preserved_in_metal_codegen():
+    with tvm.transform.PassContext(), tvm.target.Target("metal"):
+        artifact = tilelang.lower(
+            partial_m_gemm,
+            target="metal",
+            enable_host_codegen=False,
+            enable_device_compile=False,
+        )
+    source = artifact.kernel_source
+    assert "< arg.bound[0]" in source
+    assert "<= arg.bound[0]" in source
+    assert "simdgroup_multiply_accumulate" in source
+
+
+def test_static_valid_m_is_validated_at_construction():
+    with pytest.raises(ValueError, match="valid_m must be in"):
+
+        @T.prim_func
+        def invalid(
+            a: T.Tensor((M, K), T.float16),
+            b: T.Tensor((K, N), T.float16),
+            output: T.Tensor((M, N), T.float32),
+        ):
+            with T.Kernel(1, threads=128):
+                T.gemm(a, b, output, clear_accum=True, valid_m=M + 1)
+
+
+@tilelang.testing.requires_metal
+def test_runtime_valid_m_skips_wholly_invalid_instruction_rows():
+    compiled = tilelang.compile(
+        partial_m_gemm,
+        out_idx=[],
+        target="metal",
+        target_host="c",
+        execution_backend="tvm_ffi",
+    )
+    a = torch.randn((M, K), dtype=torch.float16, device="mps")
+    b = torch.randn((K, N), dtype=torch.float16, device="mps")
+    output = torch.full((M, N), -7.0, dtype=torch.float32, device="mps")
+    valid_m = 17
+    compiled(a, b, output, valid_m)
+    torch.mps.synchronize()
+
+    expected = a.float() @ b.float()
+    torch.testing.assert_close(output[:valid_m].cpu(), expected[:valid_m].cpu(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(output[32:].cpu(), torch.full((M - 32, N), -7.0))
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/cuda/language/gemm_op.py
+++ b/tilelang/cuda/language/gemm_op.py
@@ -21,6 +21,7 @@ def gemm(
     clear_accum: bool = False,
     mbar: BarrierType | None = None,
     annotations: dict | None = None,
+    valid_m: int | tirx.PrimExpr | None = None,
 ) -> tirx.PrimExpr:
     """TileLang GEMM operator for CUDA.
 
@@ -45,6 +46,7 @@ def gemm(
         mbar (BarrierType, i.e. Buffer | BufferLoad, or Var, optional): Mbarrier in Blackwell.
             Required when this GEMM lowers to TCGEN5MMA. Defaults to None.
         annotations (Optional[dict]): Additional annotations.
+        valid_m (int | PrimExpr | None): Runtime-valid prefix of the M axis.
 
     Returns:
         tirx.Call: A handle to the GEMM operation.
@@ -60,6 +62,7 @@ def gemm(
         clear_accum,
         mbar,
         annotations=annotations,
+        valid_m=valid_m,
     )
 
 

--- a/tilelang/language/gemm_op.py
+++ b/tilelang/language/gemm_op.py
@@ -29,6 +29,7 @@ def _gemm_impl(
     clear_accum: bool = False,
     mbar: BarrierType | None = None,
     annotations: dict | None = None,
+    valid_m: int | tirx.PrimExpr | None = None,
 ) -> tirx.PrimExpr:
     """Shared GEMM implementation.
 
@@ -93,6 +94,13 @@ def _gemm_impl(
         if not isinstance(dim, tirx.IntImm):
             raise ValueError(f"T.gemm requires static tile dimensions, but {name} is symbolic: {dim}")
 
+    if valid_m is not None and (isinstance(valid_m, bool) or not isinstance(valid_m, (int, tirx.PrimExpr))):
+        raise TypeError(f"T.gemm valid_m must be an int, PrimExpr, or None, got {valid_m!r}")
+    elif isinstance(valid_m, int):
+        if not 0 <= valid_m <= int(M):
+            raise ValueError(f"T.gemm valid_m must be in [0, {int(M)}], got {valid_m}")
+        valid_m = tirx.const(valid_m, dtype=M.dtype)
+
     if mbar is not None:
         assert isinstance(mbar, (tirx.Buffer, tirx.BufferLoad)), (
             f"mbar for tcgen5mma must be a tirx.Buffer or tirx.BufferLoad, but got {type(mbar)}"
@@ -107,9 +115,7 @@ def _gemm_impl(
     # accepts the mbar slot when it is a BufferLoadNode, so the placeholder is
     # correctly ignored.
     mbar_arg = mbar if mbar is not None else tirx.const(0, dtype="int32")
-    return tirx.call_intrin(
-        "handle",
-        tirx.op.Op.get(op_key),
+    call_args = [
         A_arg,
         B_arg,
         C_arg,
@@ -123,6 +129,13 @@ def _gemm_impl(
         mbar_arg,
         C_coords[0],
         C_coords[1],
+    ]
+    if valid_m is not None:
+        call_args.append(valid_m)
+    return tirx.call_intrin(
+        "handle",
+        tirx.op.Op.get(op_key),
+        *call_args,
         annotations=annotations,
     )
 
@@ -136,6 +149,7 @@ def gemm(
     policy: GemmWarpPolicy = GemmWarpPolicy.Square,
     clear_accum: bool = False,
     annotations: dict | None = None,
+    valid_m: int | tirx.PrimExpr | None = None,
 ) -> tirx.PrimExpr:
     """TileLang GEMM operator.
 
@@ -157,6 +171,9 @@ def gemm(
         policy (GemmWarpPolicy): GEMM warp partition policy.
         clear_accum (bool): Whether to clear the accumulator.
         annotations (Optional[dict]): Additional annotations.
+        valid_m (int | PrimExpr | None): Runtime-valid prefix of the M axis.
+            The physical A/C tile shapes remain static. Rows in ``[0, valid_m)``
+            are computed; the suffix is unspecified. Defaults to the full tile.
 
     Backend dialects extend this signature with their hardware's knobs:
     ``tilelang.cuda.language.gemm`` adds ``mbar`` (Blackwell TCGEN5MMA
@@ -176,6 +193,7 @@ def gemm(
         clear_accum,
         None,
         annotations=annotations,
+        valid_m=valid_m,
     )
 
 

--- a/tilelang/metal/intrinsics/metal_macro_generator.py
+++ b/tilelang/metal/intrinsics/metal_macro_generator.py
@@ -108,7 +108,14 @@ class MPSIntrinEmitter:
             stride = buffer.shape[-1]
         return buffer, extra, off_row, off_col, stride
 
-    def ldmatrix_a(self, A_local_buf, A_shared_buf: Buffer | BufferRegion, ki, k_inner: int = 0):
+    def ldmatrix_a(
+        self,
+        A_local_buf,
+        A_shared_buf: Buffer | BufferRegion,
+        ki,
+        k_inner: int = 0,
+        valid_m: tir.PrimExpr | None = None,
+    ):
         """Load matrix A tiles from memory into simdgroup/cooperative tensor buffers."""
         warp_rows = self.warp_rows
         warp_row_tiles = self.warp_row_tiles
@@ -132,37 +139,46 @@ class MPSIntrinEmitter:
                 else:
                     row_idx = offset_m + warp_m * warp_row_tiles + i * micro_size_x
                     col_idx = offset_k + ki * micro_size_k
-                ptr = T.access_ptr(buffer[extra + (row_idx, col_idx)], "r")
-                if use_cooperative_tensor:
-                    T.cooperative_tensor_load(
-                        A_local_buf.data,
-                        k_inner * warp_rows + i,
-                        ptr,
-                        stride,
-                        micro_size_x,
-                        micro_size_k,
-                        T.bool(a_transposed),
-                        micro_size_x,
-                        micro_size_y,
-                        micro_size_k,
-                        OPERAND_LEFT,
-                    )
-                else:
-                    T.simdgroup_load(
-                        A_local_buf.data,
-                        i,
-                        ptr,
-                        stride,
-                        micro_size_x,
-                        micro_size_k,
-                        T.bool(a_transposed),
-                    )
+                if valid_m is None or warp_m * warp_row_tiles + i * micro_size_x < valid_m:
+                    ptr = T.access_ptr(buffer[extra + (row_idx, col_idx)], "r")
+                    if use_cooperative_tensor:
+                        T.cooperative_tensor_load(
+                            A_local_buf.data,
+                            k_inner * warp_rows + i,
+                            ptr,
+                            stride,
+                            micro_size_x,
+                            micro_size_k,
+                            T.bool(a_transposed),
+                            micro_size_x,
+                            micro_size_y,
+                            micro_size_k,
+                            OPERAND_LEFT,
+                        )
+                    else:
+                        T.simdgroup_load(
+                            A_local_buf.data,
+                            i,
+                            ptr,
+                            stride,
+                            micro_size_x,
+                            micro_size_k,
+                            T.bool(a_transposed),
+                        )
 
         return _warp_ldmatrix_a(A_local_buf, buffer, offset_m, offset_k, stride, warp_m, ki)
 
-    def ldmatrix_b(self, B_local_buf, B_shared_buf: Buffer | BufferRegion, ki, k_inner: int = 0):
+    def ldmatrix_b(
+        self,
+        B_local_buf,
+        B_shared_buf: Buffer | BufferRegion,
+        ki,
+        k_inner: int = 0,
+        valid_m: tir.PrimExpr | None = None,
+    ):
         """Load matrix B tiles from memory into simdgroup/cooperative tensor buffers."""
         warp_cols = self.warp_cols
+        warp_row_tiles = self.warp_row_tiles
         warp_col_tiles = self.warp_col_tiles
         micro_size_x = self.micro_size_x
         micro_size_y = self.micro_size_y
@@ -170,94 +186,106 @@ class MPSIntrinEmitter:
         b_transposed = self.b_transposed
         use_cooperative_tensor = self.use_cooperative_tensor
 
-        _, warp_n = self._get_warp_indices()
+        warp_m, warp_n = self._get_warp_indices()
         buffer, extra, offset_k, offset_n, stride = self._parse_buffer_nd(B_shared_buf)
         if self.b_stride_override is not None:
             stride = self.b_stride_override
 
         @T.macro
         def _warp_ldmatrix_b(B_local_buf, buffer, offset_k, offset_n, stride, warp_n, ki):
-            for j in T.serial(warp_cols):
-                if b_transposed:
-                    row_idx = offset_n + warp_n * warp_col_tiles + j * micro_size_y
-                    col_idx = offset_k + ki * micro_size_k
-                else:
-                    row_idx = offset_k + ki * micro_size_k
-                    col_idx = offset_n + warp_n * warp_col_tiles + j * micro_size_y
-                ptr = T.access_ptr(buffer[extra + (row_idx, col_idx)], "r")
-                if use_cooperative_tensor:
-                    T.cooperative_tensor_load(
-                        B_local_buf.data,
-                        k_inner * warp_cols + j,
-                        ptr,
-                        stride,
-                        micro_size_k,
-                        micro_size_y,
-                        T.bool(b_transposed),
-                        micro_size_x,
-                        micro_size_y,
-                        micro_size_k,
-                        OPERAND_RIGHT,
-                    )
-                else:
-                    T.simdgroup_load(
-                        B_local_buf.data,
-                        j,
-                        ptr,
-                        stride,
-                        micro_size_k,
-                        micro_size_y,
-                        T.bool(b_transposed),
-                    )
+            if valid_m is None or warp_m * warp_row_tiles < valid_m:
+                for j in T.serial(warp_cols):
+                    if b_transposed:
+                        row_idx = offset_n + warp_n * warp_col_tiles + j * micro_size_y
+                        col_idx = offset_k + ki * micro_size_k
+                    else:
+                        row_idx = offset_k + ki * micro_size_k
+                        col_idx = offset_n + warp_n * warp_col_tiles + j * micro_size_y
+                    ptr = T.access_ptr(buffer[extra + (row_idx, col_idx)], "r")
+                    if use_cooperative_tensor:
+                        T.cooperative_tensor_load(
+                            B_local_buf.data,
+                            k_inner * warp_cols + j,
+                            ptr,
+                            stride,
+                            micro_size_k,
+                            micro_size_y,
+                            T.bool(b_transposed),
+                            micro_size_x,
+                            micro_size_y,
+                            micro_size_k,
+                            OPERAND_RIGHT,
+                        )
+                    else:
+                        T.simdgroup_load(
+                            B_local_buf.data,
+                            j,
+                            ptr,
+                            stride,
+                            micro_size_k,
+                            micro_size_y,
+                            T.bool(b_transposed),
+                        )
 
         return _warp_ldmatrix_b(B_local_buf, buffer, offset_k, offset_n, stride, warp_n, ki)
 
-    def mma(self, A_local_buf, B_local_buf, C_local_buf, k_inner: int = 0):
+    def mma(
+        self,
+        A_local_buf,
+        B_local_buf,
+        C_local_buf,
+        k_inner: int = 0,
+        valid_m: tir.PrimExpr | None = None,
+    ):
         """Perform matrix multiply-accumulate: C += A * B."""
         warp_rows = self.warp_rows
         warp_cols = self.warp_cols
+        warp_row_tiles = self.warp_row_tiles
         micro_size_x = self.micro_size_x
         micro_size_y = self.micro_size_y
         micro_size_k = self.micro_size_k
         a_transposed = self.a_transposed
         b_transposed = self.b_transposed
         use_cooperative_tensor = self.use_cooperative_tensor
+        warp_m, _ = self._get_warp_indices()
 
         @T.macro
         def _warp_mma(A_local_buf, B_local_buf, C_local_buf):
-            for i, j in T.grid(warp_rows, warp_cols):
-                index_c = i * warp_cols + j
-                if use_cooperative_tensor:
-                    T.cooperative_tensor_multiply_accumulate(
-                        C_local_buf.data,
-                        index_c,
-                        A_local_buf.data,
-                        k_inner * warp_rows + i,
-                        B_local_buf.data,
-                        k_inner * warp_cols + j,
-                        C_local_buf.data,
-                        index_c,
-                        micro_size_x,
-                        micro_size_y,
-                        micro_size_k,
-                        T.bool(a_transposed),
-                        T.bool(b_transposed),
-                    )
-                else:
-                    T.simdgroup_multiply_accumulate(
-                        C_local_buf.data,
-                        index_c,
-                        A_local_buf.data,
-                        i,
-                        B_local_buf.data,
-                        j,
-                        C_local_buf.data,
-                        index_c,
-                    )
+            for i in T.serial(warp_rows):
+                if valid_m is None or warp_m * warp_row_tiles + i * micro_size_x < valid_m:
+                    for j in T.serial(warp_cols):
+                        index_c = i * warp_cols + j
+                        if use_cooperative_tensor:
+                            T.cooperative_tensor_multiply_accumulate(
+                                C_local_buf.data,
+                                index_c,
+                                A_local_buf.data,
+                                k_inner * warp_rows + i,
+                                B_local_buf.data,
+                                k_inner * warp_cols + j,
+                                C_local_buf.data,
+                                index_c,
+                                micro_size_x,
+                                micro_size_y,
+                                micro_size_k,
+                                T.bool(a_transposed),
+                                T.bool(b_transposed),
+                            )
+                        else:
+                            T.simdgroup_multiply_accumulate(
+                                C_local_buf.data,
+                                index_c,
+                                A_local_buf.data,
+                                i,
+                                B_local_buf.data,
+                                j,
+                                C_local_buf.data,
+                                index_c,
+                            )
 
         return _warp_mma(A_local_buf, B_local_buf, C_local_buf)
 
-    def simdgroup_copy(self, C_simd_buf, C_dst, is_store=True):
+    def simdgroup_copy(self, C_simd_buf, C_dst, is_store=True, valid_m: tir.PrimExpr | None = None):
         """Copy between register-backed Metal matrix buffers and memory."""
         warp_rows = self.warp_rows
         warp_cols = self.warp_cols
@@ -277,35 +305,37 @@ class MPSIntrinEmitter:
 
         @T.macro
         def _simdgroup_copy(C_simd_buf, buffer, offset_m, offset_n, stride, warp_m, warp_n):
-            for i, j in T.grid(warp_rows, warp_cols):
-                row = offset_m + warp_m * warp_row_tiles + i * micro_size_x
-                col = offset_n + warp_n * warp_col_tiles + j * micro_size_y
-                index_c = i * warp_cols + j
-                ptr = T.access_ptr(buffer[extra + (row, col)], access_mode)
-                if use_cooperative_tensor:
-                    ct_op(
-                        C_simd_buf.data,
-                        index_c,
-                        ptr,
-                        stride,
-                        micro_size_x,
-                        micro_size_y,
-                        T.bool(False),
-                        micro_size_x,
-                        micro_size_y,
-                        micro_size_k,
-                        OPERAND_DEST,
-                    )
-                else:
-                    simd_op(
-                        C_simd_buf.data,
-                        index_c,
-                        ptr,
-                        stride,
-                        micro_size_x,
-                        micro_size_y,
-                        T.bool(False),
-                    )
+            for i in T.serial(warp_rows):
+                if valid_m is None or warp_m * warp_row_tiles + i * micro_size_x < valid_m:
+                    for j in T.serial(warp_cols):
+                        row = offset_m + warp_m * warp_row_tiles + i * micro_size_x
+                        col = offset_n + warp_n * warp_col_tiles + j * micro_size_y
+                        index_c = i * warp_cols + j
+                        ptr = T.access_ptr(buffer[extra + (row, col)], access_mode)
+                        if use_cooperative_tensor:
+                            ct_op(
+                                C_simd_buf.data,
+                                index_c,
+                                ptr,
+                                stride,
+                                micro_size_x,
+                                micro_size_y,
+                                T.bool(False),
+                                micro_size_x,
+                                micro_size_y,
+                                micro_size_k,
+                                OPERAND_DEST,
+                            )
+                        else:
+                            simd_op(
+                                C_simd_buf.data,
+                                index_c,
+                                ptr,
+                                stride,
+                                micro_size_x,
+                                micro_size_y,
+                                T.bool(False),
+                            )
 
         return _simdgroup_copy(C_simd_buf, buffer, offset_m, offset_n, stride, warp_m, warp_n)
 
@@ -342,10 +372,10 @@ class MPSIntrinEmitter:
 
         return T.Fragment(shape, forward_thread_fn=forward_thread, forward_index_fn=forward_index)
 
-    def simd_store(self, C_simd_buf, C_dst):
+    def simd_store(self, C_simd_buf, C_dst, valid_m: tir.PrimExpr | None = None):
         """Store simdgroup/cooperative tensor local buffer to memory."""
-        return self.simdgroup_copy(C_simd_buf, C_dst, is_store=True)
+        return self.simdgroup_copy(C_simd_buf, C_dst, is_store=True, valid_m=valid_m)
 
-    def simd_load(self, C_simd_buf, C_src):
+    def simd_load(self, C_simd_buf, C_src, valid_m: tir.PrimExpr | None = None):
         """Load memory into simdgroup/cooperative tensor local buffer."""
-        return self.simdgroup_copy(C_simd_buf, C_src, is_store=False)
+        return self.simdgroup_copy(C_simd_buf, C_src, is_store=False, valid_m=valid_m)

--- a/tilelang/metal/op/gemm/gemm_metal.py
+++ b/tilelang/metal/op/gemm/gemm_metal.py
@@ -15,6 +15,7 @@ from tilelang.utils.language import (
     is_global,
     is_shared,
 )
+from tvm import arith
 from tvm import tirx as tir
 from tvm.ir import Range
 from tvm.target import Target
@@ -22,6 +23,18 @@ from tvm.target import Target
 
 GEMM_INST_METAL = "metal.simdgroup"
 GEMM_INST_METAL_COOPERATIVE_TENSOR = "metal.cooperative_tensor"
+
+
+def _partial_m_extent(gemm: GemmBase):
+    """Return a runtime M bound, or None for the ordinary full-tile path."""
+    valid_m = gemm.valid_m
+    if arith.Analyzer().can_prove_equal(valid_m, gemm.M):
+        return None
+    if isinstance(valid_m, tir.IntImm):
+        extent = int(valid_m)
+        if not 0 <= extent <= int(gemm.M):
+            raise ValueError(f"Metal T.gemm valid_m must be in [0, {gemm.M}], got {extent}")
+    return valid_m
 
 
 def _make_padded_layout(buffer):
@@ -36,6 +49,8 @@ def _make_padded_layout(buffer):
 
 
 class GemmMetalSimdGroup(GemmBase):
+    supports_runtime_valid_m = True
+
     def is_gemm_ss(self) -> bool:
         return is_shared(self.A) and is_shared(self.B)
 
@@ -80,6 +95,11 @@ class GemmMetalSimdGroup(GemmBase):
         num_simd_c = warp_rows * warp_cols
         block_K = mps_emitter.chunk
         micro_size_k = mps_emitter.micro_size_k
+        micro_size_x = mps_emitter.micro_size_x
+        valid_m = _partial_m_extent(self)
+        warp_m, _ = mps_emitter._get_warp_indices()
+        warp_start_m = warp_m * warp_row_tiles
+        warp_end_m = warp_start_m + warp_row_tiles
 
         A_region = self.ARegion
         B_region = self.BRegion
@@ -97,19 +117,33 @@ class GemmMetalSimdGroup(GemmBase):
         if not self.is_gemm_ss():
             raise ValueError(f"Unsupported gemm combination, A: {self.A.scope()}, B: {self.B.scope()}")
 
+        @T.macro
+        def multiply(A_local, B_local, C_local, bound):
+            for ki in T.serial(block_K // micro_size_k):
+                mps_emitter.ldmatrix_a(A_local, A_region, ki, valid_m=bound)
+                mps_emitter.ldmatrix_b(B_local, B_region, ki, valid_m=bound)
+                mps_emitter.mma(A_local, B_local, C_local, ki, bound)
+
         if c_in_register:
 
             @T.prim_func
             def _gemm_ss_simdgroup() -> None:
                 A_local = T.alloc_local((warp_rows * 64), a_dtype, scope="metal.simdgroup")
                 B_local = T.alloc_local((warp_cols * 64), b_dtype, scope="metal.simdgroup")
-                if clear_accum:
-                    for _i in T.serial(num_simd_c):
-                        T.make_filled_simdgroup_matrix(C_buf.data, _i, T.cast(0, accum_dtype))
-                for ki in T.serial(0, (block_K // micro_size_k)):
-                    mps_emitter.ldmatrix_a(A_local, A_region, ki)
-                    mps_emitter.ldmatrix_b(B_local, B_region, ki)
-                    mps_emitter.mma(A_local, B_local, C_buf)
+                if valid_m is None:
+                    if clear_accum:
+                        for _i in T.serial(num_simd_c):
+                            T.make_filled_simdgroup_matrix(C_buf.data, _i, T.cast(0, accum_dtype))
+                    multiply(A_local, B_local, C_buf, None)
+                elif warp_start_m < valid_m:
+                    if clear_accum:
+                        for _i in T.serial(num_simd_c):
+                            if warp_start_m + (_i // warp_cols) * micro_size_x < valid_m:
+                                T.make_filled_simdgroup_matrix(C_buf.data, _i, T.cast(0, accum_dtype))
+                    if warp_end_m <= valid_m:
+                        multiply(A_local, B_local, C_buf, None)
+                    else:
+                        multiply(A_local, B_local, C_buf, valid_m)
 
             return _Simplify(_gemm_ss_simdgroup, inline_let=True)
 
@@ -118,21 +152,33 @@ class GemmMetalSimdGroup(GemmBase):
             A_local = T.alloc_local((warp_rows * 64), a_dtype, scope="metal.simdgroup")
             B_local = T.alloc_local((warp_cols * 64), b_dtype, scope="metal.simdgroup")
             C_simd = T.alloc_local((num_simd_c * 64), accum_dtype, scope="metal.simdgroup")
-            if clear_accum:
-                for _i in T.serial(num_simd_c):
-                    T.make_filled_simdgroup_matrix(C_simd.data, _i, T.cast(0, accum_dtype))
-            else:
-                mps_emitter.simd_load(C_simd, C_buf)
-            for ki in T.serial(0, (block_K // micro_size_k)):
-                mps_emitter.ldmatrix_a(A_local, A_region, ki)
-                mps_emitter.ldmatrix_b(B_local, B_region, ki)
-                mps_emitter.mma(A_local, B_local, C_simd)
-            mps_emitter.simd_store(C_simd, C_buf)
+            if valid_m is None:
+                if clear_accum:
+                    for _i in T.serial(num_simd_c):
+                        T.make_filled_simdgroup_matrix(C_simd.data, _i, T.cast(0, accum_dtype))
+                else:
+                    mps_emitter.simd_load(C_simd, C_buf)
+                multiply(A_local, B_local, C_simd, None)
+                mps_emitter.simd_store(C_simd, C_buf)
+            elif warp_start_m < valid_m:
+                if clear_accum:
+                    for _i in T.serial(num_simd_c):
+                        if warp_start_m + (_i // warp_cols) * micro_size_x < valid_m:
+                            T.make_filled_simdgroup_matrix(C_simd.data, _i, T.cast(0, accum_dtype))
+                else:
+                    mps_emitter.simd_load(C_simd, C_buf, valid_m=valid_m)
+                if warp_end_m <= valid_m:
+                    multiply(A_local, B_local, C_simd, None)
+                else:
+                    multiply(A_local, B_local, C_simd, valid_m)
+                mps_emitter.simd_store(C_simd, C_buf, valid_m=valid_m)
 
         return _Simplify(_gemm_ss_shared, inline_let=True)
 
 
 class GemmMetal(GemmBase):
+    supports_runtime_valid_m = True
+
     def is_gemm_ss(self) -> bool:
         return is_shared(self.A) and is_shared(self.B)
 
@@ -265,6 +311,8 @@ class GemmMetal(GemmBase):
         a_tile_elems = micro_size_x * micro_size_k
         b_tile_elems = micro_size_k * micro_size_y
         c_tile_elems = micro_size_x * micro_size_y
+        valid_m = _partial_m_extent(self)
+        warp_m, _ = mps_emitter._get_warp_indices()
 
         A_region = self.ARegion
         B_region = self.BRegion
@@ -286,14 +334,15 @@ class GemmMetal(GemmBase):
                 B_local = T.alloc_local((warp_cols * b_tile_elems * inner_k_steps), b_dtype, scope="metal.cooperative_tensor")
                 if clear_accum:
                     for _i in T.serial(num_simd_c):
-                        T.cooperative_tensor_fill(C_buf.data, _i, T.cast(0, accum_dtype), micro_size_x, micro_size_y)
+                        if valid_m is None or warp_m * warp_row_tiles + (_i // warp_cols) * micro_size_x < valid_m:
+                            T.cooperative_tensor_fill(C_buf.data, _i, T.cast(0, accum_dtype), micro_size_x, micro_size_y)
                 for k_outer in T.serial(0, (block_K // (micro_size_k * inner_k_steps))):
                     for k_inner in T.serial(0, inner_k_steps):
                         ki = k_outer * inner_k_steps + k_inner
-                        mps_emitter.ldmatrix_a(A_local, A_region, ki, k_inner)
-                        mps_emitter.ldmatrix_b(B_local, B_region, ki, k_inner)
+                        mps_emitter.ldmatrix_a(A_local, A_region, ki, k_inner, valid_m)
+                        mps_emitter.ldmatrix_b(B_local, B_region, ki, k_inner, valid_m)
                     for k_inner in T.serial(0, inner_k_steps):
-                        mps_emitter.mma(A_local, B_local, C_buf, k_inner)
+                        mps_emitter.mma(A_local, B_local, C_buf, k_inner, valid_m)
 
             return _Simplify(_gemm_cooperative_tensor, inline_let=True)
 
@@ -304,16 +353,17 @@ class GemmMetal(GemmBase):
             C_ct = T.alloc_local((num_simd_c * c_tile_elems), accum_dtype, scope="metal.cooperative_tensor")
             if clear_accum:
                 for _i in T.serial(num_simd_c):
-                    T.cooperative_tensor_fill(C_ct.data, _i, T.cast(0, accum_dtype), micro_size_x, micro_size_y)
+                    if valid_m is None or warp_m * warp_row_tiles + (_i // warp_cols) * micro_size_x < valid_m:
+                        T.cooperative_tensor_fill(C_ct.data, _i, T.cast(0, accum_dtype), micro_size_x, micro_size_y)
             else:
-                mps_emitter.simd_load(C_ct, C_region)
+                mps_emitter.simd_load(C_ct, C_region, valid_m=valid_m)
             for k_outer in T.serial(0, (block_K // (micro_size_k * inner_k_steps))):
                 for k_inner in T.serial(0, inner_k_steps):
                     ki = k_outer * inner_k_steps + k_inner
-                    mps_emitter.ldmatrix_a(A_local, A_region, ki, k_inner)
-                    mps_emitter.ldmatrix_b(B_local, B_region, ki, k_inner)
+                    mps_emitter.ldmatrix_a(A_local, A_region, ki, k_inner, valid_m)
+                    mps_emitter.ldmatrix_b(B_local, B_region, ki, k_inner, valid_m)
                 for k_inner in T.serial(0, inner_k_steps):
-                    mps_emitter.mma(A_local, B_local, C_ct, k_inner)
-            mps_emitter.simd_store(C_ct, C_region)
+                    mps_emitter.mma(A_local, B_local, C_ct, k_inner, valid_m)
+            mps_emitter.simd_store(C_ct, C_region, valid_m=valid_m)
 
         return _Simplify(_gemm_with_c_writeback, inline_let=True)

--- a/tilelang/rocm/language/gemm_op.py
+++ b/tilelang/rocm/language/gemm_op.py
@@ -21,6 +21,7 @@ def gemm(
     clear_accum: bool = False,
     k_pack: int = 1,
     annotations: dict | None = None,
+    valid_m: int | tirx.PrimExpr | None = None,
 ) -> tirx.PrimExpr:
     """TileLang GEMM operator for ROCm.
 
@@ -40,6 +41,7 @@ def gemm(
         k_pack (int): Number of packed matrix cores along K. Must be 1 or 2.
             Defaults to 1.
         annotations (Optional[dict]): Additional annotations.
+        valid_m (int | PrimExpr | None): Runtime-valid prefix of the M axis.
 
     Returns:
         tirx.Call: A handle to the GEMM operation.
@@ -60,4 +62,5 @@ def gemm(
         clear_accum,
         None,
         annotations=ann,
+        valid_m=valid_m,
     )

--- a/tilelang/tileop/gemm/__init__.py
+++ b/tilelang/tileop/gemm/__init__.py
@@ -1,5 +1,5 @@
 from tilelang import tvm as tvm
-from tvm import tirx
+from tvm import arith, tirx
 from tvm.target import Target
 from tvm.ir.base import Node
 from tvm.ir import Range
@@ -33,7 +33,7 @@ def gemm_lower(
 class Gemm(Node, Scriptable):
     # FFI fields (LLVM/MLIR-style lowerCamel via reflection):
     # a, b, c, aPtr, bPtr, cPtr, m, n, k, transA, transB,
-    # clearAccum, kPack, wgWait, policy
+    # clearAccum, validM, kPack, wgWait, policy
     #
     # Backward-compat alias properties are provided below to support old names.
 
@@ -87,6 +87,10 @@ class Gemm(Node, Scriptable):
         return self.clearAccum
 
     @property
+    def valid_m(self):
+        return self.validM
+
+    @property
     def k_pack(self):
         return self.kPack
 
@@ -120,6 +124,8 @@ class Gemm(Node, Scriptable):
         thread_nums = thread_bounds.extent
         gemm_inst = self._select_gemm_instruction(thread_nums, target)
         impl_class = self._get_implementation_class(gemm_inst, target)
+        if not arith.Analyzer().can_prove_equal(self.valid_m, self.m) and not impl_class.supports_runtime_valid_m:
+            raise NotImplementedError(f"{impl_class.__name__} does not support T.gemm valid_m")
         return impl_class(self).lower(layout_map, target, thread_bounds, thread_index, mbar_phase_expr)
 
     def _select_gemm_instruction(self, thread_nums: int, target: Target) -> str:

--- a/tilelang/tileop/gemm/gemm_base.py
+++ b/tilelang/tileop/gemm/gemm_base.py
@@ -23,6 +23,7 @@ class GemmBase:
     """
 
     gemm_node: Node
+    supports_runtime_valid_m = False
 
     def __post_init__(self) -> None:
         validate_gemm_ab_dtypes(
@@ -135,6 +136,10 @@ class GemmBase:
     @property
     def clear_accum(self) -> PrimExpr:
         return getattr(self.gemm_node, "clearAccum", None)
+
+    @property
+    def valid_m(self) -> PrimExpr:
+        return getattr(self.gemm_node, "validM", tvm.tirx.const(self.M, T.int32))
 
     @property
     def k_pack(self) -> int:


### PR DESCRIPTION
## Problem

Kernels with a runtime-valid prefix of an otherwise static GEMM tile must either compute padded rows, branch to a different implementation, or abandon the hardware matrix path. Decode and routed-expert workloads need to retain static tile shapes while avoiding invalid M-axis instruction rows.

## Change

- Add an optional target-neutral `valid_m` argument to `T.gemm` while preserving static physical tile dimensions.
- Preserve the existing block-scaled GEMM call protocol and default ordinary GEMMs to the full M extent.
- Require each GEMM implementation to declare support before accepting a partial runtime M extent.
- Implement Metal simdgroup and cooperative-tensor lowering with whole-instruction-row predicates for loads, multiply-accumulate, initialization, and writeback.
- Keep unpredicated fast paths for complete per-warp tiles; the invalid suffix remains unspecified.
- Add construction, generated-source, and Metal execution regressions.

## Tests

- Rebuilt TileLang with `USE_METAL=ON USE_CUDA=OFF USE_ROCM=OFF` from this branch's exact source.
- `pytest -q testing/python/metal/test_metal_gemm_valid_m.py`: 3 passed.
- Remaining Metal suite: 21 passed, 3 skipped.
- `pre-commit run --files ...` and `git diff --check`: passed.

## Validation

Executed a runtime `valid_m=17` GEMM on Apple Metal, verified the valid prefix against PyTorch, and verified wholly invalid instruction rows remain untouched. Two existing upstream codegen-expectation files were excluded from the directory run because they independently fail against upstream `main`.

## Related

Independent of the buffer-region-offset bug fix. This extends the target-neutral GEMM contract and supplies its Metal realization without exposing Metal-specific controls to callers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add optional `valid_m` support to `T.gemm`.
- Preserve full-tile behavior by default.
- Add validation and backend capability checks for runtime partial M extents.
- Add Metal predication for loads, accumulation, initialization, and writeback.
- Preserve fast paths for complete warp tiles.
- Add construction, code-generation, and Metal execution tests.

## C++ style / lint notes

- The PR touches FFI-visible GEMM fields and reflection.
- The C++ style guide requires preserving FFI-visible field names.
- The C++ API Style Audit runs in warning-only mode in CI.
- TLCPP003/TLCPP004 findings are advisory unless they indicate an API, FFI, or maintainability risk.
- No correctness, build, or test issue is reported.

## Tests

- 3 dedicated tests pass.
- 21 additional Metal tests pass.
- 3 tests are skipped.
- Metal execution with `valid_m=17` matches PyTorch for valid rows and preserves invalid accumulator rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->