### PR TITLE
[Language] Restore deprecated T.symbolic alias

### DIFF
--- a/docs/programming_guides/language_basics.md
+++ b/docs/programming_guides/language_basics.md
@@ -80,6 +80,7 @@ def bar(A: T.Tensor((K,), "float32")):
 ```
 
 Notes
+- `T.symbolic(name, dtype)` is a deprecated alias of `T.dynamic` and will be removed in v0.1.15; prefer `T.dynamic`.
 - Under `@jit`, concrete sizes come from the actual tensor arguments at the first call.
 - Symbols in annotations do not need to be separate kernel arguments; TileLang binds them from argument shapes.
 

--- a/tilelang/language/common.py
+++ b/tilelang/language/common.py
@@ -140,7 +140,7 @@ from .builtin import (  # noqa: F401
 
 from .utils import index_to_coordinates  # noqa: F401
 
-from .symbolics import dynamic  # noqa: F401
+from .symbolics import dynamic, symbolic  # noqa: F401
 from .annotations import (  # noqa: F401
     WSID,
     use_swizzle,
@@ -255,6 +255,7 @@ _LOCAL_EXPORTS = (
     "cummax",
     "cumsum",
     "dynamic",
+    "symbolic",
     "empty",
     "fill",
     "reducer_init",

--- a/tilelang/language/symbolics.py
+++ b/tilelang/language/symbolics.py
@@ -5,8 +5,9 @@ import re
 from tvm import tirx
 
 from tilelang._typing import DType
+from tilelang.utils import deprecated
 
-__all__ = ["dynamic"]
+__all__ = ["dynamic", "symbolic"]
 
 
 def dynamic(name: str, dtype: DType = "int32") -> tuple[tirx.Var, ...] | tirx.Var:
@@ -27,3 +28,9 @@ def dynamic(name: str, dtype: DType = "int32") -> tuple[tirx.Var, ...] | tirx.Va
         names = re.split(r"\s+", name)
         return tuple(tirx.Var(n, dtype) for n in names)
     return tirx.Var(name, dtype)
+
+
+@deprecated("T.symbolic(...)", "T.dynamic(...)", "v0.1.15")
+def symbolic(name: str, dtype: DType = "int32") -> tuple[tirx.Var, ...] | tirx.Var:
+    """Deprecated alias for `T.dynamic`."""
+    return dynamic(name, dtype)


### PR DESCRIPTION
## Summary

- Restore `T.symbolic` as a compatibility alias for `T.dynamic`.
- Keep the alias deprecated with removal planned for v0.1.15.

## Changes

- Re-export `symbolic` through the common language surface so it is available as `T.symbolic` across dialects.
- Route calls through `T.dynamic` while preserving names, dtypes, and multi-symbol parsing.
- Update the language guide with the deprecation and migration guidance.

## Validation

- `./format.sh`
- `python -m compileall -q tilelang/language/symbolics.py tilelang/language/common.py`
- Compatibility smoke test covering exports, scalar and multi-symbol inputs, dtypes, and the deprecation warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Restored `T.symbolic` as a deprecated alias for `T.dynamic`.
- Exported `symbolic` through the common language surface.
- Preserved symbol names, dtypes, and multi-symbol parsing.
- Added deprecation and migration guidance to the language guide.
- Added compatibility coverage for exports, inputs, dtypes, and warnings.
- Validated formatting and compilation checks.

`T.symbolic` is planned for removal in v0.1.15. Use `T.dynamic` for new code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->