### PR TITLE
[Language] Add tile-level argmax and argmin reductions

### DIFF
--- a/docs/programming_guides/instructions.md
+++ b/docs/programming_guides/instructions.md
@@ -98,6 +98,48 @@ Reductions and scans
 - Allocate and initialize accumulators via `T.alloc_fragment` + `T.clear` or
   `T.fill`.
 
+### Index reductions
+
+`T.reduce_argmax(src, indices, dim=-1)` and `T.reduce_argmin` return the
+zero-based index along a tile dimension. They support fragment and shared
+buffers, including copies between these scopes. The destination uses `int32`
+or `int64`; its shape removes the reduced axis or retains it with extent one.
+For a one-dimensional input, use a scalar destination `()` or `(1,)`.
+
+```python
+@tilelang.jit(out_idx=[1])
+def row_argmax(rows, cols):
+    @T.prim_func
+    def main(A: T.Tensor((rows, cols), "float32"), I: T.Tensor((rows,), "int32")):
+        with T.Kernel(1, threads=128):
+            values = T.alloc_fragment((rows, cols), "float32")
+            indices = T.alloc_fragment((rows,), "int32")
+            T.copy(A, values)
+            T.reduce_argmax(values, indices, dim=1)
+            T.copy(indices, I)
+
+    return main
+```
+
+Ties choose the first index, including ties between positive and negative zero.
+If a row contains NaNs, both operations return the first NaN's index. For
+example, `[3, 7, 7]` has argmax `1`, and `[7, NaN, NaN]` has argmax and argmin
+`1`. Integer comparisons retain the input precision.
+
+The source may use `float16`, `bfloat16`, `float32`, `float64`, or signed/unsigned
+8-, 16-, 32-, or 64-bit integers, subject to the backend's ordinary reduction
+support. The reduced extent must be a positive compile-time constant that fits
+the output index dtype. Non-power-of-two reduction extents are padded internally;
+padding positions are excluded from the returned indices. The input remains
+unchanged and the output is replaced on every call. Like other tile reductions,
+all participating threads must execute the operation collectively.
+
+Index reductions expand into a value reduction and a minimum-index reduction
+within the same kernel. Intermediate values and indices use fragments, with
+shared workspace managed by the existing reduction backend. There is no
+additional kernel launch or global temporary allocation. A shared input is
+copied into a fragment once before the two reductions.
+
 Elementwise math
 - Most math ops mirror TVM TIR: `T.exp`, `T.log`, `T.max`, `T.min`, `T.rsqrt`,
   `T.sigmoid`, etc. Compose freely inside loops.
@@ -170,6 +212,7 @@ Compute primitives
 - `T.gemm(A_s, B_s, C_f)`: Tile GEMM into fragment accumulator.
 - `T.gemm_sp(...)`: Sparse (2:4) tensor core GEMM.
 - Reductions: `T.reduce_sum/max/min/abssum/absmax`, bitwise `and/or/xor`.
+- Index reductions: `T.reduce_argmax`, `T.reduce_argmin`.
 - Scans: `T.cumsum`, `T.cummax`, finalize: `T.finalize_reducer`.
 - Warp reducers: `T.warp_reduce_sum/max/min/bitand/bitor`.
 - Elementwise math: TIR ops (`T.exp`, `T.log`, `T.max`, `T.min`, `T.rsqrt`, ...).

--- a/testing/python/language/test_tilelang_language_arg_reduce.py
+++ b/testing/python/language/test_tilelang_language_arg_reduce.py
@@ -1,0 +1,195 @@
+import numpy as np
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+@tilelang.jit(out_idx=[1])
+def arg_reduce_kernel(
+    shape, dim=-1, kind="max", dtype="float32", index_dtype="int32", threads=128, src_shared=False, dst_shared=False, keepdim=False
+):
+    axis = dim % len(shape)
+    out_shape = list(shape)
+    if keepdim:
+        out_shape[axis] = 1
+    else:
+        out_shape.pop(axis)
+    op = T.reduce_argmax if kind == "max" else T.reduce_argmin
+
+    @T.prim_func
+    def main(A: T.Tensor(shape, dtype), B: T.Tensor(out_shape, index_dtype)):
+        with T.Kernel(1, threads=threads):
+            src = T.alloc_shared(shape, dtype) if src_shared else T.alloc_fragment(shape, dtype)
+            dst = T.alloc_shared(out_shape, index_dtype) if dst_shared else T.alloc_fragment(out_shape, index_dtype)
+            T.copy(A, src)
+            op(src, dst, dim)
+            if len(out_shape) == 0:
+                T.copy(dst[()], B[()])
+            else:
+                T.copy(dst, B)
+
+    return main
+
+
+@pytest.mark.parametrize("kind", ["max", "min"])
+@pytest.mark.parametrize(
+    "shape,dim,threads", [((128,), -1, 32), ((4, 128), 1, 128), ((128, 4), 0, 128), ((4, 16, 8), 1, 128), ((2, 4, 64), -1, 256)]
+)
+@pytest.mark.parametrize("index_dtype,keepdim", [("int32", False), ("int64", True)])
+def test_arg_reduce_dimensions(kind, shape, dim, threads, index_dtype, keepdim):
+    torch.manual_seed(0)
+    x = torch.randint(-8, 9, shape, device="cuda").float()
+    kernel = arg_reduce_kernel(shape, dim, kind, index_dtype=index_dtype, threads=threads, keepdim=keepdim)
+    expected = getattr(torch, "arg" + kind)(x, dim=dim, keepdim=keepdim)
+    torch.testing.assert_close(kernel(x), expected.to(getattr(torch, index_dtype)), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("kind", ["max", "min"])
+@pytest.mark.parametrize(
+    "dtype", ["float16", "bfloat16", "float32", "float64", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"]
+)
+def test_arg_reduce_dtypes(kind, dtype):
+    torch.manual_seed(1)
+    x = torch.randint(0, 32, (4, 128), device="cuda").to(getattr(torch, dtype))
+    kernel = arg_reduce_kernel(tuple(x.shape), 1, kind, dtype=dtype)
+    if dtype in ("uint16", "uint32", "uint64"):
+        expected = torch.from_numpy(getattr(np, "arg" + kind)(x.cpu().numpy(), axis=1)).cuda().int()
+    else:
+        expected = getattr(torch, "arg" + kind)(x, dim=1).int()
+    torch.testing.assert_close(kernel(x), expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("kind", ["max", "min"])
+@pytest.mark.parametrize("src_shared,dst_shared", [(False, False), (False, True), (True, False), (True, True)])
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16", "float32", "float64"])
+def test_arg_reduce_special_values(kind, src_shared, dst_shared, dtype):
+    x = torch.full((8, 256), -3.0, device="cuda", dtype=getattr(torch, dtype))
+    extreme = float("inf") if kind == "max" else -float("inf")
+    x[0, 200] = extreme
+    x[0, 33] = extreme
+    x[1, 0] = extreme
+    x[1, 130] = float("nan")
+    x[1, 63] = float("nan")
+    x[2] = float("nan")
+    x[3] = extreme
+    x[4] = -extreme
+    x[5] = 0.0
+    x[5, 0] = -0.0
+    x[6, -1] = float("nan")
+    x[7, 255] = extreme
+    kernel = arg_reduce_kernel(tuple(x.shape), 1, kind, dtype=dtype, src_shared=src_shared, dst_shared=dst_shared)
+    expected = getattr(torch, "arg" + kind)(x, dim=1).int()
+    for _ in range(3):
+        torch.testing.assert_close(kernel(x), expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("kind", ["max", "min"])
+@pytest.mark.parametrize("extent", [1, 7, 31, 33, 129])
+def test_arg_reduce_tail(kind, extent):
+    x = torch.full((4, extent), -2.0, device="cuda")
+    x[:, -1] = 7.0 if kind == "max" else -7.0
+    torch.testing.assert_close(
+        arg_reduce_kernel(tuple(x.shape), 1, kind)(x), torch.full((4,), extent - 1, device="cuda", dtype=torch.int32), rtol=0, atol=0
+    )
+
+
+def test_arg_reduce_integer_precision():
+    x = torch.full((4, 128), 2**60, dtype=torch.int64, device="cuda")
+    x[:, 97] += 1
+    x[:, 3] -= 1
+    for kind in ("min", "max"):
+        expected = getattr(torch, "arg" + kind)(x, dim=1).int()
+        torch.testing.assert_close(arg_reduce_kernel(tuple(x.shape), 1, kind, dtype="int64")(x), expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("kind", ["max", "min"])
+@pytest.mark.parametrize(
+    "shape,dtype,out_shape,index_dtype,dim,scope,message",
+    [
+        ((4, 128), "float32", (4,), "int32", 2, "local.fragment", "out of bounds"),
+        ((4, 128), "float32", (4,), "int32", -3, "local.fragment", "out of bounds"),
+        ((4, 128), "float32", (4,), "float32", 1, "local.fragment", "output dtype"),
+        ((4, 128), "float32", (3,), "int32", 1, "local.fragment", "output shape"),
+        ((4, 128), "float32", (4,), "int32", 1, "global", "fragment or shared"),
+        ((4, 0), "float32", (4,), "int32", 1, "local.fragment", "positive constant"),
+        ((4, 2**31), "float32", (4,), "int32", 1, "local.fragment", "cannot be represented"),
+        ((4, 128), "bool", (4,), "int32", 1, "local.fragment", "input dtype"),
+    ],
+)
+def test_arg_reduce_invalid_arguments(kind, shape, dtype, out_shape, index_dtype, dim, scope, message):
+    from tvm import tirx
+
+    src = tirx.decl_buffer(shape, dtype, scope=scope)
+    dst = tirx.decl_buffer(out_shape, index_dtype, scope="local.fragment")
+    with pytest.raises(ValueError, match=message):
+        getattr(T, "reduce_arg" + kind)(src, dst, dim)
+
+
+@pytest.mark.parametrize("kind", ["max", "min"])
+def test_arg_reduce_operand_type(kind):
+    from tvm import tirx
+
+    src = tirx.decl_buffer((4, 128), "float32", scope="local.fragment")
+    dst = tirx.decl_buffer((4,), "int32", scope="local.fragment")
+    op = getattr(T, "reduce_arg" + kind)
+    with pytest.raises(TypeError, match="Buffers"):
+        op(src[0, 0], dst)
+    with pytest.raises(TypeError, match="dim must be an integer"):
+        op(src, dst, 1.5)
+
+
+@pytest.mark.parametrize("kind", ["max", "min"])
+def test_arg_reduce_gemm_accumulator(kind):
+    op = T.reduce_argmax if kind == "max" else T.reduce_argmin
+
+    @tilelang.jit(out_idx=[2])
+    def make_kernel():
+        @T.prim_func
+        def main(A: T.Tensor((32, 64), "float16"), B: T.Tensor((64, 128), "float16"), I: T.Tensor((32,), "int32")):
+            with T.Kernel(1, threads=128):
+                a = T.alloc_shared((32, 64), "float16")
+                b = T.alloc_shared((64, 128), "float16")
+                scores = T.alloc_fragment((32, 128), "float32")
+                indices = T.alloc_fragment((32,), "int32")
+                T.copy(A, a)
+                T.copy(B, b)
+                T.gemm(a, b, scores, clear_accum=True)
+                op(scores, indices, dim=1)
+                T.copy(indices, I)
+
+        return main
+
+    torch.manual_seed(7)
+    a = torch.randn((32, 64), dtype=torch.float16, device="cuda")
+    b = torch.randn((64, 128), dtype=torch.float16, device="cuda")
+    # FP64 reference avoids precision-mode differences in the reference GEMM.
+    expected = getattr(torch, "arg" + kind)(a.double() @ b.double(), dim=1).int()
+    torch.testing.assert_close(make_kernel()(a, b), expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("kind", ["max", "min"])
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16", "float32", "float64", "int8", "int32", "int64", "uint64"])
+@pytest.mark.parametrize("shape,dim", [((7, 4), 0), ((2, 7, 4), 1)])
+def test_arg_reduce_padding_identities(kind, dtype, shape, dim):
+    is_float = dtype.startswith("float") or dtype == "bfloat16"
+    if is_float:
+        identity = -float("inf") if kind == "max" else float("inf")
+        x = torch.full(shape, identity, device="cuda", dtype=getattr(torch, dtype))
+        # Equal identity values must choose a real input, never the padding.
+        expected = torch.zeros(shape[:dim] + shape[dim + 1 :], device="cuda", dtype=torch.int64)
+        if shape[0] == 2:
+            x.select(dim, shape[dim] - 1).fill_(float("nan"))
+            expected.fill_(shape[dim] - 1)
+    else:
+        info = np.iinfo(getattr(np, dtype))
+        x = torch.from_numpy(np.full(shape, info.min if kind == "max" else info.max, dtype=getattr(np, dtype))).cuda()
+        expected = torch.zeros(shape[:dim] + shape[dim + 1 :], device="cuda", dtype=torch.int64)
+    kernel = arg_reduce_kernel(shape, dim, kind, dtype=dtype, index_dtype="int64", src_shared=True, dst_shared=True)
+    torch.testing.assert_close(kernel(x), expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/language/arg_reduce_op.py
+++ b/tilelang/language/arg_reduce_op.py
@@ -1,0 +1,147 @@
+"""Tile-level index reductions built from the ordinary reduction primitives."""
+
+from __future__ import annotations
+
+from tvm import arith, tirx
+from tvm.tirx.script.builder.ir import buffer_store, evaluate
+
+from tilelang.language.allocate import alloc_fragment
+from tilelang.language.copy_op import copy
+from tilelang.language.loop import Parallel
+from tilelang.language.reduce_op import reduce
+from tilelang.utils.language import is_fragment, is_shared
+
+
+def _reduce_arg(buffer: tirx.Buffer, out: tirx.Buffer, dim: int, kind: str) -> None:
+    op_name = f"reduce_arg{kind}"
+    if not isinstance(buffer, tirx.Buffer) or not isinstance(out, tirx.Buffer):
+        raise TypeError(f"{op_name} expects input and output Buffers")
+    if not isinstance(dim, int):
+        raise TypeError(f"{op_name} dim must be an integer, got {dim!r}")
+    rank = len(buffer.shape)
+    if not -rank <= dim < rank:
+        raise ValueError(f"{op_name} dim {dim} is out of bounds for input rank {rank}")
+    dim %= rank
+    if out.dtype not in ("int32", "int64"):
+        raise ValueError(f"{op_name} output dtype must be int32 or int64, got {out.dtype}")
+    supported_dtypes = (
+        "float16",
+        "bfloat16",
+        "float32",
+        "float64",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+    )
+    if buffer.dtype not in supported_dtypes:
+        raise ValueError(f"{op_name} does not support input dtype {buffer.dtype}")
+    if not (is_fragment(buffer) or is_shared(buffer)) or not (is_fragment(out) or is_shared(out)):
+        raise ValueError(f"{op_name} expects fragment or shared buffers, got {buffer.scope()} and {out.scope()}")
+
+    analyzer = arith.Analyzer()
+    extent = analyzer.simplify(buffer.shape[dim])
+    if not isinstance(extent, tirx.IntImm) or extent.value <= 0:
+        raise ValueError(f"{op_name} currently requires a positive constant reduction extent, got {extent}")
+    index_bits = 32 if out.dtype == "int32" else 64
+    if extent.value > (1 << (index_bits - 1)) - 1:
+        raise ValueError(f"{op_name} reduction extent {extent} cannot be represented by output dtype {out.dtype}")
+
+    squeezed_shape = list(buffer.shape[:dim]) + list(buffer.shape[dim + 1 :])
+    kept_shape = list(buffer.shape)
+    kept_shape[dim] = tirx.IntImm("int32", 1)
+
+    def matches(shape):
+        return len(out.shape) == len(shape) and all(analyzer.can_prove_equal(a, b) for a, b in zip(out.shape, shape))
+
+    keep_dim = matches(kept_shape)
+    if not keep_dim and not matches(squeezed_shape):
+        raise ValueError(f"{op_name} output shape must be {squeezed_shape} or {kept_shape}, got {out.shape}")
+
+    # The ordinary butterfly reduction requires power-of-two lane groups.
+    # Pad only the reduction axis and mask padded indices out of the arg result.
+    is_float = buffer.dtype.startswith("float") or buffer.dtype == "bfloat16"
+    padded_extent = 1 << (extent.value - 1).bit_length()
+    needs_padding = padded_extent != extent.value
+    src = buffer
+    if needs_padding:
+        padded_shape = list(buffer.shape)
+        padded_shape[dim] = padded_extent
+        src = alloc_fragment(padded_shape, buffer.dtype)
+        if is_float:
+            identity = tirx.const(float("-inf") if kind == "max" else float("inf"), buffer.dtype)
+        else:
+            identity = tirx.min_value(buffer.dtype) if kind == "max" else tirx.max_value(buffer.dtype)
+        with Parallel(*padded_shape) as loop_vars:
+            coords = [loop_vars] if rank == 1 else list(loop_vars)
+            value = tirx.if_then_else(coords[dim] < extent, tirx.BufferLoad(buffer, coords), identity)
+            buffer_store(src, value, coords)
+    elif is_shared(buffer):
+        src = alloc_fragment(buffer.shape, buffer.dtype)
+        evaluate(copy(buffer, src))
+    reduced_shape = squeezed_shape or [1]
+    values = alloc_fragment(reduced_shape, buffer.dtype)
+    candidates = alloc_fragment(src.shape, out.dtype)
+    indices = alloc_fragment(reduced_shape, out.dtype)
+    reduce(src, values, kind, dim, True)
+
+    extent_index = tirx.IntImm(out.dtype, extent.value)
+    with Parallel(*src.shape) as loop_vars:
+        coords = [loop_vars] if rank == 1 else list(loop_vars)
+        reduced_coords = coords[:dim] + coords[dim + 1 :] or [0]
+        index = tirx.Cast(out.dtype, coords[dim])
+        value = tirx.BufferLoad(src, coords)
+        candidate = tirx.Select(value == tirx.BufferLoad(values, reduced_coords), index, extent_index)
+        if is_float:
+            # NaN indices occupy [-extent, -1], so they precede every numeric
+            # candidate and still order ties by the original logical index.
+            # This does not depend on the value reducer's NaN propagation mode.
+            nan_value = tirx.Cast("float32", value) if buffer.dtype == "bfloat16" else value
+            candidate = tirx.Select(tirx.isnan(nan_value), index - extent_index, candidate)
+        if needs_padding:
+            candidate = tirx.Select(index < extent_index, candidate, extent_index)
+        buffer_store(candidates, candidate, coords)
+    reduce(candidates, indices, "min", dim, True)
+
+    with Parallel(*(list(out.shape) or [1])) as loop_vars:
+        coords = ([loop_vars] if len(out.shape) <= 1 else list(loop_vars)) if out.shape else []
+        reduced_coords = (coords[:dim] + coords[dim + 1 :] if keep_dim else coords) or [0]
+        index = tirx.BufferLoad(indices, reduced_coords)
+        result = tirx.Select(index < 0, index + extent_index, index) if is_float else index
+        buffer_store(out, result, coords)
+
+
+def reduce_argmax(buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1) -> None:
+    """Write the index of the maximum value along ``dim`` to ``out``.
+
+    ``buffer`` and ``out`` must be fragment or shared buffers. The output must
+    have dtype ``int32`` or ``int64`` and the input shape with ``dim`` removed
+    or replaced by one. Negative dimensions are accepted. The reduction extent
+    must be a positive compile-time constant representable by the output dtype.
+    Non-power-of-two reduction extents are padded internally; padding indices
+    never participate in the result.
+
+    Indices are zero-based within the reduction dimension. Ties select the
+    first index, including ties between positive and negative zero. If any
+    input is NaN, the first NaN index is returned. Input values are not modified.
+
+    Expands to a value reduction followed by an index reduction in the same
+    kernel, with register temporaries and the ordinary reduction backend's
+    synchronization. It does not launch another kernel or allocate global memory.
+    All participating threads must execute the operation collectively.
+    """
+    _reduce_arg(buffer, out, dim, "max")
+
+
+def reduce_argmin(buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1) -> None:
+    """Write the index of the minimum value along ``dim`` to ``out``.
+
+    Uses the same shape, dtype, scope, collective-execution and first-index tie
+    rules as :func:`reduce_argmax`. If any input is NaN, the first NaN index is
+    returned. Expands to two reductions in the same kernel.
+    """
+    _reduce_arg(buffer, out, dim, "min")

--- a/tilelang/language/common.py
+++ b/tilelang/language/common.py
@@ -102,6 +102,7 @@ from .reduce_op import (
     warp_reduce_bitand,  # noqa: F401
     warp_reduce_bitor,  # noqa: F401
 )
+from .arg_reduce_op import reduce_argmax, reduce_argmin  # noqa: F401
 from .scan_op import cumsum, cummax  # noqa: F401
 from .customize import (
     atomic_max,  # noqa: F401
@@ -290,6 +291,8 @@ _LOCAL_EXPORTS = (
     "reduce",
     "reduce_absmax",
     "reduce_abssum",
+    "reduce_argmax",
+    "reduce_argmin",
     "reduce_bitand",
     "reduce_bitor",
     "reduce_bitxor",


### PR DESCRIPTION
Tile-level reductions currently expose values but not their indices. This adds `T.reduce_argmax(src, indices, dim=-1)` and `T.reduce_argmin` so kernels can consume indices directly from fragment or shared tiles, including a GEMM accumulator. Related to #1126.

Both operations support squeezed or retained reduction dimensions and int32/int64 outputs. Ties select the first logical index, including signed zeros; any NaN selects the first NaN index. Integer ordering retains its original precision. Non-power-of-two reduction extents are padded internally and padded indices are excluded.

The implementation composes the existing value reduction and a minimum-index reduction inside one kernel, reusing the current layout and synchronization machinery. It requires a positive compile-time reduction extent and fragment/shared buffers. It uses two reduction passes and makes no performance claim.

Validation on RTX 3090 (SM86), CUDA toolkit 13.0, PyTorch 2.8.0+cu128:

- 139 new tests plus 43 existing reduction regression cases: 182 passed.
- Compute Sanitizer memcheck, racecheck, and synccheck: 24 targeted cases each, zero errors or race warnings.
- Four CUDA Graph replays with changing NaN positions and full-range uint64 ordering checks passed.
- Repository formatter/pre-commit checks passed.

Tests cover axes, shapes, scopes, input/index dtypes, ties, NaNs, infinities, padding identities, integer precision, invalid arguments, and a fused Tensor Core GEMM accumulator. Documentation includes the API contract and a row-argmax example. Other GPU architectures and CPU/ROCm backends were not validated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added tile-level `T.reduce_argmax` and `T.reduce_argmin` for fragment and shared tiles, including GEMM accumulators.
- Added support for squeezed or retained dimensions, `int32` and `int64` indices, first-index tie-breaking, NaN handling, integer precision preservation, and non-power-of-two reduction extents.
- Added validation for reduction dimensions, buffer scopes, dtypes, output shapes, and positive compile-time extents.
- Exported both operations through the public language API.
- Added API documentation and a row-argmax example.
- Added 139 new tests and 43 regression cases, plus sanitizer, CUDA Graph, formatter, and pre-commit validation.

Testing used an RTX 3090 with CUDA 13.0 and PyTorch 2.8.0+cu128. Other GPU architectures and CPU/ROCm backends were not validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->