### PR TITLE
[Refactor][JIT] Replace callee-allocated-output target sniffing with a backend capability flag

### DIFF
--- a/src/transform/make_packed_api.cc
+++ b/src/transform/make_packed_api.cc
@@ -36,6 +36,8 @@ using namespace ffi;
 
 namespace {
 constexpr const char *kTileLangOutIdx = "tilelang_out_idx";
+constexpr const char *kTileLangCalleeAllocatedOutputs =
+    "tilelang_callee_allocated_outputs";
 constexpr const char *kOutputStorageDTypeResolver =
     "tl.tvm_ffi.resolve_output_storage_dtype";
 
@@ -338,20 +340,20 @@ Optional<String> RequiresPackedAPI(const PrimFunc &func) {
 }
 
 std::vector<int> GetCalleeAllocatedOutputIndices(const PrimFunc &func) {
-  auto output_attr = func->GetAttr<Array<Integer>>(kTileLangOutIdx);
-  if (!output_attr || output_attr.value().empty() ||
+  // The callee-allocated-output ABI decision is made at compile time by the
+  // execution backend that declared the capability (see
+  // ExecutionBackendSpec.supports_callee_allocated_outputs) and recorded on
+  // the entry function; the pass honors the recorded decision instead of
+  // inspecting target kinds.
+  if (!func->HasNonzeroAttr(kTileLangCalleeAllocatedOutputs) ||
       !func->HasNonzeroAttr(tirx::attr::kIsEntryFunc)) {
     return {};
   }
 
-  auto target = func->GetAttr<Target>(tvm::attr::kTarget);
-  if (!target || target.value()->kind->name != "cuda") {
-    return {};
-  }
-  auto target_host = target.value()->GetHost();
-  if (!target_host || target_host.value()->kind->name != "c") {
-    return {};
-  }
+  auto output_attr = func->GetAttr<Array<Integer>>(kTileLangOutIdx);
+  ICHECK(output_attr && !output_attr.value().empty())
+      << kTileLangCalleeAllocatedOutputs << " requires a non-empty "
+      << kTileLangOutIdx << " attribute listing the output parameters";
 
   std::vector<int> indices;
   std::unordered_set<int> seen;

--- a/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
+++ b/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
@@ -153,9 +153,41 @@ def test_subbyte_output_uses_callee_allocated_abi():
     adapter, _ = _make_adapter()
     adapter.params = [SimpleNamespace(dtype=SimpleNamespace(bits=4))]
     adapter.result_idx = [0]
-    adapter.target = tvm.target.Target("cuda", host="c")
+    output_param = tirx.Var("output", "handle")
+    source = tirx.PrimFunc([output_param], tirx.Evaluate(0))
+    adapter._test_prim_func, _ = prepare_tvm_ffi_callee_allocated_outputs(source, 0, supports_callee_allocated_outputs=True)
 
     assert adapter._uses_ffi_callee_allocated_output_abi()
+
+
+def test_unsupported_backend_keeps_preallocated_output_abi():
+    adapter, _ = _make_adapter()
+    adapter.result_idx = [0]
+    output_param = tirx.Var("output", "handle")
+    source = tirx.PrimFunc([output_param], tirx.Evaluate(0))
+    adapter._test_prim_func, _ = prepare_tvm_ffi_callee_allocated_outputs(source, 0, supports_callee_allocated_outputs=False)
+
+    assert not adapter._uses_ffi_callee_allocated_output_abi()
+
+
+def test_capability_flag_gates_callee_allocated_attr():
+    input_param = tirx.Var("input", "handle")
+    output_param = tirx.Var("output", "handle")
+    source = tirx.PrimFunc([input_param, output_param], tirx.Evaluate(0))
+
+    prepared, _ = prepare_tvm_ffi_callee_allocated_outputs(source, -1)
+    assert "tilelang_callee_allocated_outputs" not in prepared.attrs
+
+    prepared, _ = prepare_tvm_ffi_callee_allocated_outputs(source, -1, supports_callee_allocated_outputs=True)
+    assert int(prepared.attrs["tilelang_callee_allocated_outputs"]) != 0
+    assert list(prepared.attrs["tilelang_out_idx"]) == [-1]
+
+    # Pre-attributed functions (e.g. eager builder) get the decision stamped
+    # without disturbing the declarative out_idx attribute.
+    attributed = source.with_attr("tilelang_out_idx", [-1])
+    prepared, _ = prepare_tvm_ffi_callee_allocated_outputs(attributed, None, supports_callee_allocated_outputs=True)
+    assert int(prepared.attrs["tilelang_callee_allocated_outputs"]) != 0
+    assert list(prepared.attrs["tilelang_out_idx"]) == [-1]
 
 
 def test_manual_out_idx_is_exposed_to_tvm_ffi_lowering_without_mutating_source():

--- a/tilelang/autotuner/grouped_compile.py
+++ b/tilelang/autotuner/grouped_compile.py
@@ -64,7 +64,11 @@ def compile_grouped_unit_tvm_ffi(
                 original_symbol = str(program.attrs["global_symbol"])
                 unique_symbol = f"{original_symbol}_gc_{idx}"
                 program = program.with_attr("global_symbol", unique_symbol)
-                program, output_indices = prepare_tvm_ffi_callee_allocated_outputs(program, compile_args.out_idx)
+                program, output_indices = prepare_tvm_ffi_callee_allocated_outputs(
+                    program,
+                    compile_args.out_idx,
+                    supports_callee_allocated_outputs=backend_context.execution_backend.supports_callee_allocated_outputs,
+                )
 
                 lower_context = f"stage=grouped-lower, config={idx}, kernel={unique_symbol}"
                 config_instruments = [

--- a/tilelang/backend/execution_backend.py
+++ b/tilelang/backend/execution_backend.py
@@ -22,6 +22,11 @@ class ExecutionBackendSpec:
     supports_target: TargetPredicate | None = None
     enable_host_codegen: bool = False
     enable_device_compile: bool = False
+    # Declares that this backend's host codegen lowers the TVM-FFI
+    # callee-allocated-output result slot and that its runtime provides an
+    # environment tensor allocator, so kernels with out_idx may allocate
+    # their outputs inside the generated host function.
+    supports_callee_allocated_outputs: bool = False
 
     def matches(self, target: Target) -> bool:
         return True if self.supports_target is None else self.supports_target(target)

--- a/tilelang/cuda/execution_backend.py
+++ b/tilelang/cuda/execution_backend.py
@@ -26,6 +26,7 @@ CUDA_EXECUTION_BACKENDS = [
         "tvm_ffi",
         enable_host_codegen=True,
         enable_device_compile=True,
+        supports_callee_allocated_outputs=True,
     ),
     ExecutionBackendSpec("nvrtc", is_available=_is_nvrtc_available),
     ExecutionBackendSpec("cython"),

--- a/tilelang/jit/abi.py
+++ b/tilelang/jit/abi.py
@@ -7,6 +7,14 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from tvm.tirx import PrimFunc
 
+# Declarative attribute: which parameters are outputs (mirrors out_idx).
+OUT_IDX_ATTR = "tilelang_out_idx"
+# ABI decision attribute: set only when the resolved execution backend
+# declares supports_callee_allocated_outputs. MakePackedAPI and the TVM-FFI
+# adapter both read this attribute, so the compile-time decision has a single
+# source of truth instead of each side re-deriving it from the target.
+CALLEE_ALLOCATED_OUTPUTS_ATTR = "tilelang_callee_allocated_outputs"
+
 
 def _normalize_output_indices(output_indices: list[int], num_params: int) -> list[int]:
     normalized = []
@@ -22,25 +30,45 @@ def _normalize_output_indices(output_indices: list[int], num_params: int) -> lis
     return normalized
 
 
+def _stamp_callee_allocated_decision(func: PrimFunc) -> PrimFunc:
+    if func.attrs is not None and CALLEE_ALLOCATED_OUTPUTS_ATTR in func.attrs:
+        return func
+    return func.with_attr(CALLEE_ALLOCATED_OUTPUTS_ATTR, 1)
+
+
 def prepare_tvm_ffi_callee_allocated_outputs(
     func: PrimFunc,
     out_idx: list[int] | int | None,
+    *,
+    supports_callee_allocated_outputs: bool = False,
 ) -> tuple[PrimFunc, list[int] | None]:
-    """Resolve output indices and expose them to TVM-FFI lowering."""
+    """Resolve output indices and expose them to TVM-FFI lowering.
+
+    When the resolved execution backend declares
+    ``supports_callee_allocated_outputs``, the ABI decision is recorded on the
+    derived PrimFunc so lowering and the runtime adapter both honor it.
+    Otherwise ``tilelang_out_idx`` stays purely declarative and the kernel
+    keeps the caller-preallocated output path.
+    """
     requested_indices = None if out_idx is None else ([out_idx] if isinstance(out_idx, int) else list(out_idx))
     attr_indices = None
-    if func.attrs is not None and "tilelang_out_idx" in func.attrs:
-        attr_indices = [int(index) for index in func.attrs["tilelang_out_idx"]]
+    if func.attrs is not None and OUT_IDX_ATTR in func.attrs:
+        attr_indices = [int(index) for index in func.attrs[OUT_IDX_ATTR]]
 
     if attr_indices is not None:
         if requested_indices is not None:
             num_params = len(func.params)
             if _normalize_output_indices(requested_indices, num_params) != _normalize_output_indices(attr_indices, num_params):
                 raise ValueError("out_idx does not match the PrimFunc's tilelang_out_idx attribute")
+        if attr_indices and supports_callee_allocated_outputs:
+            func = _stamp_callee_allocated_decision(func)
         return func, attr_indices
 
     output_indices = requested_indices or []
     if not output_indices:
         return func, None
     _normalize_output_indices(output_indices, len(func.params))
-    return func.with_attr("tilelang_out_idx", output_indices), output_indices
+    func = func.with_attr(OUT_IDX_ATTR, output_indices)
+    if supports_callee_allocated_outputs:
+        func = _stamp_callee_allocated_decision(func)
+    return func, output_indices

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -19,6 +19,7 @@ from tvm import runtime, tirx
 from tvm.target import Target
 from tvm.relax import TensorType
 from tilelang.backend.target import determine_target
+from tilelang.jit.abi import CALLEE_ALLOCATED_OUTPUTS_ATTR
 from tilelang.jit.adapter.base import BaseKernelAdapter, CachedTextSource
 from tilelang.utils.language import retrieve_func_from_module
 from tilelang.engine.param import KernelParam
@@ -148,13 +149,14 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
         if not self.result_idx:
             return False
 
-        # The native wrapper is currently emitted for CUDA with TileLang's C
-        # host codegen. Other device and host backends retain the preallocated-
-        # output path until they have equivalent result-slot lowering.
-        if self.target.kind.name != "cuda":
+        # The ABI decision is stamped on the PrimFunc at compile time from the
+        # execution backend's declared capability; read it back rather than
+        # re-deriving it from the target, so lowering and dispatch can never
+        # disagree.
+        attrs = getattr(self.prim_func, "attrs", None)
+        if attrs is None or CALLEE_ALLOCATED_OUTPUTS_ATTR not in attrs:
             return False
-        target_host = self.target.host
-        return target_host is not None and target_host.kind.name == "c"
+        return int(attrs[CALLEE_ALLOCATED_OUTPUTS_ATTR]) != 0
 
     def _process_dynamic_symbolic(self) -> dict[tirx.Var, tuple[int, int, int, int]]:
         """Extract information about dynamic shapes from the TIR function.

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -179,6 +179,16 @@ class JITKernel(Generic[_P, _T]):
             backend_context=backend_context,
         )
 
+        if instance.execution_backend == "tvm_ffi" and isinstance(func, PrimFunc):
+            # The cached artifact was compiled with the ABI decision derived
+            # from the same capability flag; re-stamp the loaded PrimFunc so
+            # the adapter reads the identical decision.
+            func, _ = prepare_tvm_ffi_callee_allocated_outputs(
+                func,
+                out_idx,
+                supports_callee_allocated_outputs=instance.execution_backend_spec.supports_callee_allocated_outputs,
+            )
+
         instance.adapter = instance._create_adapter_from_database(
             func_or_mod=func,
             params=params,
@@ -218,11 +228,16 @@ class JITKernel(Generic[_P, _T]):
     ) -> BaseKernelAdapter:
         """Compile one kernel and construct its adapter in one tool session."""
         if self.execution_backend == "tvm_ffi":
-            # MakePackedAPI consumes this attribute to omit all result buffers
-            # from main's packed arguments and replace them with one allocator
-            # anchor.  Use a derived PrimFunc so manual out_idx does not become
-            # a persistent frontend attribute on the user's function.
-            tilelang_func, out_idx = prepare_tvm_ffi_callee_allocated_outputs(tilelang_func, out_idx)
+            # Record out_idx declaratively and, when the execution backend
+            # declares the capability, stamp the callee-allocated ABI decision
+            # that MakePackedAPI and the adapter both honor.  Use a derived
+            # PrimFunc so neither attribute becomes a persistent frontend
+            # attribute on the user's function.
+            tilelang_func, out_idx = prepare_tvm_ffi_callee_allocated_outputs(
+                tilelang_func,
+                out_idx,
+                supports_callee_allocated_outputs=self.execution_backend_spec.supports_callee_allocated_outputs,
+            )
 
         func_name = str(tilelang_func.attrs.get("global_symbol", "<unknown>"))
         timing_tool = create_pass_timing_tool(self.pass_configs)


### PR DESCRIPTION
## Summary

`MakePackedAPI` gated the TVM-FFI callee-allocated-output ABI (introduced in #2937) on hardcoded target kind names (`cuda` device + `c` host), and `TVMFFIKernelAdapter` duplicated the exact same check. The two gates had to stay in sync by hand — a mismatch means the caller passes the wrong number of packed arguments — and a shared transform sniffing target kinds is hostile to new backends: there is no way to discover the fast path, let alone enable it, without editing shared code. Same family of cleanup as #3186 / #3203.

This PR makes the decision capability-based with a single source of truth:

- `ExecutionBackendSpec` grows `supports_callee_allocated_outputs` (default `False`). Only CUDA's `tvm_ffi` spec declares it for now; a backend that later validates the path (e.g. ROCm, whose torch c-dlpack allocator support already exists upstream) flips its own spec without touching shared code.
- `prepare_tvm_ffi_callee_allocated_outputs` records the decision as a `tilelang_callee_allocated_outputs` attribute on the derived PrimFunc when the capability is declared. `tilelang_out_idx` stays purely declarative (which parameters are outputs). All three compile entries pass the resolved spec's flag: `JITKernel` fresh compile, `JITKernel.from_database` (cache load re-stamps with the same decision function), and grouped compile.
- `GetCalleeAllocatedOutputIndices` honors the recorded attribute and no longer inspects target kinds. A decision attribute without `out_idx` now fails with an explicit `ICHECK` instead of silently degrading.
- The adapter reads the same attribute back (`_uses_ffi_callee_allocated_output_abi`) instead of re-deriving the ABI from the target, removing the dual-gate sync hazard.

No behavior change for any backend: CUDA + tvm_ffi keeps the callee-allocated ABI, everything else keeps the caller-preallocated path.

## Validation

- `testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py` + `testing/python/language/test_tilelang_language_func_attrs.py`: 26 passed (includes 3 new tests covering the capability gate on both the prepare helper and the adapter).
- `testing/python/jit/test_tilelang_jit_tvm_ffi.py`, `test_tilelang_jit_gemm.py`, `testing/python/language/test_tilelang_language_dtype_as_torch.py`: 8 passed, 2 skipped.
- `testing/python/autotune/test_tilelang_autotune.py`, `test_tilelang_autotune_eager_mode.py` (grouped-compile path): 5 passed.
- `testing/python/jit/test_tilelang_jit_gemm_cython.py` (uncapable-backend path): 6 passed, 1 skipped.
- Disk-cache round trip verified in two separate processes: the cached load goes through `from_database`, keeps the callee-allocated ABI, and returns correct outputs.
- New tests are backend-agnostic (pure PrimFunc attribute logic, no compilation), so they run on all CI runners.
- `./format.sh` clean, `git diff --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaced target-kind checks with the `supports_callee_allocated_outputs` backend capability.
- Enabled the capability for CUDA `tvm_ffi`.
- Propagated the capability through compilation, cache loading, and grouped compilation.
- Recorded the ABI decision on PrimFuncs with `tilelang_callee_allocated_outputs`.
- Updated lowering and `TVMFFIKernelAdapter` to use this attribute.
- Added validation for missing output-index metadata.
- Added tests for supported and unsupported backends and ABI attribute gating.
- Validation passed for unit, JIT, autotune, cache, formatting, and diff checks.

## C++ style / lint notes

- The PR changes C++ code, but the available repository search found no direct references to `TLCPP003`, `TLCPP004`, or the “C++ API Style Audit (warning only)” step.
- The repository links to `docs/developer_guide/cpp_style.md`; no evidence shows that this PR changes its documented rules.
- No correctness or build issue is identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->